### PR TITLE
feat: 实现难度平衡集成系统 (tsk-d5446254-8f4)

### DIFF
--- a/.cursor/rules/game_phase.md
+++ b/.cursor/rules/game_phase.md
@@ -69,3 +69,30 @@ globs: ["src/game_phase.js"]
 | `tesla` | 特斯拉山峡 | 大 Boss | 极速+多次行动，狂暴后行动次数再+1 |
 | `chimera` | 奇美拉 | 大 Boss | 初始高温，狂暴后温度直接达到阈值 |
 | `ouroboros` | 奥罗波罗斯 | 大 Boss | 每 N 回合切换词缀组，狂暴后切换加速 |
+
+## 5. 难度平衡系统 (Difficulty Balance System)
+### 5.1 战后高压因子 (Post-Boss Surge)
+- **触发时机**: 击杀 Boss 时（监听 `boss:defeated` 事件）
+- **机制**: 
+  - Boss 击杀后，激活战后高压因子 `postBossMultiplier = 1.3`，持续 `postBossSurgeRoundsLeft = 3` 回合。
+  - 在高压期间，普通敌人的基础血量 `finalBaseHP` 会乘以 `postBossMultiplier`。
+  - 在高压期间，双词缀精英怪的生成概率临时提升 25%。
+- **衰减逻辑**: 
+  - 在 `phase_finalizeRound` 中，每回合结束时 `postBossSurgeRoundsLeft` 减 1。
+  - `postBossMultiplier` 每次减 0.1，直到恢复至 1.0。
+
+### 5.2 Boss 底线怜悯掉落 (Pity Drop)
+- **触发时机**: 敌人越过失败线时（`input_checkDefeat` 检测到越线）
+- **机制**: 
+  - 如果越线的敌人是 Boss（`e.type === 'boss'`），触发 `_triggerPityDrop` 怜悯掉落。
+  - 系统分析玩家近期的伤害历史，找出主属性（占比最高的属性）。
+  - 根据 `COUNTER_MAP` 找到该主属性的克制属性。
+  - 调用 `loot_calcRuneDrop` 强制生成一个克制属性的 1 级符文，掉落在 Boss 越线位置。
+  - 触发 UI 提示："💔 怜悯掉落：获得克制符文"。
+
+### 5.3 掉落权重边际递减 (Marginal Decay)
+- **触发时机**: 计算符文掉落权重时（`loot_system.js` 中的 `_calcBuildVector`）
+- **机制**: 
+  - 统计玩家近期伤害占比 `buildVector` 时，如果某一属性的伤害占比超过阈值（默认 60%），则对超出部分进行衰减。
+  - 衰减系数为 0.5，即超出部分减半。
+  - 衰减后重新归一化 `buildVector`，防止玩家过度依赖单一属性导致掉落过于单一。

--- a/.cursor/rules/rune_system.md
+++ b/.cursor/rules/rune_system.md
@@ -64,3 +64,11 @@ globs: ["src/rune_system.js", "src/rune_config.js", "src/loot_system.js"]
 - `BOSS_DB` 包含 8 个 Boss 的 `themeWeights` 配置。
 - `themeWeights` 键为 RUNE_DB 中的 `element` 字段，在 `loot_calcRuneDrop` 第三层抽取中放大对应属性符文的掉落权重。
 - Boss 实体需将对应的 `BOSS_DB` 条目引用为 `enemy.bossConfig`，供死亡掉落逻辑读取。
+
+## 7. 掉落权重边际递减 (Marginal Decay)
+### 7.1 触发时机
+- 计算符文掉落权重时（`loot_system.js` 中的 `_calcBuildVector`）。
+### 7.2 机制
+- 统计玩家近期伤害占比 `buildVector` 时，如果某一属性的伤害占比超过阈值（默认 60%），则对超出部分进行衰减。
+- 衰减系数为 0.5，即超出部分减半。
+- 衰减后重新归一化 `buildVector`，防止玩家过度依赖单一属性导致掉落过于单一。

--- a/src/core.js
+++ b/src/core.js
@@ -286,6 +286,13 @@ class Game {
             console.log('[Game] Audio system ready');
         });
 
+        // [难度平衡] Boss 被击杀事件：触发战后高压因子
+        this.eventBus.on('boss:defeated', (data) => {
+            this.postBossMultiplier = 1.3;
+            this.postBossSurgeRoundsLeft = 3;
+            console.log('[DifficultyBalance] Boss击杀，战后高压因子激活: x1.3，持续3回合');
+        });
+
         // [Task 3.2] 注册 UI 层 EventBus 监听器
         // ui_initEventListeners: 全局 UI 事件（色差特效、全屏闪光）
         // hud_initEventListeners: HUD 事件（弹药动画、命中进度、充能符文）

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -572,9 +572,19 @@ phase_gathering_getRandomPegType() {
             this.nextRoundHpMultiplier = 1;
         }
 
-        // [修复] 回合切换时清空蝴蝶法阵和风刃，防止残留
+        // [修复] 回合切换时清空蝶蝶法阵和风刃，防止残留
         if (this.butterflyCircles) this.butterflyCircles = [];
         if (this.butterflyBlades) this.butterflyBlades = [];
+
+        // [难度平衡] 战后高压因子递减
+        if (this.postBossSurgeRoundsLeft > 0) {
+            this.postBossSurgeRoundsLeft--;
+            this.postBossMultiplier = Math.max(1.0, this.postBossMultiplier - 0.1);
+            if (this.postBossSurgeRoundsLeft === 0) {
+                this.postBossMultiplier = 1.0;
+                console.log('[DifficultyBalance] 战后高压因子已恢复正常');
+            }
+        }
         
         this.round++;
         this.prevRoundDamage = this.roundDamage;

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -13,9 +13,12 @@
  * - 弹珠选择切换 (sys_toggleMarbleSelection)
  * - 分数乘数重置 (sys_resetMultiplier)
  */
-import { Vec2, showToast } from './entities.js';
+import { Vec2, showToast, RuneLoot } from './entities.js';
 import { CONFIG } from './config.js';
 import { audio } from './audio.js';
+import { loot_calcRuneDrop } from './loot_system.js';
+import { COUNTER_MAP } from './rune_config.js';
+import { eventBus } from './event_bus.js';
 
 export const game_system = {
 
@@ -190,6 +193,9 @@ export const game_system = {
         // 重置 Boss 系统状态
         this.bossHistory = [];
         this._pendingBossSpawn = null;
+        // [难度平衡] 重置战后高压因子
+        this.postBossMultiplier = 1.0;
+        this.postBossSurgeRoundsLeft = 0;
     },
 
     /**
@@ -620,10 +626,86 @@ export const game_system = {
         const viewShiftY = this.boardTilt.current.y * -20;
         for (let e of this.enemies) {
             if (e.active && (e.pos.y + viewShiftY) > this.defeatLineY) {
+                // [难度平衡] Boss 越线：触发怡悯掉落
+                if (e.type === 'boss') {
+                    this._triggerPityDrop(e);
+                }
                 return true;
             }
         }
         return false;
+    },
+
+    /**
+     * @method _triggerPityDrop
+     * @description [难度平衡] Boss 越线时触发怡悯掉落，生成一个克制属性符文。
+     * @param {Enemy} bossEnemy - 越线的 Boss 实体
+     */
+    _triggerPityDrop(bossEnemy) {
+        try {
+            // 1. 找到玩家当前 buildVector 中占比最高的属性
+            // 直接使用导入的 loot_calcRuneDrop 函数，它内部会调用 _calcBuildVector
+            // 这里我们手动计算 buildVector，以便找到主属性
+            const attrTotals = {};
+            const history = this.roundDamageHistory;
+            if (history && history.length > 0) {
+                const recentHistory = history.slice(-5);
+                for (const roundRecord of recentHistory) {
+                    if (roundRecord.shots && Array.isArray(roundRecord.shots)) {
+                        for (const shot of roundRecord.shots) {
+                            if (shot.byAttr) {
+                                for (const [attr, dmg] of Object.entries(shot.byAttr)) {
+                                    attrTotals[attr] = (attrTotals[attr] || 0) + (typeof dmg === 'number' ? dmg : 0);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            const grandTotal = Object.values(attrTotals).reduce((a, b) => a + b, 0);
+            const buildVector = {};
+            if (grandTotal > 0) {
+                for (const [attr, dmg] of Object.entries(attrTotals)) {
+                    buildVector[attr] = dmg / grandTotal;
+                }
+            }
+            let dominantAttr = null;
+            let maxWeight = -1;
+            for (const attr of Object.keys(buildVector)) {
+                if (buildVector[attr] > maxWeight) {
+                    maxWeight = buildVector[attr];
+                    dominantAttr = attr;
+                }
+            }
+            if (!dominantAttr) return;
+
+            // 2. 找到克制属性（COUNTER_MAP 中权重最高的 tag 对应的元素）
+            let counterElement = null;
+            if (COUNTER_MAP && COUNTER_MAP[dominantAttr]) {
+                const counterMap = COUNTER_MAP[dominantAttr];
+                let maxCounterWeight = -1;
+                for (const [tag, weight] of Object.entries(counterMap)) {
+                    if (weight > maxCounterWeight) {
+                        maxCounterWeight = weight;
+                        counterElement = tag;
+                    }
+                }
+            }
+
+            // 3. 调用 loot_calcRuneDrop 生成1个怡悯符文
+            const themeWeights = counterElement ? { [counterElement]: 10.0 } : {};
+            const drop = loot_calcRuneDrop(this, { forcedLevel: 1, themeWeights });
+            if (drop && drop.runeId) {
+                const loot = new RuneLoot(bossEnemy.pos.x, bossEnemy.pos.y, drop.runeId);
+                loot.level = drop.level || 1;
+                this.runeLootItems.push(loot);
+                // 4. 通过 EventBus 显示提示
+                eventBus.emit('ui:toast', { message: '💔 怡悯掉落：获得克制符文' });
+                showToast('💔 怡悯掉落：获得克制符文');
+            }
+        } catch (err) {
+            console.warn('[_triggerPityDrop] 怡悯掉落失败:', err);
+        }
     },
 
     /**

--- a/src/loot_system.js
+++ b/src/loot_system.js
@@ -122,6 +122,23 @@ function _calcBuildVector(game) {
         buildVector[attr] = dmg / grandTotal;
     }
 
+    // [难度平衡] 边际递减：当某属性伤害占比 > 60% 时，该属性的 buildVector 权重衰减
+    const MARGINAL_DECAY_THRESHOLD = 0.60;
+    const MARGINAL_DECAY_FACTOR = 0.5; // 超过阈値后权重减半
+    for (const attr of Object.keys(buildVector)) {
+        if (buildVector[attr] > MARGINAL_DECAY_THRESHOLD) {
+            buildVector[attr] = MARGINAL_DECAY_THRESHOLD +
+                (buildVector[attr] - MARGINAL_DECAY_THRESHOLD) * MARGINAL_DECAY_FACTOR;
+        }
+    }
+    // 重新归一化
+    const totalBV = Object.values(buildVector).reduce((a, b) => a + b, 0);
+    if (totalBV > 0) {
+        for (const attr of Object.keys(buildVector)) {
+            buildVector[attr] /= totalBV;
+        }
+    }
+
     return buildVector;
 }
 

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -103,9 +103,14 @@ export const spawn_system = {
         const chance1 = Math.min(0.6, 0.1 + r * 0.025);
         const chance2 = r > 10 ? Math.min(0.15, (r - 10) * 0.01) : 0;
         
+        // [难度平衡] Boss 战后，双词缀精英怪概率临时提升 25%
+        const postBossBonus = (this.postBossMultiplier && this.postBossMultiplier > 1.0) ? 0.25 : 0;
+        // 将 postBossBonus 叠加到 chance2（双词缀概率）
+        const effectiveChance2 = Math.min(chance2 + postBossBonus, 0.40);
+
         const roll = Math.random();
-        if (roll < chance2) count = 2;
-        else if (roll < chance1 + chance2) count = 1;
+        if (roll < effectiveChance2) count = 2;
+        else if (roll < chance1 + effectiveChance2) count = 1;
         
         if (count === 0) return [];
 
@@ -185,6 +190,12 @@ export const spawn_system = {
             finalBaseHP = (linearHP * 0.6) + (idealHP * 0.4);
         }
         
+        // [难度平衡] 战后高压因子（Post-Boss Surge）
+        // Boss 击杀后 2-3 回合内，普通敌人血量 ×1.3，每回合递减 0.1
+        if (this.postBossMultiplier && this.postBossMultiplier > 1.0) {
+            finalBaseHP *= this.postBossMultiplier;
+        }
+
         // 3. 应用最终倍率
         const baseHP = Math.floor(finalBaseHP * this.nextRoundHpMultiplier);
         


### PR DESCRIPTION
## 功能概述

本 PR 实现了 Echo Alchemist V2 的难度平衡集成系统，包含四个核心模块：

## 变更内容

### 1. 战后高压因子 (Post-Boss Surge)
- **触发**: 击杀 Boss 时，通过 EventBus 监听 `boss:defeated` 事件
- **效果**: 激活 `postBossMultiplier = 1.3`，持续 3 回合
- **衰减**: 每回合结束时 `postBossMultiplier` 减 0.1，直到恢复 1.0
- **涉及文件**: `core.js`, `spawn_system.js`, `game_phase.js`, `game_system.js`

### 2. 双词缀精英怪概率提升
- **触发**: 战后高压因子激活期间
- **效果**: 双词缀精英怪生成概率临时提升 25%（上限 40%）
- **涉及文件**: `spawn_system.js`

### 3. 掉落权重边际递减 (Marginal Decay)
- **触发**: 计算符文掉落权重时
- **效果**: 单一属性伤害占比 > 60% 时，超出部分衰减 50%，防止掉落单一化
- **涉及文件**: `loot_system.js`

### 4. Boss 底线怜悯掉落 (Pity Drop)
- **触发**: Boss 越过失败线时
- **效果**: 自动生成一个克制玩家主属性的 1 级符文，帮助玩家应对下一局
- **涉及文件**: `game_system.js`

## 文档更新
- `.cursor/rules/game_phase.md`: 新增第 5 节「难度平衡系统」
- `.cursor/rules/rune_system.md`: 新增第 7 节「掉落权重边际递减」

## 测试建议
1. 击杀 Boss 后，观察接下来 3 回合的敌人血量是否明显提升
2. 击杀 Boss 后，观察双词缀精英怪的出现频率是否提升
3. 使用单一属性打法，观察符文掉落是否更加多样化
4. 让 Boss 越线，观察是否触发怜悯掉落提示