### PR TITLE
fix: 缩小倍化球尺寸并降低倍化状态摩擦力，解决卡墙问题

### DIFF
--- a/.cursor/rules/entities.md
+++ b/.cursor/rules/entities.md
@@ -35,7 +35,14 @@
 - `entities.js` 的 `setAudioProvider(provider)` 会同时调用上述两个函数，确保音频注入传播到所有子模块
 - `core.js` 只需调用 `setAudioProvider`，无需感知子模块的存在
 
-## 4. 开发规范
+## 4. 参数调整记录
+
+| 日期 | 文件 | 修改内容 |
+|------|------|----------|
+| 2026-04-11 | `src/entities.js` | `DropBall.update`：当 `this.radius > CONFIG.physics.marbleRadius`（即处于倍化状态）时，使用 `friction + 0.005`（上限 0.998）替代默认摩擦力，减少卡墙概率 |
+| 2026-04-11 | `src/ui/shop.js` | `permanent_size_up` 效果：`marbleSizeBonus` 从 `4.2` 调整为 `2.5`，防止倍化球在钉盘左右墙面间就少尺寸内将球夹住 |
+
+## 5. 开发规范
 *   **依赖管理**：
     *   `math_utils.js` 和 `particles.js` 作为底层模块，**严禁**引入 `entities.js`、`config.js` 或 `audio.js` 等高层业务模块，以避免循环依赖。
     *   `entities.js` 通过 ES Modules (`import`) 引入拆分出的工具和特效类，并对外重新导出 (`export`) 以保持对其他子系统（如 `combat_system.js`）的向后兼容性。

--- a/src/entities.js
+++ b/src/entities.js
@@ -1219,7 +1219,11 @@ class DropBall {
             
             this.vel = this.vel.add(gravityStep);
             this.pos = this.pos.add(this.vel.mult(timeScale));
-            this.vel = this.vel.mult(Math.pow(CONFIG.physics.friction, timeScale));
+            // 当弹珠处于倍化状态（sizeBonus > 0）时，使用更低的摩擦力，防止卡墙
+            const effectiveFriction = (this.radius > CONFIG.physics.marbleRadius)
+                ? Math.min(CONFIG.physics.friction + 0.005, 0.998)
+                : CONFIG.physics.friction;
+            this.vel = this.vel.mult(Math.pow(effectiveFriction, timeScale));
 
             //  更新滚动音效
             // 计算当前速度的大小 (Magnitude)

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -122,7 +122,7 @@ export const shop_system = {
         else if (relic.effect === 'combat_wall') {
             this.hasCombatWall = true;
         }else if (relic.effect === 'permanent_size_up') {
-    this.marbleSizeBonus = 4.2; // 每次获得增加 4 像素半径
+    this.marbleSizeBonus = 2.5; // 每次获得增加 2.5 像素半径（缩小以防卡墙）
 }else if (relic.effect === 'unlock_slot') {
             if (!this.unlockedSlots.includes(relic.slotType)) {
                 this.unlockedSlots.push(relic.slotType);


### PR DESCRIPTION
## 问题描述
钉盘左右墙面间距较窄，倍化球（获得「倍化之术」遗物后）尺寸过大，导致球在墙壁间卡住无法通过。

## 修改内容

### 1. 缩小倍化球尺寸 `src/ui/shop.js`
- `permanent_size_up` 效果的 `marbleSizeBonus`：**4.2 → 2.5**
- 倍化后弹珠半径：11.9 → 10.2（基础 7.7 + 2.5）

### 2. 降低倍化状态下的摩擦力 `src/entities.js`
- `DropBall.update`：当 `this.radius > CONFIG.physics.marbleRadius`（即处于倍化状态）时，使用 `friction + 0.005`（上限 0.998）替代默认摩擦力
- 减少倍化球在狭窄空间因摩擦力过大导致的卡顿/卡墙

### 3. 同步更新文档 `.cursor/rules/entities.md`
- 新增「参数调整记录」章节，记录本次修改