### PR TITLE
feat(Task 3.3): 移除 Object.assign Mixin，改为构造函数组合模式

### DIFF
--- a/.cursor/rules/global.md
+++ b/.cursor/rules/global.md
@@ -8,7 +8,7 @@
 
 为了解决这些问题，项目的目标架构如下：
 
-*   **事件驱动（Event-Driven）**：废弃 `Object.assign` 的巨型 Mixin 模式，引入 `event_bus.js` 作为事件总线（Event Bus）。各个子系统（如 UI、战斗、掉落等）通过事件进行通信，而不是直接修改全局 `Game` 实例的状态。
+*   **事件驱动（Event-Driven）**：已废弃 `Object.assign(Game.prototype, ...)` 的巨型 Mixin 模式（Task 3.3 已完成移除）。引入 `event_bus.js` 作为事件总线（Event Bus）。各个子系统（如 UI、战斗、掉落等）通过事件进行通信，而不是直接修改全局 `Game` 实例的状态。
 *   **视图与数据分离**：UI 渲染逻辑必须从业务模块中剥离，避免在业务逻辑中使用超长的 `innerHTML` 或直接操作 DOM 节点。
 *   **模块化封装**：将核心逻辑拆分为多个独立的子系统（如 `game_system.js`、`combat_system.js` 等），每个模块只负责单一职责，通过导出和导入函数进行协作。
 *   **资源与状态管理**：音频系统（`audio.js`）延迟初始化以适应浏览器策略，实体系统（`entities.js`）需进行性能优化（如空间分区），以应对高频碰撞检测。
@@ -75,3 +75,66 @@
 *   **禁止业务逻辑操作 DOM**：严禁在非 UI 模块（特别是 `combat_system.js` 和 `entities.js`）中直接调用 DOM API（如 `innerHTML`、`classList.add` 等）。所有视图更新必须通过事件总线交由 `ui_system.js` 处理。
 *   **禁止遗留魔法数字和 TODO**：在重构过程中，必须将硬编码的魔法数字提取到 `config.js` 中。严禁提交带有 `[AUTO-GENERATED] TODO:` 等无意义的机器生成注释的代码。
 *   **禁止不当的历史文档存放**：历史更新文档、废弃的设计方案必须归档到 `docs/archive/` 目录，禁止散落在项目根目录或活跃的 `docs/` 目录中。
+*   **禁止使用 Mixin 模式扩展 Game 类**：严禁在 `core.js` 文件末尾或任何地方使用 `Object.assign(Game.prototype, ...)` 将子系统方法批量混入 `Game` 原型。新增子系统必须遵循第 5 节「子系统扩展规范」中的组合模式。
+
+## 5. 子系统扩展规范（Task 3.3 新增）
+
+自 Task 3.3 起，`core.js` 已完全移除 `Object.assign(Game.prototype, ...)` Mixin 模式。当前采用的是**组合模式（Composition via bind）**。
+
+### 当前架构状态
+
+*   **已迁移完成的子系统（全部 10 个）**：
+    *   `game_system.js`、`game_phase.js`、`combat_system.js`、`render_system.js`、`spawn_system.js`
+    *   `ui_system.js`、`ui/hud.js`、`ui/shop.js`、`ui/rune_launcher.js`、`calc_utils.js`
+*   **待迁移子系统**：无（全部完成）
+
+### 组合模式实现方式
+
+在 `Game` 构造函数的第一段，通过以下模式将子系统注入为实例方法：
+
+```js
+// core.js 构造函数开头
+const _subsystems = [
+    game_system, game_phase, combat_system, render_system, spawn_system,
+    ui_system, hud_system, shop_system, rune_launcher_system,
+    calc_utils
+];
+for (const subsystem of _subsystems) {
+    for (const [key, val] of Object.entries(subsystem)) {
+        if (typeof val === 'function') {
+            this[key] = val.bind(this);  // 函数绑定到实例
+        } else if (typeof val !== 'undefined') {
+            this[key] = Array.isArray(val) ? [...val] : val;  // 非函数属性直接赋值
+        }
+    }
+}
+```
+
+### 新增子系统的正确方式
+
+如需新增子系统，必须遵循以下步骤：
+
+1.  创建新的子系统文件（如 `src/new_system.js`），以对象字面量形式导出：
+    ```js
+    export const new_system = {
+        newSystem_method() { /* 使用 this 访问 Game 实例 */ },
+    };
+    ```
+2.  在 `core.js` 中导入新子系统：
+    ```js
+    import { new_system } from './new_system.js';
+    ```
+3.  将新子系统添加到 `_subsystems` 数组中：
+    ```js
+    const _subsystems = [
+        ...,
+        new_system  // 新增
+    ];
+    ```
+4.  **严禁**在文件末尾添加 `Object.assign(Game.prototype, new_system)` 。
+
+### 注意事项
+
+*   组合模式创建的是**实例方法**（存在于实例上，而非原型链），每个 `Game` 实例拥有自己的方法副本。由于游戏只有一个实例，这不是问题。
+*   子系统中的非函数属性（如 `_flyEffectPool: []`）会被拷贝到实例上，每个实例拥有独立副本（数组会浅拷贝）。
+*   子系统方法中的 `this` 始终指向 `Game` 实例，无需修改子系统文件。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@
 *   **游戏阶段规范**：[`.cursor/rules/game_phase.md`](.cursor/rules/game_phase.md) - 阶段转换逻辑（命运抉择→研磨→战斗的状态机、各阶段的入口/出口条件）。
 *   **事件总线规范**：[`.cursor/rules/events.md`](.cursor/rules/events.md) - 事件总线机制（EventBus）、标准事件字典与事件通信规范。（Task 3.1 完成）
 *   **实体系统规范**：[`.cursor/rules/entities.md`](.cursor/rules/entities.md) - 实体系统拆分状态、依赖管理与性能要求规范。（Task 2.2 完成：已提取 Enemy 和 Projectile 类，entities.js 减少约 2004 行）
-*   **战斗系统规范**：[`src/combat/combat.md`](src/combat/combat.md) - 包含战斗模块拆分结构、职责边界、Mixin 注入方式及 DOM 操作迁移计划。（Task 2.3 完成）
+*   **战斗系统规范**：[`src/combat/combat.md`](src/combat/combat.md) - 包含战斗模块拆分结构、职责边界、组合模式注入方式及 DOM 操作迁移计划。（Task 2.3 完成）
 *   **UI 系统规范**：[`.cursor/rules/ui_system.md`](.cursor/rules/ui_system.md) - UI 子模块架构（hud.js、shop.js、rune_launcher.js）、函数命名约定、耦合点标记规范。
+
+> **架构状态（Task 3.3 更新）**：`core.js` 已完全移除 `Object.assign(Game.prototype, ...)` Mixin 模式。全部 10 个子系统均已迁移至组合模式（Composition via bind）。新增子系统必须遵循 [`.cursor/rules/global.md`](.cursor/rules/global.md) 第 5 节「子系统扩展规范」。
+
 > **注意**：随着项目的拆分和重构，本索引应持续更新。每个子模块的负责 Agent 在完成初步重构后，需创建并维护对应的规则文档。

--- a/src/core.js
+++ b/src/core.js
@@ -89,7 +89,29 @@ setupAudioInitListener();
 
 class Game {
     constructor() {
-        // ==================== 事件总线挂载 ====================
+        // ==================== [Task 3.3] 组合模式：将子系统方法绑定到实例 ====================
+        // 替代原有的 Object.assign(Game.prototype, ...) Mixin 模式。
+        // 通过 bind(this) 将各子系统的方法作为实例方法注入，保持 this 指向正确。
+        // 各子系统仍以对象字面量形式维护，无需修改子系统文件。
+        const _subsystems = [
+            game_system, game_phase, combat_system, render_system, spawn_system,
+            ui_system, hud_system, shop_system, rune_launcher_system,
+            calc_utils
+        ];
+        for (const subsystem of _subsystems) {
+            for (const [key, val] of Object.entries(subsystem)) {
+                if (typeof val === 'function') {
+                    // 函数：绑定到当前实例，确保 this 指向正确
+                    this[key] = val.bind(this);
+                } else if (typeof val !== 'undefined') {
+                    // 非函数属性（如 _flyEffectPool、_flyEffectMaxNodes）：
+                    // 直接赋值到实例（数组/对象会居于实例上，而非原型链）
+                    this[key] = Array.isArray(val) ? [...val] : val;
+                }
+            }
+        }
+
+        // ==================== 事件总线挂载 =====================
         this.eventBus = eventBus;
         
         this.variantLevels = { flying_sword: 1 };
@@ -272,11 +294,8 @@ class Game {
     }
 }
 
-// [Task 2.4] UI 子模块通过 Object.assign 混入 Game 实例
-Object.assign(Game.prototype, 
-    game_system, game_phase, combat_system, render_system, spawn_system,
-    ui_system, hud_system, shop_system, rune_launcher_system,
-    calc_utils
-);
+// [Task 3.3] 已移除 Object.assign(Game.prototype, ...) Mixin 模式。
+// 各子系统方法现在通过构造函数中的 bind(this) 注入为实例方法（组合模式）。
+// 详见 .cursor/rules/global.md 第 5 节「子系统扩展规范」。
 
 export { SoundManager, Game, audio, eventBus, initAudio };


### PR DESCRIPTION
## 变更说明

### 核心修改：src/core.js
- 在 Game 构造函数开头通过 `bind(this)` 将 10 个子系统方法注入为实例方法
- 完全替代末尾的 `Object.assign(Game.prototype, ...)` Mixin 模式
- 函数属性：`val.bind(this)` 绑定到实例，确保 this 指向正确
- 非函数属性（如 `_flyEffectPool`）：直接赋值到实例（数组浅拷贝）
- **无需修改任何子系统文件**，this 指向始终正确

### 文档更新：.cursor/rules/global.md
- 新增第 5 节「子系统扩展规范」，记录组合模式实现方式和代码示例
- 明确禁止使用 `Object.assign(Game.prototype, ...)` Mixin 模式
- 说明新增子系统的正确步骤

### 文档更新：AGENTS.md
- 更新架构状态说明，记录 Task 3.3 完成

### 迁移范围
全部 10 个子系统均已完成迁移：
- game_system、game_phase、combat_system、render_system、spawn_system
- ui_system、hud_system、shop_system、rune_launcher_system、calc_utils

### 验证
- JavaScript 语法检查通过（node --check）
- 无方法名冲突（已验证）
- 非函数属性正确处理（_flyEffectPool 等）