### PR TITLE
archive: 暂时注释符文发射器教程功能 (ui_showRuneLauncherTour)

### DIFF
--- a/.cursor/rules/ui_system.md
+++ b/.cursor/rules/ui_system.md
@@ -1,6 +1,6 @@
 # UI 系统规范文档
 
-> 最后更新：2026-04-16（符文发射器消失 bug 完整修复：_isRuneLauncherOpen 辅助函数 + 事件拦截强化）
+> 最后更新：2026-04-16（符文发射器教程功能暂时归档）
 
 ## 1. 模块架构概述
 
@@ -90,7 +90,8 @@ for (const subsystem of _subsystems) {
 | 2026-04-15 | `src/ui/shop.js` | 炼金工房（局外商店）所有商品描述显示为 `undefined`：`ui_renderShop` 中读取 `upgrade.description`，但 `META_SHOP_CONFIG.upgrades` 中的字段名为 `desc`，导致字段名不匹配。 | 将 `shop.js` 第 374 行的 `upgrade.description` 改为 `upgrade.desc`。 |
 | 2026-04-16 | `src/ui_system.js` + `src/game_system.js` | 符文发射器打开后立即消失：**真正根因是 canvas 输入穿透**——符文发射器面板层叠在 canvas 上方（z-index:300），但 canvas 的 `mousedown`/`touchstart` 监听器是直接绑定在 DOM 上的，不受 z-index 限制。玩家点击发射器面板时事件穿透到 canvas，导致 gathering 阶段弹珠被自动发射，所有弹珠打完后自动进入战斗阶段，`phase_switchPhase('combat')` 调用 `ui_updateUI()` 将发射器面板强制隐藏；同时 `.ui-overlay` 的 `transition: opacity 0.3s` 导致面板在 0.3s 内淡出消失而非立即关闭。 | 三处修复：① `game_system.js` 新增 `_isRuneLauncherOpen()` 辅助函数，兼容移动端（`style.display`）和 PC 模式（`dataset.pcMigrated`）两种判断方式；② `input_handleInputStart/Move/End` 开头统一改用 `_isRuneLauncherOpen()` 屏蔽 canvas 事件穿透；③ `ui_updateUI` 全局隐藏循环和 `phase_switchPhase` 的 DEBUG-LOG 也改用 `_isRuneLauncherOpen()`；④ `ui/rune_launcher.js` 的 `ui_openRuneLauncher` 在移动端模式下为面板添加 `touchmove` 的 `stopPropagation` 作为第二道防线，防止触摸滑动穿透到底层 Canvas。 |
 | 2026-04-16 | `index.html`, `src/game_system.js`, `src/ui_system.js`, `src/ui/rune_launcher.js` | PC 横屏模式下游戏区域宽度占满全屏且无侧边栏，底部抽屉和符文发射器不能同时展示。 | 1. `index.html` 新增 `#app-wrapper`（flex 三栏容器）、`#pc-left-sidebar`、`#pc-right-sidebar` 结构和对应 CSS；2. `#game-container` 改为固定宽高比 `min(calc(100dvh*9/16), 480px)` 宽度；3. `sys_resize()` 移除强制覆盖宽度的代码，`defeatLineY` 在 PC 模式下缩小安全边距；4. `ui_system.js` 新增 `ui_updatePCLayout()`、`_ui_migrateRuneLauncherToSidebar()`、`_ui_migrateHUDToLeftSidebar()` 三个方法；5. `rune_launcher.js` 的 `ui_openRuneLauncher`/`ui_closeRuneLauncher` 在 PC 模式下不修改 display；6. `core.js` 的 resize 监听器和构造函数中调用 `ui_updatePCLayout()`。 |
-| 2026-04-16 | `src/ui/rune_launcher.js` | 符文发射器内部引导教学（`ui_showRuneLauncherTour`）存在两个 Bug：① 教学期间 `highlight` 元素的 `box-shadow: 0 0 0 2000px rgba(0,0,0,0.45)` 溢出 `#phase-rune-launcher` panel 边界（panel 无 `overflow: hidden`），在整个屏幕上形成常驻黑色蒙版；② 教学完成时调用 `this.saveGame()`（该方法不存在），导致 `runeLauncherTourDone = true` 仅写入内存对象，从未持久化到 localStorage，每次游戏重启后教学都重复触发。 | ① 在 `ui_showRuneLauncherTour()` 中，创建 overlay 前保存 `panel.style.overflow` 原值，并临时设为 `hidden`；教学完成时恢复原值；`ui_closeRuneLauncher()` 中移除 tour overlay 时也同步恢复 overflow（防止用户未完成教学直接关闭面板）。② 将 `if (this.saveGame) this.saveGame()` 替换为 `this.sys_saveData()`，确保完成状态正确持久化。 |
+| 2026-04-16 | `src/ui/rune_launcher.js` | 符文发射器内部引导教学（`ui_showRuneLauncherTour`）存在两个 Bug：① 教学期间 `highlight` 元素的 `box-shadow: 0 0 0 2000px rgba(0,0,0,0.45)` 溢出 `#phase-rune-launcher` panel 边界（panel 无 `overflow: hidden`），在整个屏幕上形成常驻黑色蒙版；② 教学完成时调用 `this.saveGame()`（该方法不存在），导致 `runeLauncherTourDone = true` 仅写入内存对象，从未持久化到 localStorage，每次游戏重启后教学都重复触发。 | ① 在 `ui_showRuneLauncherTour()` 中，创建 overlay 前保存 `panel.style.overflow` 原値，并临时设为 `hidden`；教学完成时恢复原値；`ui_closeRuneLauncher()` 中移除 tour overlay 时也同步恢复 overflow（防止用户未完成教学直接关闭面板）。② 将 `if (this.saveGame) this.saveGame()` 替换为 `this.sys_saveData()`，确保完成状态正确持久化。 |
+| 2026-04-16 | `src/ui/rune_launcher.js` | 符文发射器内部引导教学（`ui_showRuneLauncherTour`）暂时归档。 | 将 `ui_openRuneLauncher` 中的教程触发调用和 `ui_showRuneLauncherTour` 函数体全部注释（`[ARCHIVED]` 标记）。如需恢复，取消 `rune_launcher.js` 第 114-117 行和第 1444-1604 行的注释即可。 |
 
 ## 6. 修改规范
 

--- a/src/ui/rune_launcher.js
+++ b/src/ui/rune_launcher.js
@@ -111,9 +111,10 @@ export const rune_launcher_system = {
         // 关闭气泡提示（玩家已进入发射器）
         this._ui_hideRunewordBubble();
         // 首次打开时显示内部引导教学（移动端不影响 PC 端常驻）
-        if (!isPCMode && this.saveData && !this.saveData.runeLauncherTourDone) {
-            setTimeout(() => this.ui_showRuneLauncherTour(), 400);
-        }
+        // [ARCHIVED] 教程功能暂时禁用，如需恢复请取消下方注释
+        // if (!isPCMode && this.saveData && !this.saveData.runeLauncherTourDone) {
+        //     setTimeout(() => this.ui_showRuneLauncherTour(), 400);
+        // }
     },
 
 
@@ -1433,173 +1434,174 @@ export const rune_launcher_system = {
     },
 
 
-    // ==================== 引导式教学 ====================
+    // ==================== 引导式教学（暂时归档，如需恢复请取消注释） ====================
 
-    /**
+    /*
+     * [ARCHIVED] ui_showRuneLauncherTour
      * 展示符文发射器内部引导教学
      * 首次打开发射器时自动调用，也可通过帮助按鈕手动触发
      */
-    ui_showRuneLauncherTour() {
+    // ui_showRuneLauncherTour() {
         // 如果发射器面板不在显示状态则不展示
-        const panel = document.getElementById('phase-rune-launcher');
-        if (!panel || panel.style.display === 'none') return;
+        // const panel = document.getElementById('phase-rune-launcher');
+        // if (!panel || panel.style.display === 'none') return;
 
-        // 移除旧教学层
-        const existingTour = document.getElementById('rune-launcher-tour-overlay');
-        if (existingTour) existingTour.remove();
+//         // 移除旧教学层
+        // const existingTour = document.getElementById('rune-launcher-tour-overlay');
+        // if (existingTour) existingTour.remove();
 
-        const tourSteps = [
-            {
-                targetId: 'rune-grid-container',
-                title: '① 符文网格',
-                desc: '将库存中的符文拖入这里。特定符文组合可触发强力「词条」！',
-                position: 'bottom',
-            },
-            {
-                targetId: 'rune-inventory-container',
-                title: '② 符文库存',
-                desc: '你拥有的所有符文在这里。点击符文可选中，选中 3 个可进行合成或重铸。',
-                position: 'top',
-            },
-            {
-                targetId: 'rune-merge-btn',
-                title: '③ 合成炉',
-                desc: '选中 3 个相同 ID 且相同等级的符文，合成为更高等级的同类符文。',
-                position: 'top',
-            },
-            {
-                targetId: 'rune-reforge-btn',
-                title: '④ 重铸炉',
-                desc: '选中任意 3 个符文消耗，随机获得一个全新符文。当库存符文不理想时可用。',
-                position: 'top',
-            },
-            {
-                targetId: 'rune-active-runewords',
-                title: '⑤ 已激活词条',
-                desc: '当网格中符文组合匹配词条时，词条将在这里展示并生效。',
-                position: 'top',
-            },
-        ];
+//         // const tourSteps = [
+            // {
+                // targetId: 'rune-grid-container',
+                // title: '① 符文网格',
+                // desc: '将库存中的符文拖入这里。特定符文组合可触发强力「词条」！',
+                // position: 'bottom',
+            // },
+            // {
+                // targetId: 'rune-inventory-container',
+                // title: '② 符文库存',
+                // desc: '你拥有的所有符文在这里。点击符文可选中，选中 3 个可进行合成或重铸。',
+                // position: 'top',
+            // },
+            // {
+                // targetId: 'rune-merge-btn',
+                // title: '③ 合成炉',
+                // desc: '选中 3 个相同 ID 且相同等级的符文，合成为更高等级的同类符文。',
+                // position: 'top',
+            // },
+            // {
+                // targetId: 'rune-reforge-btn',
+                // title: '④ 重铸炉',
+                // desc: '选中任意 3 个符文消耗，随机获得一个全新符文。当库存符文不理想时可用。',
+                // position: 'top',
+            // },
+            // {
+                // targetId: 'rune-active-runewords',
+                // title: '⑤ 已激活词条',
+                // desc: '当网格中符文组合匹配词条时，词条将在这里展示并生效。',
+                // position: 'top',
+            // },
+        // ];
 
-        // 创建教学层容器（不阔读背景，只展示高亮提示）
-        const overlay = document.createElement('div');
-        overlay.id = 'rune-launcher-tour-overlay';
-        overlay.style.cssText = [
-            'position: absolute;',
-            'inset: 0;',
-            'z-index: 500;',
-            'pointer-events: none;',
-        ].join(' ');
-        panel.style.position = 'relative';
+//         // 创建教学层容器（不阔读背景，只展示高亮提示）
+        // const overlay = document.createElement('div');
+        // overlay.id = 'rune-launcher-tour-overlay';
+        // overlay.style.cssText = [
+            // 'position: absolute;',
+            // 'inset: 0;',
+            // 'z-index: 500;',
+            // 'pointer-events: none;',
+        // ].join(' ');
+        // panel.style.position = 'relative';
         // [BUGFIX] 防止 highlight 的超大 box-shadow (2000px) 溢出 panel 边界，在屏幕外形成常驻黑色蒙版
-        const _prevOverflow = panel.style.overflow;
-        panel.style.overflow = 'hidden';
-        panel.appendChild(overlay);
+        // const _prevOverflow = panel.style.overflow;
+        // panel.style.overflow = 'hidden';
+        // panel.appendChild(overlay);
 
-        let currentStep = 0;
+//         // let currentStep = 0;
 
-        const showStep = (stepIdx) => {
+//         // const showStep = (stepIdx) => {
             // 清除当前提示卡
-            overlay.innerHTML = '';
+            // overlay.innerHTML = '';
 
-            if (stepIdx >= tourSteps.length) {
+//             // if (stepIdx >= tourSteps.length) {
                 // 教学完成
-                overlay.remove();
+                // overlay.remove();
                 // [BUGFIX] 恢复 panel 的 overflow 属性（教学期间临时设为 hidden 防止 box-shadow 溢出）
-                panel.style.overflow = _prevOverflow;
-                if (this.saveData) this.saveData.runeLauncherTourDone = true;
-                this.sys_saveData(); // [BUGFIX] 原为 this.saveGame()，该方法不存在，导致存档从未持久化，教学每次都重复触发
-                return;
-            }
+                // panel.style.overflow = _prevOverflow;
+                // if (this.saveData) this.saveData.runeLauncherTourDone = true;
+                // this.sys_saveData(); // [BUGFIX] 原为 this.saveGame()，该方法不存在，导致存档从未持久化，教学每次都重复触发
+                // return;
+            // }
 
-            const step = tourSteps[stepIdx];
-            const targetEl = document.getElementById(step.targetId);
-            if (!targetEl) {
+//             // const step = tourSteps[stepIdx];
+            // const targetEl = document.getElementById(step.targetId);
+            // if (!targetEl) {
                 // 目标元素不存在，跳过
-                showStep(stepIdx + 1);
-                return;
-            }
+                // showStep(stepIdx + 1);
+                // return;
+            // }
 
-            // 计算目标元素相对于 panel 的位置
-            const panelRect = panel.getBoundingClientRect();
-            const targetRect = targetEl.getBoundingClientRect();
-            const relTop = targetRect.top - panelRect.top;
-            const relLeft = targetRect.left - panelRect.left;
+//             // 计算目标元素相对于 panel 的位置
+            // const panelRect = panel.getBoundingClientRect();
+            // const targetRect = targetEl.getBoundingClientRect();
+            // const relTop = targetRect.top - panelRect.top;
+            // const relLeft = targetRect.left - panelRect.left;
 
-            // 创建高亮边框
-            const highlight = document.createElement('div');
-            highlight.style.cssText = [
-                'position: absolute;',
-                `top: ${relTop - 4}px;`,
-                `left: ${relLeft - 4}px;`,
-                `width: ${targetRect.width + 8}px;`,
-                `height: ${targetRect.height + 8}px;`,
-                'border: 2px solid rgba(245,158,11,0.8);',
-                'border-radius: 12px;',
-                'box-shadow: 0 0 0 2000px rgba(0,0,0,0.45);',
-                'pointer-events: none;',
-                'animation: tour-highlight-pulse 1.5s ease-in-out infinite;',
-            ].join(' ');
-            overlay.appendChild(highlight);
+//             // 创建高亮边框
+            // const highlight = document.createElement('div');
+            // highlight.style.cssText = [
+                // 'position: absolute;',
+                // `top: ${relTop - 4}px;`,
+                // `left: ${relLeft - 4}px;`,
+                // `width: ${targetRect.width + 8}px;`,
+                // `height: ${targetRect.height + 8}px;`,
+                // 'border: 2px solid rgba(245,158,11,0.8);',
+                // 'border-radius: 12px;',
+                // 'box-shadow: 0 0 0 2000px rgba(0,0,0,0.45);',
+                // 'pointer-events: none;',
+                // 'animation: tour-highlight-pulse 1.5s ease-in-out infinite;',
+            // ].join(' ');
+            // overlay.appendChild(highlight);
 
-            // 创建提示卡
-            const card = document.createElement('div');
-            card.style.cssText = [
-                'position: absolute;',
-                'pointer-events: auto;',
-                'background: linear-gradient(135deg, rgba(15,23,42,0.97), rgba(30,27,75,0.97));',
-                'border: 1px solid rgba(245,158,11,0.5);',
-                'border-radius: 14px;',
-                'padding: 12px 14px;',
-                'width: 220px;',
-                'box-shadow: 0 4px 20px rgba(0,0,0,0.6), 0 0 12px rgba(245,158,11,0.2);',
-                'z-index: 10;',
-            ].join(' ');
+//             // 创建提示卡
+            // const card = document.createElement('div');
+            // card.style.cssText = [
+                // 'position: absolute;',
+                // 'pointer-events: auto;',
+                // 'background: linear-gradient(135deg, rgba(15,23,42,0.97), rgba(30,27,75,0.97));',
+                // 'border: 1px solid rgba(245,158,11,0.5);',
+                // 'border-radius: 14px;',
+                // 'padding: 12px 14px;',
+                // 'width: 220px;',
+                // 'box-shadow: 0 4px 20px rgba(0,0,0,0.6), 0 0 12px rgba(245,158,11,0.2);',
+                // 'z-index: 10;',
+            // ].join(' ');
 
-            // 卡片定位
-            const cardTop = step.position === 'bottom'
-                ? relTop + targetRect.height + 12
-                : relTop - 120;
-            const cardLeft = Math.max(4, Math.min(relLeft, panelRect.width - 230));
-            card.style.top = `${cardTop}px`;
-            card.style.left = `${cardLeft}px`;
+//             // 卡片定位
+            // const cardTop = step.position === 'bottom'
+                // ? relTop + targetRect.height + 12
+                // : relTop - 120;
+            // const cardLeft = Math.max(4, Math.min(relLeft, panelRect.width - 230));
+            // card.style.top = `${cardTop}px`;
+            // card.style.left = `${cardLeft}px`;
 
-            card.innerHTML = `
-                <div class="text-xs font-bold text-amber-300 mb-1">${step.title}</div>
-                <div class="text-[11px] text-slate-300 leading-relaxed mb-3">${step.desc}</div>
-                <div class="flex items-center justify-between">
-                    <span class="text-[10px] text-slate-500">${stepIdx + 1} / ${tourSteps.length}</span>
-                    <div class="flex gap-2">
-                        ${stepIdx > 0 ? `<button id="tour-skip-btn" style="font-size:10px;color:#94a3b8;background:none;border:none;cursor:pointer;">跳过</button>` : ''}
-                        <button id="tour-next-btn" style="font-size:11px;font-weight:bold;color:#fef3c7;background:rgba(120,53,15,0.8);border:1px solid rgba(245,158,11,0.5);border-radius:8px;padding:4px 10px;cursor:pointer;">${stepIdx < tourSteps.length - 1 ? '下一步 →' : '知道了 ✓'}</button>
-                    </div>
-                </div>
-            `;
-            overlay.appendChild(card);
+//             // card.innerHTML = `
+                // <div class="text-xs font-bold text-amber-300 mb-1">${step.title}</div>
+                // <div class="text-[11px] text-slate-300 leading-relaxed mb-3">${step.desc}</div>
+                // <div class="flex items-center justify-between">
+                    // <span class="text-[10px] text-slate-500">${stepIdx + 1} / ${tourSteps.length}</span>
+                    // <div class="flex gap-2">
+                        // ${stepIdx > 0 ? `<button id="tour-skip-btn" style="font-size:10px;color:#94a3b8;background:none;border:none;cursor:pointer;">跳过</button>` : ''}
+                        // <button id="tour-next-btn" style="font-size:11px;font-weight:bold;color:#fef3c7;background:rgba(120,53,15,0.8);border:1px solid rgba(245,158,11,0.5);border-radius:8px;padding:4px 10px;cursor:pointer;">${stepIdx < tourSteps.length - 1 ? '下一步 →' : '知道了 ✓'}</button>
+                    // </div>
+                // </div>
+            // `;
+            // overlay.appendChild(card);
 
-            // 事件绑定
-            const nextBtn = document.getElementById('tour-next-btn');
-            if (nextBtn) nextBtn.addEventListener('click', () => showStep(stepIdx + 1));
+//             // 事件绑定
+            // const nextBtn = document.getElementById('tour-next-btn');
+            // if (nextBtn) nextBtn.addEventListener('click', () => showStep(stepIdx + 1));
 
-            const skipBtn = document.getElementById('tour-skip-btn');
-            if (skipBtn) skipBtn.addEventListener('click', () => showStep(tourSteps.length));
-        };
+//             // const skipBtn = document.getElementById('tour-skip-btn');
+            // if (skipBtn) skipBtn.addEventListener('click', () => showStep(tourSteps.length));
+        // };
 
-        // 注入动画 CSS
-        if (!document.getElementById('rune-tour-style')) {
-            const style = document.createElement('style');
-            style.id = 'rune-tour-style';
-            style.textContent = `
-                @keyframes tour-highlight-pulse {
-                    0%, 100% { box-shadow: 0 0 0 2000px rgba(0,0,0,0.45), 0 0 8px rgba(245,158,11,0.4); }
-                    50%       { box-shadow: 0 0 0 2000px rgba(0,0,0,0.55), 0 0 16px rgba(245,158,11,0.8); }
-                }
-            `;
-            document.head.appendChild(style);
-        }
+//         // 注入动画 CSS
+        // if (!document.getElementById('rune-tour-style')) {
+            // const style = document.createElement('style');
+            // style.id = 'rune-tour-style';
+            // style.textContent = `
+                // @keyframes tour-highlight-pulse {
+                    // 0%, 100% { box-shadow: 0 0 0 2000px rgba(0,0,0,0.45), 0 0 8px rgba(245,158,11,0.4); }
+                    // 50%       { box-shadow: 0 0 0 2000px rgba(0,0,0,0.55), 0 0 16px rgba(245,158,11,0.8); }
+                // }
+            // `;
+            // document.head.appendChild(style);
+        // }
 
-        showStep(0);
-    },
+//         // showStep(0);
+    // },
 
 
 };


### PR DESCRIPTION
## 变更说明

暂时将符文发射器的内部引导教学（`ui_showRuneLauncherTour`）注释归档，不影响其他功能正常运行。

## 修改范围

| 文件 | 修改内容 |
|---|---|
| `src/ui/rune_launcher.js` | 注释 `ui_openRuneLauncher` 中的教程触发调用（第 114-117 行） |
| `src/ui/rune_launcher.js` | 注释 `ui_showRuneLauncherTour` 完整函数体（第 1444-1604 行），以 `[ARCHIVED]` 标记保留 |
| `.cursor/rules/ui_system.md` | 同步更新修改记录，说明归档原因及恢复方式 |

## 恢复方式

如需重新启用教程功能，取消 `rune_launcher.js` 以下两处注释即可：
- 第 114-117 行（触发调用）
- 第 1444-1604 行（函数体）