### PR TITLE
fix(ui): 8 项游戏 UI/UX 修复（精华按钮/HP 方向/PC 布局/设置面板/拖尾/动画）

### DIFF
--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -1353,8 +1353,22 @@ class Enemy {
         } else {
             ctx.roundRect(-w/2, -h/2, w, h, r);
         }
-        ctx.fillStyle = '#0f172a'; 
-        ctx.fill(); 
+        ctx.fillStyle = '#0f172a';
+        ctx.fill();
+        // [增强对比 #4] 在裁剪之前先给容器外缘绘制一圈柔光描边，
+        // 让敌人在与背景同色的「液态」战场上仍能识别轮廓（精英/Boss 尤其关键）。
+        // 由于 ctx.clip() 之后描边会被裁剪一半，这里预先绘制可保留完整外缘。
+        ctx.save();
+        ctx.shadowColor = (this.type === 'boss') ? 'rgba(239, 68, 68, 0.85)'
+                         : (this.type === 'elite') ? 'rgba(168, 85, 247, 0.75)'
+                         : 'rgba(148, 163, 184, 0.55)';
+        ctx.shadowBlur = (this.type === 'boss') ? 18 : (this.type === 'elite') ? 14 : 8;
+        ctx.strokeStyle = (this.type === 'boss') ? 'rgba(239, 68, 68, 0.9)'
+                         : (this.type === 'elite') ? 'rgba(196, 152, 255, 0.85)'
+                         : 'rgba(203, 213, 225, 0.7)';
+        ctx.lineWidth = (this.type === 'boss') ? 3 : 2;
+        ctx.stroke();
+        ctx.restore();
         ctx.clip();
 
          // === Layer 1.5: 底层纹理 (预计算 OffscreenCanvas) ===
@@ -1362,29 +1376,36 @@ class Enemy {
             ctx.drawImage(this._textureCanvas, -w/2, -h/2);
         }
         // === Layer 2: 液体血条 (含延迟白条) ===
-        // [修改] 血量从顶部向下填充，血量满时占满顶部，血量少时从顶部缩短
-        // 顶部留少量间距（_hpTopPad），血条高度 = h * ratio
-        
+        // [修改] 血量从上往下扣除：满血时占满整个容器，血量减少时从顶部开始消失，
+        // 残余血量沉在底部，类似液面下降的视觉。
+
         // A. 计算高度比例
         const hpRatio = Math.max(0, Math.min(1, this.displayHp / this.maxHp));
         const whiteRatio = Math.max(0, Math.min(1, this.delayedHp / this.maxHp)); // 白色条比例
         const greenRatio = Math.max(0, Math.min(1, this.greenHp / this.maxHp));   // 绿色条比例
-        
-        const _hpTopPad = 4; // 血条距顶部的间距（px）
-        const _hpBarTop = -h/2 + _hpTopPad; // 血条起始 Y（顶部）
-        
+
+        const _hpBarBottom = h/2; // 血条底部 Y（贴住容器底部）
+
         const fillHeight = h * hpRatio;
         const whiteHeight = h * whiteRatio; // 白色条高度
         const greenHeight = h * greenRatio; // 绿色条高度
-        
-        // 从顶部向下：fillY 固定在顶部，高度随血量变化
-        const fillY = _hpBarTop;
-        const whiteY = _hpBarTop; // 白色条从顶部开始
-        const greenY = _hpBarTop; // 绿色条从顶部开始
-        
+
+        // 锚定底部：fillY = bottom - height，血量减少时顶部下沉
+        const fillY = _hpBarBottom - fillHeight;
+        const whiteY = _hpBarBottom - whiteHeight;
+        const greenY = _hpBarBottom - greenHeight;
+
+        // [增强对比] 先在容器内填一层稍亮的「空槽底色」，避免扣血后的空白和外部背景同色，
+        // 让玩家清晰看到敌人的轮廓与剩余血量边界（精英/Boss 同样适用）。
+        let emptySlotColor = 'rgba(15, 23, 42, 0.65)'; // 普通敌人：偏深的板岩蓝
+        if (this.type === 'elite') emptySlotColor = 'rgba(45, 27, 78, 0.7)';   // 精英：暗紫
+        if (this.type === 'boss') emptySlotColor = 'rgba(60, 12, 20, 0.75)';   // Boss：暗血红
+        ctx.fillStyle = emptySlotColor;
+        ctx.fillRect(-w/2, -h/2, w, h);
+
         // B. 绘制白色延迟条 (在彩色条底下)
         if (whiteRatio > hpRatio) {
-            ctx.fillStyle = '#ffffff'; 
+            ctx.fillStyle = '#ffffff';
             ctx.globalAlpha = 0.8;
             ctx.fillRect(-w/2, whiteY, w, whiteHeight);
             ctx.globalAlpha = 1.0;
@@ -1399,26 +1420,27 @@ class Enemy {
         }
 
         // C. 绘制真实彩色条 (盖在白条上面)
-        let baseColor = '#475569'; 
-        if (this.type === 'elite') baseColor = '#581c87'; 
-        if (this.type === 'boss') baseColor = '#7f1d1d';  
-        
+        // [增强对比] 加深基础血色，并与外部背景拉开差异。
+        let baseColor = '#64748b';                  // 普通：石板蓝（更亮）
+        if (this.type === 'elite') baseColor = '#7c3aed'; // 精英：饱和紫
+        if (this.type === 'boss') baseColor = '#dc2626';  // Boss：饱和血红
+
         // 温度变色逻辑
         if (this.temp > 0) {
             const t = Math.min(1, this.temp / 34);
-            baseColor = lerpColor(baseColor, '#ea580c', t); 
+            baseColor = lerpColor(baseColor, '#ea580c', t);
         } else if (this.temp < 0) {
             const t = Math.min(1, Math.abs(this.temp) / 34);
             baseColor = lerpColor(baseColor, '#0891b2', t);
         }
 
-        ctx.fillStyle = baseColor; 
+        ctx.fillStyle = baseColor;
         ctx.fillRect(-w/2, fillY, w, fillHeight);
-        
-        // D. 液面亮边（血条底部边缘）
+
+        // D. 液面顶部亮边（血量减少时呈现「液面下降」的高光）
         if (hpRatio > 0 && hpRatio < 1) {
-            ctx.fillStyle = 'rgba(255, 255, 255, 0.3)'; 
-            ctx.fillRect(-w/2, fillY + fillHeight - 2, w, 2);
+            ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
+            ctx.fillRect(-w/2, fillY, w, 2);
         }
 
         // === Layer 3: 内部覆盖层 (Glow & Mist) - [修改：降低浓度] ===

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -73,8 +73,20 @@ class Projectile {
         this.windBladeAngle = 0; // 风属性环绕风刃的旋转角度
         this.lifeTime = 60 * 30; // [修改] 加倍子弹生命时间 (从15秒增加到30秒)
         this.chainHistory = [];
-        this.trail = [];      
-        this.deformation = { x: 1, y: 1 }; 
+        this.trail = [];
+        // [拖尾增强 #6] 根据子弹强度（属性层数）和类型决定拖尾长度，提高高强度子弹的视觉显著度。
+        const _tierStat = (config.damage || 0) + (config.bounce || 0) + (config.pierce || 0)
+            + (config.scatter || 0) + (config.cryo || 0) + (config.pyro || 0)
+            + (config.lightning || 0) + (config.laser || 0)
+            + (config.flying_sword || 0) + (config.wind || 0);
+        let _trailMax = 6 + Math.min(28, Math.floor(_tierStat * 0.6));
+        if (config.isLaser) _trailMax += 8;
+        if (config.type === 'flying_sword') _trailMax += 6;
+        if (config.pierce > 0) _trailMax += 4;
+        if (config.explosive) _trailMax += 2;
+        this.maxTrailLength = _trailMax;
+        this.tierStat = _tierStat;
+        this.deformation = { x: 1, y: 1 };
         this.targetDeformation = { x: 1, y: 1 }; 
         this.elasticity = 0.2;
         this.crackSeed = [];
@@ -122,7 +134,7 @@ class Projectile {
         this.deformation.x += (this.targetDeformation.x - this.deformation.x) * this.elasticity * timeScale;
         this.deformation.y += (this.targetDeformation.y - this.deformation.y) * this.elasticity * timeScale;
         this.trail.push({x: this.pos.x, y: this.pos.y});
-        if (this.trail.length > 8) this.trail.shift();
+        if (this.trail.length > (this.maxTrailLength || 8)) this.trail.shift();
         for (const [enemy, timer] of this.hitCooldowns) {
             if (timer > 0) this.hitCooldowns.set(enemy, timer - timeScale);
             else this.hitCooldowns.delete(enemy);
@@ -687,7 +699,78 @@ class Projectile {
     draw(ctx) {
         if (!this.active && !this.destroyed) return;
         const integrity = (this.bouncesLeft + this.piercesLeft) / (this.maxDurability || 1);
+        // [拖尾 #6] 在主体之前先绘制拖尾，主体覆盖在最前
+        this._drawTrail(ctx);
         Projectile.drawVisuals(ctx, this.pos.x, this.pos.y, this.radius, this.config, this.rotation, this.intensity, this.deformation, integrity, this.crackSeed, this.windBladeAngle);
+    }
+
+    // @perf-impact: 子弹拖尾 - 每子弹每帧 1 条 lineTo + 渐变描边；高强度子弹 trail 长度可达 ~30 个点。
+    _drawTrail(ctx) {
+        const trail = this.trail;
+        if (!trail || trail.length < 2) return;
+        const cfg = this.config || {};
+        // 根据属性决定主拖尾色
+        let trailColor = '#94a3b8';
+        if (cfg.isLaser) trailColor = '#7dd3fc';
+        else if (cfg.type === 'flying_sword') trailColor = '#0ea5e9';
+        else if (cfg.type === 'rainbow') trailColor = '#e9d5ff';
+        else if (cfg.explosive) trailColor = '#ef4444';
+        else if ((cfg.pyro || 0) > 0) trailColor = '#f97316';
+        else if ((cfg.cryo || 0) > 0) trailColor = '#22d3ee';
+        else if ((cfg.lightning || 0) > 0) trailColor = '#c084fc';
+        else if ((cfg.wind || 0) > 0) trailColor = '#34d399';
+        else if ((cfg.pierce || 0) > 0) trailColor = '#fca5a5';
+        else if ((cfg.bounce || 0) > 0) trailColor = '#86efac';
+        else if ((cfg.scatter || 0) > 0) trailColor = '#facc15';
+
+        const tier = Math.min(3, Math.floor((this.tierStat || 0) / 8));
+        // 基础宽度随子弹半径与强度联动；S 级（tier 3）显著加宽
+        const baseWidth = Math.max(1.5, this.radius * (0.55 + tier * 0.18));
+        const len = trail.length;
+
+        ctx.save();
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        // S 级（含激光/飞剑）使用 lighter 增亮拖尾
+        if (tier >= 2 || cfg.isLaser || cfg.type === 'flying_sword' || cfg.explosive) {
+            ctx.globalCompositeOperation = 'lighter';
+        }
+        ctx.shadowColor = trailColor;
+        ctx.shadowBlur = 4 + tier * 4;
+
+        // 段落式渐变描边：越靠近当前位置越亮、越粗
+        for (let i = 1; i < len; i++) {
+            const a = trail[i - 1];
+            const b = trail[i];
+            const t = i / (len - 1);
+            const alpha = Math.max(0.04, t * (0.55 + tier * 0.12));
+            const width = Math.max(0.6, baseWidth * t);
+            ctx.strokeStyle = `${trailColor}`;
+            ctx.globalAlpha = alpha;
+            ctx.lineWidth = width;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+        }
+
+        // S 级追加一层更细更亮的核心拖尾
+        if (tier >= 3 || cfg.isLaser) {
+            ctx.shadowBlur = 12;
+            for (let i = Math.max(1, len - 8); i < len; i++) {
+                const a = trail[i - 1];
+                const b = trail[i];
+                const t = i / (len - 1);
+                ctx.strokeStyle = '#ffffff';
+                ctx.globalAlpha = 0.6 * t;
+                ctx.lineWidth = Math.max(0.8, baseWidth * 0.45 * t);
+                ctx.beginPath();
+                ctx.moveTo(a.x, a.y);
+                ctx.lineTo(b.x, b.y);
+                ctx.stroke();
+            }
+        }
+        ctx.restore();
     }
 
     static drawVisuals(ctx, x, y, radius, config, rotation, intensity, deformation = {x:1, y:1}, integrity = 1.0, crackSeed = [], windBladeAngle = 0) {

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -575,21 +575,38 @@ export const game_system = {
                 sourceRewardType: pendingMode?.sourceRewardType || this.selectionMode,
             };
         this.pendingSelectionMode = null;
-        this.phase_switchPhase('selection');
+        // [BUGFIX #7] 在 phase_switchPhase 触发 ui_updateUI 前预先清空 marble grid，
+        // 否则 ui_refreshSelectionModeUI 会用新的 selectionMode 文案搭配上一轮残留的卡片
+        // DOM，造成「先闪一帧另一种精华内容」的体验问题。
+        const _initGridEl = document.getElementById('marble-selection-grid');
+        if (_initGridEl) {
+            _initGridEl.style.cssText = '';
+            _initGridEl.innerHTML = '';
+        }
+        // 同步清掉旧的 marblesPool / 已选索引，防止 ui_refreshSelectionModeUI 读取到过期数据
+        this.marblesPool = [];
+        this.selectedMarbles = [];
         this.selectionInjectedRune = null;
         this.selectionPreviewState = null;
-        // [BUGFIX] 防御性重置 gridEl inline style：
-        // 如果上一轮经过了 ui_renderReplaceAmmoUI（子弹替换阶段）且清理逻辑未运行，
-        // gridEl 上可能残留 display:flex 的 inline style，导致卡片竖排。在此强制清空。
-        const _initGridEl = document.getElementById('marble-selection-grid');
-        if (_initGridEl) _initGridEl.style.cssText = '';
+
+        this.phase_switchPhase('selection');
         this.spawn_generateMarbleOptions();
         this.selectedMarbles = [];
         const countEl = document.getElementById('selected-count');
         const confirmBtn = document.getElementById('confirm-selection-btn');
         const recipeHud = document.getElementById('recipe-hud-container');
         if (countEl) countEl.innerText = '0';
-        if (confirmBtn) confirmBtn.disabled = true;
+        if (confirmBtn) {
+            confirmBtn.disabled = true;
+            // [BUGFIX] 上一轮 sys_initReplaceAmmoPhase / ui_renderReplaceAmmoUI 把 confirmBtn.onclick
+            // 覆盖为 sys_confirmReplaceAmmo。如果不在新一轮命运时刻强制恢复，
+            // 第二/三次触发精华或潮涌类遗物触发的混沌精华时，
+            // 玩家点击「接受命运开始炼金」会触发 sys_confirmReplaceAmmo（输出
+            // "[sys_confirmReplaceAmmo] replaceAmmoContext 未激活"）而无任何反应。
+            confirmBtn.onclick = () => {
+                if (typeof this.ui_confirmSelection === 'function') this.ui_confirmSelection();
+            };
+        }
         if (recipeHud) recipeHud.classList.add('hidden');
         if (typeof this.ui_refreshSelectionModeUI === 'function') this.ui_refreshSelectionModeUI();
         if (typeof this.sys_saveRunState === 'function') this.sys_saveRunState();

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -51,51 +51,153 @@ export const ui_system = {
 
     /**
      * @method ui_playLootToCardAnimation
-     * @description 播放掉落物飞向 UI 卡片的 3D 动画
+     * @description 播放掉落物开启 → 飞出「卡片」的 3D 动画。
+     * [BUGFIX #8] 旧版本只是把图标整体放大并翻转，没有「卡片从掉落物中飞出」的实感。
+     * 新版本分两段：
+     *   1) 掉落物原地脉冲一下并迸发出 8 道光束（开启感）
+     *   2) 一张带边框/标题/图标的「卡片」从掉落物位置弹出，缩小 → 沿弧线飞向屏幕中央
+     *      并放大成最终展示卡片，再淡出移交给后续选择 UI。
      */
     ui_playLootToCardAnimation(startX, startY, type, callback) {
         const container = document.getElementById('game-container');
         if (!container) return callback && callback();
 
-        const node = document.createElement('div');
-        node.className = 'loot-fly-proxy';
-        
         let icon = '🏆';
-        let glow = 'rgba(250, 204, 21, 0.8)';
-        if (type === 'chaos_essence') { icon = '🔮'; glow = 'rgba(168, 85, 247, 0.8)'; }
-        else if (type === 'pure_essence') { icon = '💎'; glow = 'rgba(56, 189, 248, 0.8)'; }
+        let glow = 'rgba(250, 204, 21, 0.85)';
+        let cardBg = 'linear-gradient(160deg,#78350f 0%,#3b1f05 60%,#150b01 100%)';
+        let cardBorder = '#fbbf24';
+        let title = '遺物';
+        if (type === 'chaos_essence') {
+            icon = '🔮'; glow = 'rgba(168, 85, 247, 0.85)';
+            cardBg = 'linear-gradient(160deg,#4a1d96 0%,#2e1065 60%,#0f0528 100%)';
+            cardBorder = '#c084fc';
+            title = '混沌精華';
+        } else if (type === 'pure_essence') {
+            icon = '💎'; glow = 'rgba(56, 189, 248, 0.85)';
+            cardBg = 'linear-gradient(160deg,#0c4a6e 0%,#082f49 60%,#020f1a 100%)';
+            cardBorder = '#38bdf8';
+            title = '純淨精華';
+        }
 
-        node.innerHTML = icon;
-        node.style.cssText = `
+        // ---- A. 掉落物开启脉冲 + 光束迸发（保留原图标位置感） ----
+        const burst = document.createElement('div');
+        burst.style.cssText = `
             position: absolute;
             left: ${startX}px;
             top: ${startY}px;
-            font-size: 32px;
+            width: 8px; height: 8px;
+            transform: translate(-50%, -50%);
+            border-radius: 50%;
+            box-shadow: 0 0 0 0 ${glow};
+            z-index: 1990;
+            pointer-events: none;
+            transition: box-shadow 0.35s ease-out, opacity 0.35s ease-out;
+            opacity: 1;
+        `;
+        container.appendChild(burst);
+
+        const ray = document.createElement('div');
+        ray.style.cssText = `
+            position: absolute;
+            left: ${startX}px;
+            top: ${startY}px;
+            width: 4px; height: 4px;
+            transform: translate(-50%, -50%);
+            z-index: 1991;
+            pointer-events: none;
+        `;
+        for (let i = 0; i < 8; i++) {
+            const beam = document.createElement('div');
+            const angle = (i / 8) * 360;
+            beam.style.cssText = `
+                position: absolute;
+                left: 0; top: 0;
+                width: 2px; height: 60px;
+                background: linear-gradient(to top, transparent, ${glow});
+                transform-origin: 1px 0;
+                transform: rotate(${angle}deg) translateY(0);
+                opacity: 0;
+                transition: transform 0.45s ease-out, opacity 0.45s ease-out;
+            `;
+            ray.appendChild(beam);
+        }
+        container.appendChild(ray);
+
+        // ---- B. 创建「飞出的卡片」节点 ----
+        const card = document.createElement('div');
+        card.className = 'loot-fly-card';
+        card.innerHTML = `
+            <div class="loot-fly-card-icon">${icon}</div>
+            <div class="loot-fly-card-title">${title}</div>
+        `;
+        card.style.cssText = `
+            position: absolute;
+            left: ${startX}px;
+            top: ${startY}px;
+            width: 84px;
+            height: 116px;
+            transform: translate(-50%, -50%) scale(0.05) rotate(-12deg);
+            opacity: 0;
+            background: ${cardBg};
+            border: 2px solid ${cardBorder};
+            border-radius: 10px;
+            box-shadow: 0 12px 32px rgba(0,0,0,0.6), 0 0 18px ${glow};
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            color: #f8fafc;
+            font-family: 'Cinzel', serif;
             z-index: 2000;
             pointer-events: none;
-            text-shadow: 0 0 20px ${glow};
-            transform: translate(-50%, -50%) scale(0.5) rotateX(0deg) rotateY(0deg);
-            transition: all 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
+            transition: transform 0.7s cubic-bezier(0.22, 1.2, 0.36, 1), opacity 0.5s ease-out, left 0.7s cubic-bezier(0.22, 1.2, 0.36, 1), top 0.7s cubic-bezier(0.22, 1.2, 0.36, 1);
         `;
-        container.appendChild(node);
+        const iconEl = card.querySelector('.loot-fly-card-icon');
+        if (iconEl) iconEl.style.cssText = `font-size: 38px; text-shadow: 0 0 14px ${glow};`;
+        const titleEl = card.querySelector('.loot-fly-card-title');
+        if (titleEl) titleEl.style.cssText = `font-size: 12px; letter-spacing: 2px; color: ${cardBorder}; text-shadow: 0 0 6px ${glow};`;
+        container.appendChild(card);
 
-        // 终点位置：屏幕中心偏上（卡片生成位置）
         const targetX = this.width / 2;
         const targetY = this.height * 0.4;
 
+        // 触发开启脉冲
         requestAnimationFrame(() => {
-            node.style.left = targetX + 'px';
-            node.style.top = targetY + 'px';
-            node.style.transform = 'translate(-50%, -50%) scale(2.5) rotateX(360deg) rotateY(720deg)';
-            
+            burst.style.boxShadow = `0 0 0 80px rgba(255,255,255,0)`;
+            burst.style.opacity = '0';
+            ray.querySelectorAll('div').forEach((beam) => {
+                const angle = beam.style.transform.match(/rotate\(([-\d.]+)deg\)/);
+                const a = angle ? parseFloat(angle[1]) : 0;
+                beam.style.opacity = '0.9';
+                beam.style.transform = `rotate(${a}deg) translateY(-40px)`;
+            });
+
+            // 卡片从掉落物中蹦出（先稍微停留一帧再起飞，强化「打开掉落物」的感觉）
             setTimeout(() => {
-                node.style.opacity = '0';
-                node.style.transform = 'translate(-50%, -50%) scale(4) rotateX(450deg) rotateY(900deg)';
+                card.style.opacity = '1';
+                card.style.transform = 'translate(-50%, -50%) scale(0.6) rotate(-6deg)';
+            }, 80);
+
+            // 沿弧线飞向中心，并放大
+            setTimeout(() => {
+                card.style.left = targetX + 'px';
+                card.style.top = targetY + 'px';
+                card.style.transform = 'translate(-50%, -50%) scale(1.4) rotate(0deg)';
+            }, 220);
+
+            // 抵达后短暂停留 → 淡出，触发后续 UI
+            setTimeout(() => {
+                card.style.transition = 'transform 0.25s ease-in, opacity 0.25s ease-in';
+                card.style.opacity = '0';
+                card.style.transform = 'translate(-50%, -50%) scale(1.7) rotate(0deg)';
                 setTimeout(() => {
-                    if (node.parentNode) node.parentNode.removeChild(node);
+                    if (card.parentNode) card.parentNode.removeChild(card);
+                    if (burst.parentNode) burst.parentNode.removeChild(burst);
+                    if (ray.parentNode) ray.parentNode.removeChild(ray);
                     if (callback) callback();
-                }, 200);
-            }, 650);
+                }, 260);
+            }, 920);
         });
     },
 
@@ -630,6 +732,11 @@ export const ui_system = {
             }
         }
 
+        // [PC 布局 #3] 同步左侧栏「收集 / 战斗」内容显隐
+        if (typeof this._ui_updateLeftSidebarContent === 'function') {
+            this._ui_updateLeftSidebarContent(this.phase);
+        }
+
         // 4. 底部面板：仅在收集阶段且非 PC 模式下显示
         const bottomPanel = document.querySelector('.bottom-panel');
         if (bottomPanel) {
@@ -667,17 +774,91 @@ export const ui_system = {
 
     ui_updatePCLayout() {
         const isPC = window.innerWidth > 1024;
+        const wasPC = document.body.classList.contains('pc-mode');
         document.body.classList.toggle('pc-mode', isPC);
         const leftSidebar = document.getElementById('pc-left-sidebar');
         const rightSidebar = document.getElementById('pc-right-sidebar');
         if (leftSidebar) leftSidebar.style.display = isPC ? 'flex' : 'none';
         if (rightSidebar) rightSidebar.style.display = isPC ? 'flex' : 'none';
+
+        // [PC 布局恢复 #3] 实际把右侧符文发射器、左侧 info-drawer / 收集队列 / 配方 HUD
+        // 迁移到 PC 侧边栏；离开 PC 模式时再迁回原始位置。
+        this._ui_migrateRuneLauncherToSidebar(isPC);
+        this._ui_migrateDrawerToLeftSidebar(isPC);
+        this._ui_migrateHUDToLeftSidebar(isPC);
+        this._ui_updateLeftSidebarContent(this.phase, wasPC);
     },
 
-    _ui_updateLeftSidebarContent(phase, wasPC) {},
-    _ui_migrateDrawerToLeftSidebar(toSidebar) {},
-    _ui_migrateHUDToLeftSidebar(toSidebar) {},
-    _ui_migrateRuneLauncherToSidebar(toSidebar) {},
+    _ui_updateLeftSidebarContent(phase /* , wasPC */) {
+        const gatheringPane = document.getElementById('pc-left-gathering');
+        const combatPane = document.getElementById('pc-left-combat');
+        const isPC = document.body.classList.contains('pc-mode');
+        if (!gatheringPane || !combatPane) return;
+        if (!isPC) {
+            gatheringPane.style.display = 'none';
+            combatPane.style.display = 'none';
+            return;
+        }
+        if (phase === 'gathering' || phase === 'selection') {
+            gatheringPane.style.display = 'flex';
+            combatPane.style.display = 'none';
+        } else if (phase === 'combat') {
+            gatheringPane.style.display = 'none';
+            combatPane.style.display = 'flex';
+        } else {
+            gatheringPane.style.display = 'none';
+            combatPane.style.display = 'none';
+        }
+    },
+
+    /**
+     * @description 在 PC / 移动模式之间迁移指定元素。第一次调用时记录原始 parent，
+     * 之后通过 dataset 标志位把元素移入侧边栏挂载点 / 还原回原父节点。
+     */
+    _ui_movePanelTo(elId, mountId, toSidebar) {
+        const el = document.getElementById(elId);
+        const mount = document.getElementById(mountId);
+        if (!el) return;
+        if (toSidebar) {
+            if (!mount) return;
+            if (el.parentElement !== mount) {
+                if (!el.dataset.originalParentId) {
+                    const origParent = el.parentElement;
+                    if (origParent) {
+                        if (!origParent.id) origParent.id = '_orig_parent_' + elId;
+                        el.dataset.originalParentId = origParent.id;
+                    }
+                }
+                mount.appendChild(el);
+            }
+        } else {
+            const origId = el.dataset.originalParentId;
+            if (origId) {
+                const origParent = document.getElementById(origId);
+                if (origParent && el.parentElement !== origParent) {
+                    origParent.appendChild(el);
+                }
+            }
+        }
+    },
+
+    _ui_migrateDrawerToLeftSidebar(toSidebar) {
+        this._ui_movePanelTo('info-drawer', 'pc-left-drawer-mount', toSidebar);
+    },
+
+    _ui_migrateHUDToLeftSidebar(toSidebar) {
+        this._ui_movePanelTo('gathering-queue', 'pc-left-queue-mount', toSidebar);
+        this._ui_movePanelTo('gathering-hud-mount', 'pc-left-recipe-mount', toSidebar);
+    },
+
+    _ui_migrateRuneLauncherToSidebar(toSidebar) {
+        this._ui_movePanelTo('phase-rune-launcher', 'pc-right-rune-mount', toSidebar);
+        // PC 模式下符文发射器常驻显示
+        const launcher = document.getElementById('phase-rune-launcher');
+        if (launcher && toSidebar) {
+            launcher.style.display = 'flex';
+        }
+    },
 
     /**
      * @method ui_confirmSelection
@@ -821,13 +1002,26 @@ export const ui_system = {
     },
 
     ui_openPause() {
-        const pause = document.getElementById('pause-overlay');
-        if (pause) pause.classList.remove('hidden');
+        // [BUGFIX #5] 暂停/设置面板的 DOM id 是 `phase-pause`，原代码错把它当成 `pause-overlay` 处理，
+        // 导致点击「⚙️」按鈕没有任何反应。这里改为正确的 id，并补上 hidden-phase / display 切换。
+        const pause = document.getElementById('phase-pause');
+        if (!pause) return;
+        pause.classList.remove('hidden');
+        pause.classList.remove('hidden-phase');
+        pause.classList.add('active-phase');
+        pause.style.display = 'flex';
+        pause.style.zIndex = '900';
+        pause.style.pointerEvents = 'auto';
+        if (typeof this.ui_syncPauseSettings === 'function') this.ui_syncPauseSettings();
     },
 
     ui_closePause() {
-        const pause = document.getElementById('pause-overlay');
-        if (pause) pause.classList.add('hidden');
+        const pause = document.getElementById('phase-pause');
+        if (!pause) return;
+        pause.classList.add('hidden');
+        pause.classList.add('hidden-phase');
+        pause.classList.remove('active-phase');
+        pause.style.display = 'none';
     },
 
     ui_syncPauseSettings() {},


### PR DESCRIPTION
## Summary

修复 AGENTS.md 提到的 8 个 UI/UX 问题：

1. **第二/三次触发精华或潮涌类遗物触发的混沌精华时，「接受命运开始炼金」无反应**: `sys_initSelectionPhase` 在重新进入命运时刻时把 `confirmBtn.onclick` 强制恢复为 `ui_confirmSelection`。
2. **敌人血量从下往上扣除（颠倒）**: HP 锚点改为底部，液面亮边搬到顶部。
3. **PC 端布局丢失**: 恢复 `_ui_migrate*` 系列函数，把符文发射器/info-drawer/收集队列/配方 HUD 真正搬进左右侧边栏。
4. **敌人在战场背景下难以辨识 + HP 颜色与背景混色**: 容器加柔光描边、空槽与主色加深。
5. **设置面板打不开**: `ui_openPause` ID 由 `pause-overlay` 改为实际的 `phase-pause`。
6. **子弹拖尾按强度/类型变化**: `maxTrailLength` 动态化 + `_drawTrail` 按 tier 渲染。
7. **触发精华时闪一帧另一种精华内容**: `sys_initSelectionPhase` 提前清空 `#marble-selection-grid` 与 `marblesPool`。
8. **掉落物飞出无卡片动画**: `ui_playLootToCardAnimation` 改为「开启脉冲 + 光束 → 卡片飞出 → 中心放大」两段式。

## 涉及文件
- `src/game_system.js`
- `src/ui_system.js`
- `src/entities/enemy.js`
- `src/entities/projectile.js`

## 性能影响评估

`[perf-impact]` 拖尾 ≤30 段渐变描边、S 级追加白核；敌人外缘描边 `shadowBlur 8/14/18`。变化集中在战斗阶段。

## Test plan

- [ ] 第 1/2/3 次混沌精华、潮涌类遗物触发的混沌精华，「接受命运开始炼金」均能进入研磨。
- [ ] 敌人扣血时顶部最先消失。
- [ ] PC 宽度 >1024px 时左侧栏 + 右侧符文发射器恢复。
- [ ] 战场上敌人轮廓清晰、扣血露出的暗槽与背景区分。
- [ ] ⚙️ 按钮能弹出设置面板。
- [ ] S 级子弹拖尾比普通子弹明显更长更亮，激光/飞剑/属性拖尾颜色不同。
- [ ] 触发精华前一帧不再闪出另一种精华的卡片。
- [ ] 掉落物结算播放卡片飞出动画。

https://claude.ai/code/session_01B2W6mgFWwqxcU2kKae8mcW