### PR TITLE
feat(boss): 引入前期保护机制，越早期 Boss 血量越贴近玩家实时战力

### DIFF
--- a/.cursor/rules/config.md
+++ b/.cursor/rules/config.md
@@ -20,6 +20,27 @@ globs: ["src/config.js"]
 - **格式一致性**: 添加新数据字典条目时，必须严格遵循现有对象的键名和数据类型结构。
 - **注释说明**: 修改核心数値或添加新配置项时，必须添加注释说明其用途和影响范围。
 
+## 6. Boss 血量公式参数说明（bossHpFormula）
+
+`CONFIG.balance.bossHpFormula` 控制 Boss 血量的混合计算公式。实际计算在 `src/spawn_system.js` 的 `spawn_calculateBossHP` 方法中执行。
+
+| 参数 | 类型 | 默认値 | 说明 |
+| :--- | :--- | :--- | :--- |
+| `templateWeight` | number | 0.5 | 模板血量权重（后期稳定値） |
+| `dynamicWeight` | number | 0.5 | 动态血量权重（后期稳定値） |
+| `floorMultiplier` | number | 0.7 | 保底倍率（后期稳定値） |
+| `earlyRound` | number | 5 | 前期保护完全生效的最大回合数（第一个 Boss 回合） |
+| `lateRound` | number | 20 | 过渡结束回合，完全切换为后期稳定权重 |
+| `earlyDynamicWeight` | number | 0.85 | 前期动态权重（高度依赖玩家实时伤害） |
+| `earlyFloorMultiplier` | number | 0.45 | 前期保底倍率（降低保底，避免卡死新手） |
+
+**前期保护机制原理**：
+- 在 `[earlyRound, lateRound]` 区间内，`dynamicWeight` 和 `floorMultiplier` 均进行线性插展。
+- `round <= earlyRound`：`dynamicWeight = earlyDynamicWeight`（前期小 Boss 血量高度跨随玩家实时战力）。
+- `round >= lateRound`：`dynamicWeight = dynamicWeight`（后期平衡权重）。
+- 模板权重 = `1 - dynamicWeight`，两者互补且总和始终为 1。
+- 前期低保底将保底下限从 70% 降至 45%，使血量更自由地跨随玩家战力浮动。
+
 ## 4. RELIC_DB 钉盘形态遗物规范（异型布局版）
 
 钉盘形态遗物通过修改 `Game` 实例上的 `boardLayout` 字段来切换钉盘布局模式。该字段在 `core.js` 中初始化，在 `game_system.js` 的 `sys_resetGame` 中重置。**所有钉盘形态遗物只能获取一次（maxStacks: 1）**。

--- a/src/config.js
+++ b/src/config.js
@@ -503,13 +503,22 @@ const CONFIG = {
 
         /** Boss 血量公式参数 */
         bossHpFormula: {
-            templateWeight: 0.5,         // 模板血量权重
-            dynamicWeight: 0.5,          // 动态血量权重
+            templateWeight: 0.5,         // 模板血量权重（后期稳定值）
+            dynamicWeight: 0.5,          // 动态血量权重（后期稳定值）
             miniBossKillRounds: 2.5,     // Mini-Boss 期望击杀回合数
             bigBossKillRounds: 4.0,      // 大 Boss 期望击杀回合数
-            floorMultiplier: 0.7,        // 保底：模板血量的 70%
+            floorMultiplier: 0.7,        // 保底：模板血量的 70%（后期稳定值）
             miniBossMult: 15,            // Mini-Boss 血量倍率
-            bigBossMult: 35              // 大 Boss 血量倍率
+            bigBossMult: 35,             // 大 Boss 血量倍率
+            // ── 前期保护参数（Early-Game Protection）──
+            // 越早期的 Boss，动态权重越高（更贴近玩家实时战力），模板权重越低
+            // 线性插值区间：[earlyRound, lateRound]
+            // round <= earlyRound 时：dynamicWeight = earlyDynamicWeight
+            // round >= lateRound  时：dynamicWeight = dynamicWeight（后期稳定值）
+            earlyRound: 5,               // 前期保护生效的最大回合数（第一个 Boss 所在回合）
+            lateRound: 20,               // 过渡结束回合（完全切换为后期稳定权重）
+            earlyDynamicWeight: 0.85,    // 前期动态权重（高度依赖玩家实时伤害）
+            earlyFloorMultiplier: 0.45   // 前期保底倍率（降低保底，避免卡死新手）
         },
 
         /** 8 个 Boss 专属配置 */

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -1259,8 +1259,16 @@ export const spawn_system = {
     /**
      * @method spawn_calculateBossHP
      * @description 计算 Boss 血量。
-     * 公式: BossHP = (templateHP * 0.5) + (peakDPS * expectedKillRounds * 0.5)
-     * 保底: Math.max(BossHP, templateHP * 0.7)
+     *
+     * 后期公式: BossHP = (templateHP * 0.5) + (peakDPS * expectedKillRounds * 0.5)
+     * 前期公式: BossHP = (templateHP * 0.15) + (currentDPS * expectedKillRounds * 0.85)
+     * 保底: Math.max(BossHP, templateHP * floorMultiplier)
+     *
+     * 前期保护机制（Early-Game Protection）:
+     * - 在 [earlyRound, lateRound] 区间内，动态权重和保底倍率均进行线性插展
+     * - 前期高动态权重：血量更贴近玩家实时战力，避免模板血量过高卡死新手
+     * - 前期低保底倍率：降低保底下限，使血量更自由地跡随玩家战力浮动
+     *
      * @param {boolean} isBigBoss - 是否为大 Boss
      * @returns {number} 最终 Boss 血量
      */
@@ -1275,16 +1283,38 @@ export const spawn_system = {
         const bossMult = isBigBoss ? f.bigBossMult : f.miniBossMult;
         const templateHP = (b.enemyBaseHp + r * b.enemyHpPerRound) * exponentialFactor * bossMult;
 
-        // 2. 获取玩家峰値战力
+        // 2. 获取玩家战力（前期优先使用实时弹药期望伤害，后期使用峰値历史均値）
         const peakDPS = this.calc_getPeakAverageDamage();
+        // 实时期望伤害：基于当前弹药队列的预期单发得分，前期样本少时更准确反映玩家实力
+        const currentDPS = this.combat_calculatePlayerExpectedDamage();
+        // 当 peakDPS 为 0（无历史记录）时，回落到 currentDPS
+        const effectiveDPS = peakDPS > 0 ? peakDPS : currentDPS;
 
         // 3. 计算动态血量
         const expectedTurns = isBigBoss ? f.bigBossKillRounds : f.miniBossKillRounds;
-        const dynamicHP = peakDPS * expectedTurns;
+        const dynamicHP = effectiveDPS * expectedTurns;
 
-        // 4. 混合计算 + 保底
-        const mixedHP = (templateHP * f.templateWeight) + (dynamicHP * f.dynamicWeight);
-        const finalHP = Math.max(templateHP * f.floorMultiplier, mixedHP);
+        // 4. 前期保护：根据回合数对动态权重和保底倍率进行线性插展
+        //    round <= earlyRound: 使用前期参数（高动态权重 + 低保底）
+        //    round >= lateRound:  使用后期参数（平衡权重 + 正常保底）
+        const earlyRound = f.earlyRound || 5;
+        const lateRound  = f.lateRound  || 20;
+        // t = 0 表示完全前期，t = 1 表示完全后期
+        const t = Math.max(0, Math.min(1, (r - earlyRound) / (lateRound - earlyRound)));
+
+        const earlyDynW  = f.earlyDynamicWeight  || 0.85;
+        const lateDynW   = f.dynamicWeight        || 0.5;
+        const earlyFloor = f.earlyFloorMultiplier || 0.45;
+        const lateFloor  = f.floorMultiplier       || 0.7;
+
+        // 线性插展得到当前回合的实际权重
+        const effectiveDynW   = earlyDynW  + (lateDynW  - earlyDynW)  * t;
+        const effectiveTplW   = 1 - effectiveDynW;  // 模板权重与动态权重互补，总和始终 = 1
+        const effectiveFloor  = earlyFloor + (lateFloor - earlyFloor)  * t;
+
+        // 5. 混合计算 + 保底
+        const mixedHP = (templateHP * effectiveTplW) + (dynamicHP * effectiveDynW);
+        const finalHP = Math.max(templateHP * effectiveFloor, mixedHP);
 
         return Math.floor(finalHP);
     },


### PR DESCRIPTION
## 问题背景

第一个 Boss（熔炉守卫·伊格尼斯，Round 5）出现时，玩家只打了 4 轮，历史伤害记录极少，`peakDPS`（历史最高 3 轮均值）样本不稳定，导致动态血量偏高，对新手玩家不友好。

## 核心设计思路

**越前期的 Boss，其血量与玩家当前实时伤害的关联越高。**

引入「前期保护机制（Early-Game Protection）」：在 `[earlyRound, lateRound]` 区间内，对动态权重和保底倍率进行线性插值过渡，使早期 Boss 血量高度贴近玩家实时战力，而非依赖不稳定的历史峰值。

## 变更文件

### `src/config.js` — 新增前期保护参数

```js
bossHpFormula: {
    // ... 原有参数 ...
    earlyRound: 5,               // 前期保护完全生效的最大回合数（第一个 Boss 所在回合）
    lateRound: 20,               // 过渡结束回合（完全切换为后期稳定权重）
    earlyDynamicWeight: 0.85,    // 前期动态权重（高度依赖玩家实时伤害）
    earlyFloorMultiplier: 0.45   // 前期保底倍率（降低保底，避免卡死新手）
}
```

### `src/spawn_system.js` — 重写 `spawn_calculateBossHP` 算法

| 回合 | 动态权重 | 模板权重 | 保底倍率 |
|------|---------|---------|---------|
| Round 5（第一个 Boss） | **0.85** | 0.15 | **0.45** |
| Round 12（过渡期） | ≈0.67 | ≈0.33 | ≈0.57 |
| Round 20+（后期） | 0.50 | 0.50 | 0.70 |

**关键改动：**
- 动态权重与模板权重互补（总和始终 = 1），避免血量膨胀
- 前期优先使用 `combat_calculatePlayerExpectedDamage`（实时弹药期望伤害），无历史记录时回落到 `currentDPS`
- 前期保底从 70% 降至 45%，使血量更自由地跟随玩家战力浮动

### `.cursor/rules/config.md` — 同步更新文档

新增第 6 节，说明 `bossHpFormula` 各参数含义及前期保护机制原理。