### PR TITLE
feat(tsk-14980b3f-556): Boss 符文掉落系统实现

### DIFF
--- a/.cursor/rules/rune_system.md
+++ b/.cursor/rules/rune_system.md
@@ -13,6 +13,16 @@ globs: ["src/rune_system.js", "src/rune_config.js", "src/loot_system.js"]
   1. **套路识别**: 分析玩家近几回合的伤害构成。
   2. **克制映射**: 结合套路克制关系（如火焰克制护盾/再生），动态提高相关符文的掉落权重。
   3. **加权抽取**: 基于动态权重进行随机抽取，确保掉落物符合玩家当前构建需求。
+- **函数签名** (Boss 符文掉落系统扩展):
+  ```js
+  loot_calcRuneDrop(game, overrideOptions = {})
+  ```
+  - `overrideOptions.forcedLevel` {number}: 强制指定掉落等级（如 2）
+  - `overrideOptions.themeWeights` {Object}: Boss 主题额外权重注入（如 `{ pyro: 3.0, laser: 3.0 }`）
+  - **返回值**: `{ runeId: string|null, level: number }` 对象（原来直接返回字符串，已升级）
+- **调用方彿变更警告**: 所有调用方必须适配新返回对象格式。已更新的调用方：
+  - `combat_system.js`: Boss 死亡掉落、普通敌人掉落、`combat_runeCharge_initUI`
+  - `rune_system.js`: `rune_reforge` 重铸函数
 
 ## 3. 网格拼图逻辑 (`rune_system.js`)
 - **发射器网格**: 3x3 的符文放置区域。
@@ -34,3 +44,23 @@ globs: ["src/rune_system.js", "src/rune_config.js", "src/loot_system.js"]
 - 符文对象标准格式: `{ id: String, level: Number }`。
 - `RUNE_DB`: 符文基础信息定义（包含 `baseStat`）。
 - `RUNEWORD_DB`: 符文之语组合规则定义。
+
+## 6. Boss 符文掉落系统 (`combat_system.js` + `config.js`)
+
+### 6.1 Boss 死亡丰厚掉落
+- Boss 死亡必定掉落 **3 个** 符文，分别为：
+  - **掉落 1**：`forcedLevel: 2` + `themeWeights: bossThemeWeights`（主题符文 + Lv2）
+  - **掉落 2**：20% 概率 `forcedLevel: 2`，否则 `forcedLevel: 1`（智能掉落）
+  - **掉落 3**：标准掉落（无 overrideOptions）
+- 掉落物正常出现在场地，玩家手动拾取。
+- `RuneLoot` 对象通过动态属性 `loot.level` 存储掉落等级。
+
+### 6.2 Boss 狂暴阶段即时掉落
+- Boss HP 首次降至 50% 时，立即自动掉落 1 个 Lv1 符文并拾取入库。
+- 使用 `enemy._bossEnrageDropped` 标志确保每个 Boss 仅触发一次。
+- 自动拾取复用现有拾取逻辑（直接 `push` 到 `runeInventory`）。
+
+### 6.3 Boss 主题权重配置 (`config.js` 中的 `BOSS_DB`)
+- `BOSS_DB` 包含 8 个 Boss 的 `themeWeights` 配置。
+- `themeWeights` 键为 RUNE_DB 中的 `element` 字段，在 `loot_calcRuneDrop` 第三层抽取中放大对应属性符文的掉落权重。
+- Boss 实体需将对应的 `BOSS_DB` 条目引用为 `enemy.bossConfig`，供死亡掉落逻辑读取。

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -1331,7 +1331,40 @@ combat_damageEnemy(enemy, projectile, damageOverride = null) {
         
  
         this.combat_recordDamage(actualDmg, damageType, sourceType, shotId);
-        
+
+        // [新增] Boss 狂暴阶段即时掉落：HP 首次降至 50% 时生成 1 个 Lv1 符文并立即自动拾取
+        // 使用 enemy._bossEnrageDropped 标志确保每个 Boss 仅触发一次
+        if (
+            !killed &&
+            enemy.type === 'boss' &&
+            !enemy._bossEnrageDropped &&
+            enemy.hp > 0 &&
+            enemy.hp / enemy.maxHp < 0.5
+        ) {
+            enemy._bossEnrageDropped = true; // 标记已触发，防止重复掉落
+
+            // 生成 1 个标准 Lv1 符文（无 overrideOptions）
+            const enrageDropResult = loot_calcRuneDrop(this);
+            if (enrageDropResult.runeId) {
+                // 立即自动拾取：直接将符文推入库存，复用现有拾取逻辑
+                const enrageRuneDef = RUNE_DB.find(r => r.id === enrageDropResult.runeId);
+                if (enrageRuneDef) {
+                    this.runeInventory.push({ id: enrageDropResult.runeId, level: enrageDropResult.level });
+                    const runeName = enrageRuneDef.icon
+                        ? `${enrageRuneDef.icon} ${enrageRuneDef.name}`
+                        : enrageRuneDef.name;
+                    // 视觉反馈：显示狂暴掉落提示
+                    this.spawn_createFloatingText(
+                        enemy.pos.x,
+                        enemy.pos.y - 40,
+                        `狂暴! +${runeName}`,
+                        '#f59e0b'
+                    );
+                    showToast(`Boss 狂暴！获得符文：${runeName}`);
+                }
+            }
+        }
+
         // 事件总线广播伤害事件
         eventBus.emit('damage:dealt', {
             enemy: enemy,
@@ -1556,26 +1589,59 @@ combat_damageEnemy(enemy, projectile, damageOverride = null) {
                     // ui_showRelicSelection 内部已经会设置 stateBeforeRelic，无需在此重复设置
                     this.ui_showRelicSelection();
                 }, 500);
-            }
 
-            // [符文掉落] 三因子动态掉落率公式
-            // 因子1：基础掉落率（随回合数线性增长，上限 40%）
-            const BaseDropRate = Math.min(0.05 + (this.round / 10) * 0.05, 0.40);
-            // 因子2：敌人数量修正（敌人越多，单个掉落率越低）
-            const spawnedEnemiesInRound = this.spawnedEnemiesInRound || Math.max(1, this.enemies.length);
-            const EnemyModifier = Math.max(0.3, 1.0 / Math.sqrt(spawnedEnemiesInRound));
-            // 因子3：背包与网格占用率衰减（防溢出机制）
-            const MAX_RUNE_CAPACITY = 20;
-            const runesInGrid = (this.runeGrid || []).filter(r => r !== null).length;
-            const OccupancyPenalty = Math.max(0.2, 1.0 - (this.runeInventory.length + runesInGrid) / MAX_RUNE_CAPACITY);
-            // 最终掉落率
-            const FinalDropRate = BaseDropRate * EnemyModifier * OccupancyPenalty;
-            if (Math.random() < FinalDropRate) {
-                const runeId = loot_calcRuneDrop(this);
-                if (runeId) {
-                    this.runeLootItems.push(new RuneLoot(enemy.pos.x, enemy.pos.y, runeId));
+                // [新增] Boss 死亡丰厚掉落：必定掉落 3 个符文
+                // 读取当前 Boss 的主题权重配置（如果有）
+                const bossThemeWeights = (enemy.bossConfig && enemy.bossConfig.themeWeights)
+                    ? enemy.bossConfig.themeWeights
+                    : {};
+
+                // 掉落 1：必定 Lv2 + 主题权重（主题符文）
+                const drop1 = loot_calcRuneDrop(this, { forcedLevel: 2, themeWeights: bossThemeWeights });
+                if (drop1.runeId) {
+                    const loot1 = new RuneLoot(enemy.pos.x - 20, enemy.pos.y, drop1.runeId);
+                    loot1.level = drop1.level;
+                    this.runeLootItems.push(loot1);
                 }
-            }
+
+                // 掉落 2：20% 概率 Lv2，否则 Lv1（智能掉落）
+                const forcedLevel2 = Math.random() < 0.20 ? 2 : 1;
+                const drop2 = loot_calcRuneDrop(this, { forcedLevel: forcedLevel2 });
+                if (drop2.runeId) {
+                    const loot2 = new RuneLoot(enemy.pos.x, enemy.pos.y, drop2.runeId);
+                    loot2.level = drop2.level;
+                    this.runeLootItems.push(loot2);
+                }
+
+                // 掉落 3：标准掉落（无 overrideOptions）
+                const drop3 = loot_calcRuneDrop(this);
+                if (drop3.runeId) {
+                    const loot3 = new RuneLoot(enemy.pos.x + 20, enemy.pos.y, drop3.runeId);
+                    loot3.level = drop3.level;
+                    this.runeLootItems.push(loot3);
+                }
+            } else {
+                // 普通敌人：[符文掉落] 三因子动态掉落率公式
+                // 因子1：基础掉落率（随回合数线性增长，上限 40%）
+                const BaseDropRate = Math.min(0.05 + (this.round / 10) * 0.05, 0.40);
+                // 因子2：敌人数量修正（敌人越多，单个掉落率越低）
+                const spawnedEnemiesInRound = this.spawnedEnemiesInRound || Math.max(1, this.enemies.length);
+                const EnemyModifier = Math.max(0.3, 1.0 / Math.sqrt(spawnedEnemiesInRound));
+                // 因子3：背包与网格占用率衰减（防溢出机制）
+                const MAX_RUNE_CAPACITY = 20;
+                const runesInGrid = (this.runeGrid || []).filter(r => r !== null).length;
+                const OccupancyPenalty = Math.max(0.2, 1.0 - (this.runeInventory.length + runesInGrid) / MAX_RUNE_CAPACITY);
+                // 最终掉落率
+                const FinalDropRate = BaseDropRate * EnemyModifier * OccupancyPenalty;
+                if (Math.random() < FinalDropRate) {
+                    const dropResult = loot_calcRuneDrop(this);
+                    if (dropResult.runeId) {
+                        const loot = new RuneLoot(enemy.pos.x, enemy.pos.y, dropResult.runeId);
+                        loot.level = dropResult.level;
+                        this.runeLootItems.push(loot);
+                    }
+                }
+            }}
         }
         
         // 爆炸逻辑 (保留并增强视觉)
@@ -1919,8 +1985,9 @@ combat_damageEnemy(enemy, projectile, damageOverride = null) {
         // 预生成4个符文预览（虚影），使用智能掉落预计算
         this.runeChargePreviewRunes = [];
         for (let i = 0; i < 4; i++) {
-            const runeId = loot_calcRuneDrop(this);
-            const runeDef = runeId ? RUNE_DB.find(r => r.id === runeId) : null;
+            // loot_calcRuneDrop 返回 { runeId, level }，预览仅需符文定义
+            const dropResult = loot_calcRuneDrop(this);
+            const runeDef = dropResult.runeId ? RUNE_DB.find(r => r.id === dropResult.runeId) : null;
             this.runeChargePreviewRunes.push(runeDef || null);
         }
         // [Task 3.2] 改为 EventBus 事件，由 hud.js 监听并初始化充能符文 DOM

--- a/src/config.js
+++ b/src/config.js
@@ -717,6 +717,88 @@ const SKILL_DB = [
 ];
 
 
+// ==================== Boss 配置数据库 ====================
+/**
+ * BOSS_DB - Boss 配置数据库
+ *
+ * 每个 Boss 对象包含：
+ *   id: 唯一标识符
+ *   name: 显示名称（中文）
+ *   affixes: 初始词缀数组（对应 Enemy.affixes）
+ *   themeWeights: Boss 主题符文掉落权重加成（按符文 element 字段匹配）
+ *     键为 RUNE_DB 中的 element 字段，值为额外权重加成量
+ *     在 loot_calcRuneDrop 的第三层抽取中，与 BOSS_THEME_MULTIPLIER 相乘后叠加到符文权重
+ *
+ * 弹点属性来源：docs/boss_system_design.md
+ * 对应 COUNTER_MAP 中的克制关系：
+ *   pyro.shield=1.0, pierce.shield=1.0 → 伊格尼斯（护盾+极速）
+ *   cryo.jump=0.8, pierce.jump=0.8   → 格拉西斯（跳跃+再生）
+ *   lightning.clone=1.0, scatter.clone=1.0 → 米克罗（分身+治疗）
+ *   bounce.devour=0.8, laser.devour=0.8  → 噬神者（吞噬+护盾）
+ *   laser.regen=1.0, pyro.regen=0.8      → 维里迪斯（再生+治疗）
+ *   cryo.haste=1.0, bounce.haste=0.4     → 特斯拉（极速+分身）
+ *   pierce.shield=1.0, laser.shield=0.5  → 奇美拉（狂暴+吞噬）
+ *   动态弹点                            → 奥罗波罗斯（全词缀轮转）
+ */
+const BOSS_DB = [
+    {
+        id: 'boss_ignis',
+        name: '燕炉守卫·伊格尼斯',
+        affixes: ['shield', 'haste'],
+        // 弹点：穿透 (Pierce) 与 火焰 (Pyro) —— 克制护盾
+        themeWeights: { pierce: 3.0, pyro: 3.0 }
+    },
+    {
+        id: 'boss_glacies',
+        name: '霜晶缝合怪·格拉西斯',
+        affixes: ['jump', 'regen'],
+        // 弹点：冰霜 (Cryo) 与 穿透 (Pierce) —— 克制跳跃与再生
+        themeWeights: { cryo: 3.0, pierce: 3.0 }
+    },
+    {
+        id: 'boss_micro',
+        name: '裂变母体·米克罗',
+        affixes: ['clone', 'healer'],
+        // 弹点：闪电 (Lightning) 与 散射 (Scatter) —— 克制分身与治疗
+        themeWeights: { lightning: 3.0, scatter: 3.0 }
+    },
+    {
+        id: 'boss_devourer',
+        name: '贪婪之渊·噬神者',
+        affixes: ['devour', 'shield'],
+        // 弹点：弹射 (Bounce) 与 激光 (Laser) —— 克制吞噬
+        themeWeights: { bounce: 3.0, laser: 3.0 }
+    },
+    {
+        id: 'boss_viridis',
+        name: '翠绳共生体·维里迪斯',
+        affixes: ['regen', 'healer'],
+        // 弹点：激光 (Laser) 与 火焰 (Pyro) —— 克制再生与治疗
+        themeWeights: { laser: 3.0, pyro: 3.0 }
+    },
+    {
+        id: 'boss_tesla',
+        name: '雷霆幻影·特斯拉',
+        affixes: ['haste', 'clone'],
+        // 弹点：冰霜 (Cryo) 与 弹射 (Bounce) —— 克制极速与分身
+        themeWeights: { cryo: 3.0, bounce: 3.0 }
+    },
+    {
+        id: 'boss_chimera',
+        name: '混沌融合体·奇美拉',
+        affixes: ['devour'],
+        // 弹点：穿透 (Pierce) 与 激光 (Laser) —— 克制护盾与吞噬
+        themeWeights: { pierce: 3.0, laser: 3.0 }
+    },
+    {
+        id: 'boss_ouroboros',
+        name: '永恒回声·奥罗波罗斯',
+        affixes: ['shield', 'haste'], // 初始词缀，将按回合轮转
+        // 动态弹点，暂时配置均衡权重（待导演系统实现后可根据当前词缀动态调整）
+        themeWeights: { pierce: 1.5, pyro: 1.5, cryo: 1.5, lightning: 1.5, laser: 1.5, scatter: 1.5, bounce: 1.5 }
+    }
+];
+
 // ==================== 导出配置 ====================
 // 注意：TRUTH_BOOK_DATA 已移动到 systems.js，因为它需要使用 Enemy 类
 
@@ -727,4 +809,5 @@ export {
     CONFIG,
     RELIC_DB,
     SKILL_DB,
+    BOSS_DB,
 };

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -525,8 +525,9 @@ phase_gathering_getRandomPegType() {
                 // 查找符文定义，获取名称用于视觉反馈
                 const runeDef = RUNE_DB.find(r => r.id === loot.runeId);
                 const runeName = runeDef ? runeDef.name : loot.runeId;
-                // 将符文转化为 { id, level: 1 } 对象并推入库存
-                this.runeInventory.push({ id: loot.runeId, level: 1 });
+                // 将符文转化为 { id, level } 对象并推入库存
+                // loot.level 由掉落生成时设置（Boss 掉落可能为 2+），默认为 1
+                this.runeInventory.push({ id: loot.runeId, level: loot.level || 1 });
                 // 视觉反馈：FloatingText 显示「+符文名称」
                 this.spawn_createFloatingText(
                     loot.x,
@@ -1061,7 +1062,8 @@ phase_gathering_getRandomPegType() {
                 if (activeEnemies === 0 && loot.active) {
                     const runeDef = RUNE_DB.find(r => r.id === loot.runeId);
                     if (runeDef) {
-                        const runeObj = { id: loot.runeId, level: 1 };
+                        // loot.level 由掉落生成时设置（Boss 掉落可能为 2+），默认为 1
+                        const runeObj = { id: loot.runeId, level: loot.level || 1 };
                         this.runeInventory.push(runeObj);
                         loot.active = false;
                         const runeName = runeDef.icon ? `${runeDef.icon} ${runeDef.name}` : runeDef.name;

--- a/src/loot_system.js
+++ b/src/loot_system.js
@@ -8,7 +8,13 @@
  * - 第三层：符文关联与抽取（基于权重池对 RUNE_DB 进行加权随机抽取）
  *
  * 导出：
- * - loot_calcRuneDrop(game): 计算并返回应掉落的符文 id
+ * - loot_calcRuneDrop(game, overrideOptions): 计算并返回应掉落的符文结果对象
+ *
+ * 变更记录 (Boss 符文掉落系统):
+ * - 新增 overrideOptions 参数支持：
+ *   - forcedLevel: 强制指定掉落等级（如 2），覆盖默认的 level: 1
+ *   - themeWeights: 注入额外的标签权重（如 { pyro: 3.0, laser: 3.0 }），
+ *     在第二层计算完成后叠加，放大 Boss 主题相关符文的掉落概率
  */
 
 import { RUNE_DB, COUNTER_MAP } from './rune_config.js';
@@ -26,6 +32,12 @@ const SMART_DROP_MULTIPLIER = 3.0;
  * 取最近 N 回合的伤害数据进行分析
  */
 const HISTORY_WINDOW = 5;
+
+/**
+ * Boss 主题权重注入乘数：themeWeights 的放大系数
+ * 控制 Boss 主题符文相对于智能掉落的优先级
+ */
+const BOSS_THEME_MULTIPLIER = 4.0;
 
 // ==================== 第一层：玩家套路成分识别 ====================
 
@@ -188,16 +200,19 @@ function _weightedRandomChoice(candidates) {
  * 第三层：符文关联与抽取
  *
  * 遍历 RUNE_DB，计算每个符文的最终权重：
- *   finalWeight = baseDropWeight + sum(affinity_tags 在 tagWeights 中的值) * SMART_DROP_MULTIPLIER
+ *   finalWeight = baseDropWeight
+ *               + sum(affinity_tags 在 tagWeights 中的值) * SMART_DROP_MULTIPLIER
+ *               + sum(affinity_tags 在 themeWeights 中的值) * BOSS_THEME_MULTIPLIER（可选）
  *
  * 使用加权随机算法抽取最终掉落的符文 id。
  *
  * @param {Object} tagWeights - 归一化后的标签权重池 { tag: normalizedWeight }
+ * @param {Object} [themeWeights={}] - Boss 主题额外权重注入 { elementKey: bonusWeight }
  * @returns {string} 被抽中的符文 id
  */
-function _selectRuneByWeight(tagWeights) {
+function _selectRuneByWeight(tagWeights, themeWeights = {}) {
     const candidates = RUNE_DB.map(rune => {
-        // 计算亲和标签在权重池中的累计贡献
+        // 计算亲和标签在权重池中的累计贡献（智能掉落）
         let affinityBonus = 0;
         if (rune.affinity_tags && Array.isArray(rune.affinity_tags)) {
             for (const tag of rune.affinity_tags) {
@@ -205,8 +220,16 @@ function _selectRuneByWeight(tagWeights) {
             }
         }
 
-        // 最终权重 = 基础掉落权重 + 亲和标签贡献 * 智能掉落乘数
-        const finalWeight = (rune.baseDropWeight || 1) + affinityBonus * SMART_DROP_MULTIPLIER;
+        // 计算 Boss 主题权重注入贡献（按符文 element 匹配 themeWeights 键）
+        let themeBonus = 0;
+        if (rune.element && themeWeights[rune.element]) {
+            themeBonus = themeWeights[rune.element] * BOSS_THEME_MULTIPLIER;
+        }
+
+        // 最终权重 = 基础掉落权重 + 亲和标签贡献 * 智能掉落乘数 + Boss 主题贡献
+        const finalWeight = (rune.baseDropWeight || 1)
+            + affinityBonus * SMART_DROP_MULTIPLIER
+            + themeBonus;
 
         return {
             id: rune.id,
@@ -220,7 +243,7 @@ function _selectRuneByWeight(tagWeights) {
 // ==================== 主函数：智能掉落权重计算 ====================
 
 /**
- * loot_calcRuneDrop - 计算并返回应掉落的符文 id
+ * loot_calcRuneDrop - 计算并返回应掉落的符文结果对象
  *
  * 三层逻辑：
  * 1. 玩家套路成分识别：分析近几回合伤害历史，得到套路成分向量
@@ -230,19 +253,32 @@ function _selectRuneByWeight(tagWeights) {
  * @param {Object} game - Game 实例，需包含以下属性：
  *   - game.roundDamageHistory: 历史回合伤害数据数组
  *   - game.currentShotDamageByAttr: 当前回合实时伤害数据（备用）
- * @returns {string} 被抽中的符文 id（对应 RUNE_DB 中的 id）
+ * @param {Object} [overrideOptions={}] - 可选覆盖参数（用于 Boss 特殊掉落）：
+ *   - forcedLevel {number}: 强制指定掉落等级（如 2），覆盖默认的 level: 1
+ *   - themeWeights {Object}: 注入额外的 Boss 主题标签权重（如 { pyro: 3.0, laser: 3.0 }），
+ *     按符文 element 字段匹配，放大对应属性符文的掉落概率
+ * @returns {{ runeId: string|null, level: number }} 掉落结果对象
+ *   - runeId: 被抽中的符文 id（对应 RUNE_DB 中的 id），抽取失败时为 null
+ *   - level: 掉落等级（默认 1，或由 forcedLevel 指定）
  */
-function loot_calcRuneDrop(game) {
+function loot_calcRuneDrop(game, overrideOptions = {}) {
+    const { forcedLevel, themeWeights } = overrideOptions;
+
     // 第一层：玩家套路成分识别
     const buildVector = _calcBuildVector(game);
 
     // 第二层：克制关系映射
     const tagWeights = _calcTagWeights(buildVector);
 
-    // 第三层：符文关联与抽取
-    const runeId = _selectRuneByWeight(tagWeights);
+    // 第三层：符文关联与抽取（注入 Boss 主题权重）
+    const runeId = _selectRuneByWeight(tagWeights, themeWeights || {});
 
-    return runeId;
+    // 确定掉落等级：优先使用 forcedLevel，否则默认 1
+    const level = (typeof forcedLevel === 'number' && forcedLevel >= 1)
+        ? forcedLevel
+        : 1;
+
+    return { runeId, level };
 }
 
 // ==================== 导出 ====================

--- a/src/rune_system.js
+++ b/src/rune_system.js
@@ -354,7 +354,9 @@ function rune_reforge(runeObjects, runeInventory, game) {
     const newLevel = Math.max(1, Math.floor((lvA + lvB + lvC) / 3));
 
     // ---- 调用智能掉落算法获取新符文 ID ----
-    const newId = loot_calcRuneDrop(game);
+    // loot_calcRuneDrop 返回 { runeId, level }，重铸仅需 runeId，level 由三个输入符文算得
+    const reforgeDropResult = loot_calcRuneDrop(game);
+    const newId = reforgeDropResult.runeId;
     if (!newId) {
         return {
             success: false,


### PR DESCRIPTION
## 任务概述
实现 Boss 符文掉落系统（任务 tsk-14980b3f-556）。

## 变更文件
- **src/loot_system.js**（全文件重写，249→285行）
- **src/combat_system.js**（局部修改，+67行）
- **src/config.js**（微型修改，新增 BOSS_DB）
- **src/rune_system.js**（微型修改，适配新返回值）
- **src/game_phase.js**（微型修改，读取 loot.level）
- **.cursor/rules/rune_system.md**（文档同步）

## 核心实现

### 1. loot_calcRuneDrop 扩展
新增 overrideOptions 参数：
- forcedLevel: 强制指定掉落等级
- themeWeights: Boss 主题额外权重注入
- 返回值升级为 { runeId, level } 对象

### 2. Boss 死亡 3 次掉落
- 掉落1：Lv2 + 主题权重
- 掉落2：20%概率 Lv2，否则 Lv1
- 掉落3：标准掉落

### 3. 狂暴阶段即时掉落
- HP<50% 首次触发，立即自动拾取 1 个 Lv1 符文
- 使用 enemy._bossEnrageDropped 防止重复触发

### 4. BOSS_DB 配置
8 个 Boss 的 themeWeights 配置，对应 COUNTER_MAP 克制关系

## 测试说明
- 所有修改文件通过 node --check 语法检查
- 遵循 echo-developer 技能的禁止行为清单（未全量重写大文件）