### PR TITLE
refactor(ui): UI 层分离 - 移除 window.game 依赖，集中 DOM 操作 (tsk-34f3bed9-90b)

### DIFF
--- a/INTERFACE.md
+++ b/INTERFACE.md
@@ -76,3 +76,109 @@ EventBus 实例挂载在 `Game` 类的 `this.eventBus` 属性上，并可通过 
 
 ---
 *文档生成：Manus AI 架构重构任务*
+
+---
+
+# UI 层分离重构接口文档
+
+**分支**: `refactor/ui-separation`  
+**任务 ID**: `tsk-34f3bed9-90b`  
+**生成日期**: 2026-04-10  
+
+---
+
+## 概述
+
+本次重构将 UI 渲染逻辑从业务逻辑中分离出来，主要涉及以下三个方面：
+
+1. **替换 innerHTML 字符串拼接** — 将 `ui_renderShop` 和 `ui_updateDamageStats` 中的超长 innerHTML 字符串拼接改为 `document.createElement` + `addEventListener` 方式。
+2. **移除 window.game 全局依赖** — 商店卡片的 `onclick="game.meta_buyUpgrade('...')"` 和伤害统计导航的 `onclick="game.ui_switchDamageRound(...)"` 内联事件改为模块内部的 `addEventListener` 绑定。
+3. **集中 DOM 类名操作** — 将 `combat_system.js` 中修改 `#game-container` class 的 DOM 操作和 `game_phase.js` 中的阶段标题 DOM 操作提取到 `ui_system.js` 的新增方法中。
+
+---
+
+## 新增公共接口
+
+### `ui_onPhaseChange(newPhase: string): void`
+
+**位置**: `src/ui_system.js`  
+**调用方**: `game_phase.js` 中的 `phase_switchPhase`  
+
+集中处理阶段切换时的所有 DOM 类名操作。负责阶段标题容器（`#phase-title-container`）的显示/隐藏和文本更新。
+
+```javascript
+// 调用示例（来自 game_phase.js）
+phase_switchPhase(newPhase) {
+    this.phase = newPhase;
+    this.ui_updateUI();
+    this.ui_onPhaseChange(newPhase); // [重构] 集中 DOM 操作
+},
+```
+
+**支持的阶段**:
+
+| 阶段 ID | 标题文本 | 副标题 |
+|---------|---------|--------|
+| `meta` | 回聲煉金師 | Echo Alchemist |
+| `gathering` | 研磨階段 | 收集魔力 |
+| `combat` | 戰鬥階段 | 抵禦魔像 |
+| `truth_book` | 真理之書 | 洞悉萬物之理 |
+| `training` | 試煉場 | 極限戰鬥測試 |
+| *(其他)* | 命運抉择 | 選擇你的命運 |
+
+---
+
+### `ui_triggerScreenShake(duration?: number): void`
+
+**位置**: `src/ui_system.js`  
+**调用方**: `combat_system.js` 中的 `combat_activateSkill`  
+
+触发屏幕震动效果（`shake-hard` CSS 动画）。将原先分散在 `combat_system.js` 中的直接 DOM 操作提取到 `ui_system.js`。
+
+```javascript
+// 调用示例（来自 combat_system.js）
+this.ui_triggerScreenShake(200); // 200ms 震动
+```
+
+**参数**:
+
+| 参数 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `duration` | `number` | `200` | 震动持续时间（毫秒） |
+
+---
+
+## 修改详情
+
+### `src/ui_system.js`
+
+| 修改位置 | 修改内容 |
+|---------|---------|
+| `ui_renderShop` (升级卡片部分) | 将 `card.innerHTML` 超长字符串拼接改为 `document.createElement` 逐元素构建；购买按钮从 `onclick="game.meta_buyUpgrade('...')"` 改为 `addEventListener('click', () => this.meta_buyUpgrade(id))` |
+| `ui_updateDamageStats` (顶部导航部分) | 将 `header.innerHTML` 内联事件改为 `createElement` + `addEventListener`；导航按钮从 `onclick="game.ui_switchDamageRound(...)"` 改为 `addEventListener` |
+| 末尾新增 | 新增 `ui_onPhaseChange(newPhase)` 方法 |
+| 末尾新增 | 新增 `ui_triggerScreenShake(duration)` 方法 |
+
+### `src/game_phase.js`
+
+| 修改位置 | 修改内容 |
+|---------|---------|
+| `phase_switchPhase` | 移除内联的 `#phase-title-container` DOM 操作（获取元素、修改 classList、设置文本、setTimeout）；改为调用 `this.ui_onPhaseChange(newPhase)` |
+
+### `src/combat_system.js`
+
+| 修改位置 | 修改内容 |
+|---------|---------|
+| `combat_activateSkill` (method === 'shockwave_push') | 将 `document.getElementById('game-container').classList.add/remove('shake-hard')` + `setTimeout` 替换为 `this.ui_triggerScreenShake(200)` |
+| `combat_activateSkill` (method === 'chain_lightning_all') | 同上 |
+
+---
+
+## 与任务3（refactor/event-bus）的协作说明
+
+本任务在任务3（架构解耦 - 事件总线与 Mixin 重构）尚未完成的情况下独立实施。当任务3完成后，可以考虑将以下调用改为事件总线方式：
+
+- `phase_switchPhase` 中的 `this.ui_onPhaseChange(newPhase)` → 可改为 `this.emit('phase:changed', { phase: newPhase })`
+- `combat_activateSkill` 中的 `this.ui_triggerScreenShake(200)` → 可改为 `this.emit('ui:screenShake', { duration: 200 })`
+
+当前实现已将 DOM 操作集中到 `ui_system.js`，为后续事件总线改造奠定了基础，改动量最小。

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -211,8 +211,8 @@ export const combat_system = {
             });
             this.spawn_createShockwave(this.width/2, this.height/2, p.shockwaveColor);
             if(pushedCount > 0) audio.playEffect('split');
-            document.getElementById('game-container').classList.add('shake-hard');
-            setTimeout(() => document.getElementById('game-container').classList.remove('shake-hard'), 200);
+            // [重构] 将直接 DOM 操作提取到 ui_system.js 的 ui_triggerScreenShake 方法
+            this.ui_triggerScreenShake(200);
         } 
         else if (method === 'chain_lightning_all') {
             // === [新增] 全屏闪电链逻辑 ===
@@ -224,8 +224,8 @@ export const combat_system = {
             flash.style.backgroundColor = p.flashColor;
             document.body.appendChild(flash);
             setTimeout(() => { flash.style.opacity = '0'; setTimeout(() => flash.remove(), 200); }, 50);
-            document.getElementById('game-container').classList.add('shake-hard');
-            setTimeout(() => document.getElementById('game-container').classList.remove('shake-hard'), 200);
+            // [重构] 将直接 DOM 操作提取到 ui_system.js 的 ui_triggerScreenShake 方法
+            this.ui_triggerScreenShake(200);
             // 倒序遍历（防止数组变动影响）
             // 策略：对每个敌人从天降下一道闪电，并以此为起点尝试触发连锁
             for (let i = this.enemies.length - 1; i >= 0; i--) {

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -46,22 +46,8 @@ export const game_phase = {
         eventBus.emit('phase:change', { from: oldPhase, to: newPhase });
         
         this.ui_updateUI(); // 更新 UI 界面
-        const titleContainer = document.getElementById('phase-title-container');
-        const titleText = document.getElementById('phase-title');
-        const subText = document.getElementById('phase-sub');
-        titleContainer.classList.remove('minimized'); // 显示阶段标题
-
-        // 根据阶段设置标题文本
-        let text = "命運抉择"; let sub = "選擇你的命運";
-        if (newPhase === 'meta') { text = "回聲煉金師"; sub = "Echo Alchemist"; }
-        else if (newPhase === 'gathering') { text = "研磨階段"; sub = "收集魔力"; }
-        else if (newPhase === 'combat') { text = "戰鬥階段"; sub = "抵禦魔像"; }
-        else if (newPhase === 'truth_book') { text = "真理之書"; sub = "洞悉萬物之理"; }
-        else if (newPhase === 'training') { text = "試煉場"; sub = "極限戰鬥測試"; }
-        titleText.innerText = text; subText.innerText = sub;
-        
-        // 1.2秒后隐藏阶段标题
-        setTimeout(() => { titleContainer.classList.add('minimized'); }, 1200);
+        // [重构] 将阶段标题的 DOM 操作集中到 ui_system.js 的 ui_onPhaseChange 方法中
+        this.ui_onPhaseChange(newPhase);
     },
 
 /**

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -202,31 +202,71 @@ ui_closeTruthBook() {
 
                 const card = document.createElement('div');
                 card.className = `bg-slate-900/60 border ${isMax ? 'border-slate-700 opacity-80' : 'border-slate-700/50'} p-4 rounded-xl flex flex-col gap-3 relative overflow-hidden group`;
-                
-                card.innerHTML = `
-                    <div class="flex justify-between items-start">
-                        <div class="flex gap-3">
-                            <div class="w-10 h-10 rounded-lg bg-slate-800 flex items-center justify-center text-xl shadow-inner">${upgrade.icon}</div>
-                            <div>
-                                <h3 class="font-bold text-slate-100">${upgrade.name}</h3>
-                                <p class="text-[10px] text-slate-500 uppercase tracking-wider">LV. ${level} / ${upgrade.maxLevel}</p>
-                            </div>
-                        </div>
-                        ${isMax ? '<span class="text-[10px] bg-slate-800 text-slate-500 px-2 py-1 rounded">MAX</span>' : ''}
-                    </div>
-                    <p class="text-xs text-slate-400 leading-relaxed">${upgrade.desc}</p>
-                    <div class="flex justify-between items-center mt-2">
-                        <div class="text-[10px] text-slate-500">
-                            ${!isMax ? `下一級: <span class="text-amber-400/80">+${upgrade.effect.valuePerLevel}${upgrade.effect.type === 'multiply' ? 'x' : ''}</span>` : '已達最高等級'}
-                        </div>
-                        ${!isMax ? `
-                            <button onclick="game.meta_buyUpgrade('${upgrade.id}')" 
-                                    class="px-4 py-2 rounded-lg text-xs font-bold transition-all ${canAfford ? 'bg-amber-500 text-slate-900 hover:scale-105 active:scale-95' : 'bg-slate-800 text-slate-500 cursor-not-allowed'}">
-                                ✨ ${cost.toLocaleString()}
-                            </button>
-                        ` : ''}
-                    </div>
-                `;
+
+                // --- 顶部区域：图标 + 名称 + 等级 ---
+                const topRow = document.createElement('div');
+                topRow.className = 'flex justify-between items-start';
+
+                const iconGroup = document.createElement('div');
+                iconGroup.className = 'flex gap-3';
+
+                const iconEl = document.createElement('div');
+                iconEl.className = 'w-10 h-10 rounded-lg bg-slate-800 flex items-center justify-center text-xl shadow-inner';
+                iconEl.textContent = upgrade.icon;
+
+                const nameGroup = document.createElement('div');
+                const nameEl = document.createElement('h3');
+                nameEl.className = 'font-bold text-slate-100';
+                nameEl.textContent = upgrade.name;
+                const levelEl = document.createElement('p');
+                levelEl.className = 'text-[10px] text-slate-500 uppercase tracking-wider';
+                levelEl.textContent = `LV. ${level} / ${upgrade.maxLevel}`;
+                nameGroup.appendChild(nameEl);
+                nameGroup.appendChild(levelEl);
+
+                iconGroup.appendChild(iconEl);
+                iconGroup.appendChild(nameGroup);
+                topRow.appendChild(iconGroup);
+
+                if (isMax) {
+                    const maxBadge = document.createElement('span');
+                    maxBadge.className = 'text-[10px] bg-slate-800 text-slate-500 px-2 py-1 rounded';
+                    maxBadge.textContent = 'MAX';
+                    topRow.appendChild(maxBadge);
+                }
+                card.appendChild(topRow);
+
+                // --- 描述 ---
+                const descEl = document.createElement('p');
+                descEl.className = 'text-xs text-slate-400 leading-relaxed';
+                descEl.textContent = upgrade.desc;
+                card.appendChild(descEl);
+
+                // --- 底部区域：下一级信息 + 购买按钮 ---
+                const bottomRow = document.createElement('div');
+                bottomRow.className = 'flex justify-between items-center mt-2';
+
+                const nextLevelEl = document.createElement('div');
+                nextLevelEl.className = 'text-[10px] text-slate-500';
+                if (!isMax) {
+                    nextLevelEl.innerHTML = `下一級: <span class="text-amber-400/80">+${upgrade.effect.valuePerLevel}${upgrade.effect.type === 'multiply' ? 'x' : ''}</span>`;
+                } else {
+                    nextLevelEl.textContent = '已達最高等級';
+                }
+                bottomRow.appendChild(nextLevelEl);
+
+                if (!isMax) {
+                    const buyBtn = document.createElement('button');
+                    buyBtn.className = `px-4 py-2 rounded-lg text-xs font-bold transition-all ${canAfford ? 'bg-amber-500 text-slate-900 hover:scale-105 active:scale-95' : 'bg-slate-800 text-slate-500 cursor-not-allowed'}`;
+                    buyBtn.textContent = `✨ ${cost.toLocaleString()}`;
+                    // [重构] 使用 addEventListener 替代内联 onclick="game.meta_buyUpgrade(...)"，移除 window.game 依赖
+                    buyBtn.addEventListener('click', () => {
+                        this.meta_buyUpgrade(upgrade.id);
+                    });
+                    bottomRow.appendChild(buyBtn);
+                }
+                card.appendChild(bottomRow);
+
                 itemsContainer.appendChild(card);
             });
         }
@@ -344,11 +384,25 @@ ui_closeTruthBook() {
         // --- 2. 渲染顶部导航 ---
         const header = document.createElement('div');
         header.className = 'w-full flex justify-between items-center bg-slate-800 p-2 rounded shrink-0 sticky top-0 z-10 border border-slate-700 shadow-md';
-        header.innerHTML = `
-            <button onclick="game.ui_switchDamageRound(1)" class="text-slate-400 hover:text-white px-3 py-1">◀</button>
-            <span class="text-xs font-bold text-amber-400 font-[Cinzel]">Round ${roundNumber}</span>
-            <button onclick="game.ui_switchDamageRound(-1)" class="text-slate-400 hover:text-white px-3 py-1">▶</button>
-        `;
+
+        // [重构] 使用 createElement + addEventListener 替代 innerHTML 内联事件，移除 window.game 依赖
+        const prevBtn = document.createElement('button');
+        prevBtn.className = 'text-slate-400 hover:text-white px-3 py-1';
+        prevBtn.textContent = '◀';
+        prevBtn.addEventListener('click', () => this.ui_switchDamageRound(1));
+
+        const roundLabel = document.createElement('span');
+        roundLabel.className = 'text-xs font-bold text-amber-400 font-[Cinzel]';
+        roundLabel.textContent = `Round ${roundNumber}`;
+
+        const nextBtn = document.createElement('button');
+        nextBtn.className = 'text-slate-400 hover:text-white px-3 py-1';
+        nextBtn.textContent = '▶';
+        nextBtn.addEventListener('click', () => this.ui_switchDamageRound(-1));
+
+        header.appendChild(prevBtn);
+        header.appendChild(roundLabel);
+        header.appendChild(nextBtn);
         container.appendChild(header);
 
         if (!shotsData || shotsData.length === 0) {
@@ -1209,12 +1263,9 @@ ui_closeTruthBook() {
             
             // [BUGFIX #2] 修复 setDeepValue 重复调用导致临时升级数值翻倍
             // 原 Bug: isTemporary 分支内外各调用了一次 setDeepValue，导致临时升级效果被应用两次
+            // 修复：统一在分支外调用一次
             const effectValue = upgrade.effect.valuePerLevel * (level + 1);
-            if (isTemporary) {
-                setDeepValue(CONFIG, upgrade.effect.path, effectValue, upgrade.effect.type);
-            } else {
-                setDeepValue(CONFIG, upgrade.effect.path, effectValue, upgrade.effect.type);
-            }
+            setDeepValue(CONFIG, upgrade.effect.path, effectValue, upgrade.effect.type);
             console.log(`[META] 立即应用升级: ${upgrade.id}, level: ${level + 1}, path: ${upgrade.effect.path}, value: ${effectValue}`);
 
             
@@ -1518,5 +1569,51 @@ ui_closeTruthBook() {
             tag.textContent = `${key} +${val}`;
             list.appendChild(tag);
         });
+    },
+
+    /**
+     * @method ui_onPhaseChange
+     * @description [重构] 集中处理阶段切换时的所有 DOM 类名操作。
+     * 由 phase_switchPhase 调用，负责阶段标题容器的显示/隐藏和文本更新。
+     * 将原先分散在 game_phase.js 中的 DOM 操作集中到此处统一管理。
+     * @param {string} newPhase - 新阶段名称
+     */
+    ui_onPhaseChange(newPhase) {
+        const titleContainer = document.getElementById('phase-title-container');
+        const titleText = document.getElementById('phase-title');
+        const subText = document.getElementById('phase-sub');
+        if (!titleContainer || !titleText || !subText) return;
+
+        // 显示阶段标题
+        titleContainer.classList.remove('minimized');
+
+        // 根据阶段设置标题文本
+        // 注：此处文字与 game_phase.js 原始内容保持一致
+        const PHASE_TITLES = {
+            'meta':       { text: '\u56de\u8072\u7149\u91d1\u5e2b', sub: 'Echo Alchemist' },
+            'gathering':  { text: '\u7814\u78e8\u968e\u6bb5', sub: '\u6536\u96c6\u9b54\u529b' },
+            'combat':     { text: '\u6230\u9b25\u968e\u6bb5', sub: '\u6297\u79a6\u9b54\u50cf' },
+            'truth_book': { text: '\u771f\u7406\u4e4b\u66f8', sub: '\u6d1e\u6089\u842c\u7269\u4e4b\u7406' },
+            'training':   { text: '\u8a66\u7149\u5834', sub: '\u6975\u9650\u6230\u9b25\u6e2c\u8a66' },
+        };
+        const titleData = PHASE_TITLES[newPhase] || { text: '\u547d\u904b\u6289\u62e9', sub: '\u9078\u64c7\u4f60\u7684\u547d\u904b' };
+        titleText.innerText = titleData.text;
+        subText.innerText = titleData.sub;
+
+        // 1.2秒后隐藏阶段标题
+        setTimeout(() => { titleContainer.classList.add('minimized'); }, 1200);
+    },
+
+    /**
+     * @method ui_triggerScreenShake
+     * @description [重构] 触发屏幕震动效果（shake-hard CSS 动画）。
+     * 将原先分散在 combat_system.js 中的直接 DOM 操作提取到 ui_system.js。
+     * @param {number} [duration=200] - 震动持续时间（毫秒）
+     */
+    ui_triggerScreenShake(duration = 200) {
+        const container = document.getElementById('game-container');
+        if (!container) return;
+        container.classList.add('shake-hard');
+        setTimeout(() => container.classList.remove('shake-hard'), duration);
     },
 };


### PR DESCRIPTION
## 重构内容

本 PR 完成 UI 层分离重构，集中 DOM 操作，移除内联事件处理器。已在任务1-3修复基础上 rebase，冲突已手动解决。

### 主要改动

| 改动 | 文件 | 说明 |
|------|------|------|
| Shop 卡片重构 | `ui_system.js` | card.innerHTML 改为 createElement，onclick 改为 addEventListener |
| 伤害统计重构 | `ui_system.js` | header.innerHTML 内联事件改为 addEventListener |
| 新增 ui_onPhaseChange | `ui_system.js` | 集中处理阶段切换时的 DOM 类名操作 |
| 新增 ui_triggerScreenShake | `ui_system.js` | 封装 shake-hard DOM 操作 |
| combat_system 解耦 | `src/combat_system.js` | 替换为 ui_triggerScreenShake 调用 |
| game_phase 解耦 | `src/game_phase.js` | phase_switchPhase 中 DOM 操作提取到 ui_onPhaseChange |
| INTERFACE.md 合并 | `INTERFACE.md` | 合并 EventBus 规范与 UI 分离接口规范 |

### 冲突解决说明
- INTERFACE.md：合并了任务3（EventBus）和任务4（UI分离）的接口文档
- ui_system.js：保留了任务1的 BUGFIX #2（setDeepValue 单次调用）和 BUGFIX #4（multicast 颜色顺序）
- 关联任务：tsk-34f3bed9-90b