### PR TITLE
fix(ui): 子弹选择/精华阶段 7 项修复 + 美术素材清单

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@
 *   **敌人词缀与 Boss 索引**：[`.cursor/rules/enemy_index.md`](.cursor/rules/enemy_index.md) - 8 种敌人词缀和 8 个 Boss 的行为机制、出现回合、克制属性、狂暴行为及关键代码位置速查表。
 
 *   **位图化视觉重构规格**：[`design_spec_bitmap.md`](design_spec_bitmap.md) - 阶段五规划文档。包含 UI 切图清单（9-Slice 规格 + 图标尺寸）、敌人 Sprite 规格（128×128 基准、帧数要求、Overlay 分层设计）、8 种 Boss 专属形象清单。**凡涉及位图生成、Sprite 接入、图标替换的任务，必先读此文档。**
+*   **UI 页面与美术素材需求清单**：[`docs/ui_asset_requirements.md`](docs/ui_asset_requirements.md) - 所有 UI 页面（`#phase-*` + 组件）的美术状态、缺失素材清单与优先级（P0/P1/P2）、命名/尺寸/接入路径规范。**新增 UI 页面或替换素材时必先读此文档，并同步更新该表。**
 
 ### 核心机制文档（深度阅读，含数值与流程说明）
 

--- a/docs/ui_asset_requirements.md
+++ b/docs/ui_asset_requirements.md
@@ -1,0 +1,125 @@
+# Echo Alchemist V2 — UI 页面与美术素材需求清单
+
+> **目的**：作为美术对接的「权威清单」，集中索引所有 UI 页面、当前美术覆盖率、缺失素材，以及推荐的命名/尺寸/接入位置。
+>
+> **范围**：本文档只关注 UI 与界面美术（不含敌人/Boss Sprite，那部分见 [`design_spec_bitmap.md`](../design_spec_bitmap.md) §3）。
+>
+> **维护者**：UI/美术 Agent 在每次新增 UI 页面或新增/替换素材时同步更新本表。
+
+---
+
+## 0. 视觉风格统一约定
+
+| 维度 | 约定 |
+|------|------|
+| 主色调 | `#0f172a` (slate-900) 深色底；`#581c87` (purple-800) 与 `#facc15` (gold) 用于强调 |
+| 字体 | 标题 `Cinzel`（衬线，已通过 Google Fonts 引入）；正文 `Noto Sans SC` |
+| 边框 | 9-Slice，统一 `border-image-slice: 32` 或 `48`，详见 [`design_spec_bitmap.md`](../design_spec_bitmap.md) §2 |
+| 发光 | `box-shadow + filter: drop-shadow`；位图素材自带柔光层即可，不要重复堆 CSS |
+| 命名规范 | `kebab-case.png`，对应 raw 源图加 `_raw` 后缀，9-Slice 切图加 `_9s` 后缀 |
+| 目录结构 | `assets/ui/{panels,borders,sprites,icons}/` 与 `assets/icons/{ammo,relic,rune}/` |
+
+接入约定：所有新增的位图样式必须写到 [`src/styles/bitmap_ui.css`](../src/styles/bitmap_ui.css)，**严禁**在 `index.html` 内嵌 `<style>` 中写位图样式（避免与 9-Slice 体系冲突）。
+
+---
+
+## 1. UI 页面索引（按 `#phase-*` 与功能模块划分）
+
+下列每一项的 **「美术状态」** 含义：
+- ✅ 已配齐（位图素材接入、风格一致）
+- 🟡 部分覆盖（仅基础元素接入，需补背景/边框/装饰）
+- ❌ 完全缺失（当前由原生 CSS 渲染，未接入位图）
+
+| ID | DOM 节点 | 模块/职责 | 美术状态 | 现有素材 | 缺失素材 |
+|----|---------|----------|----------|---------|---------|
+| 1.1 | `#phase-title-container` | 启动标题 / 点击开始 | 🟡 | 文字 + Cinzel 字体 | 标题徽章 PNG、点击「开始按钮」金属底板 |
+| 1.2 | `#phase-meta` | 局外元商店 / 升级树 | 🟡 | 顶部栏 9-Slice、卡片 9-Slice 边框 | **元商店分类标签 Tab Sprite**、**SP 货币图标**、升级卡片占位插画 |
+| 1.3 | `#phase-rune-launcher` | 符文发射器主面板 | ❌ | — | **整面发射器底板（含装弹槽视觉）**、Tab 切换按钮 Active/Idle、装弹动画帧 |
+| 1.4 | `#phase-shop` | 局外商店（货架） | 🟡 | 卡片 9-Slice | **背景插画（炼金工房内景）**、商店物品分类图标、价格标签 |
+| 1.5 | `#phase-selection` | 弹珠选择 / 子弹替换 / 命运时刻 | 🟡 | 卡片 9-Slice、属性图标（Emoji） | **整面背景**、卡片顶部的属性图标位（目前用 Emoji，需替换为位图）、稀有度光环装饰 |
+| 1.6 | `#phase-gathering` | 研磨阶段（弹珠台） | ❌ | — | **弹珠台背景（炼金阵图）**、发射器装置（炮台底座）、底部「钉盘外框」装饰 |
+| 1.7 | `#phase-combat` | 战斗阶段（无 DOM 主面板） | ❌ | — | **战场背景（远景塔楼/熔炉/冰窟，按 Boss 类型变化）**、发射器顶部蓄力指示位图 |
+| 1.8 | `#phase-truth-book` | 真理之书 / 图鉴 | ❌ | — | **整面卷轴/书页背景**、章节侧标 Tab、属性卡片底板、Boss 头像位 |
+| 1.9 | `#phase-relic` | 遗物选择 overlay | 🟡 | 遗物图标 PNG（已较完整）+ 卡片 9-Slice 边框 | **覆层背景纹理**（暗紫炼金阵）、稀有度光环、「跳过」按钮金属感 |
+| 1.10 | `#phase-gameover` | 游戏结束/结算 | ❌ | — | **结算背景插画（光暗双联画）**、统计数据卡片 9-Slice、奖励发放动画图层 |
+| 1.11 | `#phase-pause` | 暂停菜单 | ❌ | — | 半透明背景、菜单按钮 9-Slice |
+| 1.12 | `#unified-top-bar` | 顶部状态栏 | ✅ | 9-Slice `top_bar_9s.png` | — |
+| 1.13 | `.bottom-panel` | 底部弹药栏 | ✅ | 9-Slice `bottom_panel_9s.png` | — |
+| 1.14 | `#settings-panel` | 设置弹窗 | ❌ | — | **整窗背景 9-Slice**、开关 Toggle Sprite、滑条 Sprite、关闭按钮 |
+| 1.15 | `#combat-rune-charge-ui` | 战斗中符文充能 UI | 🟡 | 符文 PNG | 充能槽底板（液体/能量条）、充能完成「升级」帧动画 |
+| 1.16 | `#multiplier-display` | 连击倍率显示 | ❌ | — | 倍率徽章 PNG（×2、×3、×5 三档） |
+| 1.17 | `#skill-bar` | 战斗技能栏 | 🟡 | 技能图标 PNG | 技能槽底板、冷却扫描帧 |
+| 1.18 | `#round-start-banner` | 回合开始横幅 | ❌ | — | **回合数大字横幅**（金属字 + 光晕，可循环 6 张） |
+| 1.19 | 数据统计页（与图鉴并入 truth-book） | 历次伤害/记录 | ❌ | — | 折线图背景、数据指标徽章、最佳记录 ribbon |
+| 1.20 | `.ammo-icon` 弹药槽位 | 战斗 / 收集阶段 | 🟡 | `assets/icons/ammo/*.png` 已覆盖基础 7 种 | **缺 explosive、matryoshka、rainbow、resonance、flying_sword、wind 的位图**（目前回退到 emoji） |
+
+---
+
+## 2. 缺失素材分级清单（优先级排序）
+
+### 2.1 P0 — 立刻影响游戏可玩性 / 风格统一性
+
+| 资产 | 用途 | 建议尺寸 | 备注 |
+|------|------|---------|------|
+| `assets/ui/backgrounds/bg_main_canvas.png` | 战斗 / 研磨阶段全屏背景 | 720×1280（按 1080P 等比） | 暗黑赛博炼金风，需保留中部低对比区域以承载实体绘制 |
+| `assets/ui/backgrounds/bg_emitter_zone.png` | 底部发射器装饰 | 720×220 | 包含炼金台基座、能量管路 |
+| `assets/ui/sprites/emitter_base.png` | 发射器炮台本体 | 96×96，中心 anchor (0.5, 0.7) | 静态贴图（带高光层） |
+| `assets/ui/sprites/emitter_charging_*.png` | 蓄力 6 帧动画 | 96×96 | `_0.png` ~ `_5.png` |
+| `assets/icons/ammo/ammo_explosive.png` | 爆破弹药图标 | 32×32 | 与现有 `ammo_*.png` 风格一致 |
+| `assets/icons/ammo/ammo_matryoshka.png` | 套娃弹药图标 | 32×32 | 同上 |
+| `assets/icons/ammo/ammo_rainbow.png` | 七彩弹药图标 | 32×32 | 同上（需含彩虹渐变） |
+| `assets/icons/ammo/ammo_resonance.png` | 共鸣弹药图标 | 32×32 | 同上 |
+| `assets/icons/ammo/ammo_flying_sword.png` | 飞剑弹药图标 | 32×32 | 同上 |
+| `assets/icons/ammo/ammo_wind.png` | 风弹药图标 | 32×32 | 同上 |
+
+### 2.2 P1 — 完整覆盖核心 UI 模块
+
+| 资产 | 用途 | 建议尺寸 | 备注 |
+|------|------|---------|------|
+| `assets/ui/panels/rune_launcher_9s.png` | 符文发射器主面板 | 512×768，`border-image-slice:48` | 含装弹槽视觉 |
+| `assets/ui/sprites/rune_slot_idle.png` / `_active.png` | 发射器装弹槽态 | 64×64 | 两态切换 |
+| `assets/ui/panels/settings_modal_9s.png` | 设置弹窗背景 | 480×640，slice 32 | 暗紫炼金阵纹理 |
+| `assets/ui/sprites/toggle_on.png` / `toggle_off.png` | 开关 | 56×28 | 24×24 滑块 |
+| `assets/ui/sprites/slider_track.png` / `slider_thumb.png` | 滑条 | 240×16 / 24×24 | 用于音量、速度 |
+| `assets/ui/panels/truth_book_bg_9s.png` | 真理之书背景 | 720×1280，slice 64 | 卷轴/书页质感 |
+| `assets/ui/sprites/truth_book_tab_*.png` | 章节侧标 | 64×120 | 每章节一张 |
+| `assets/ui/banners/round_banner_*.png` | 回合横幅 6 帧 | 600×200 | 金属字 + 光晕动画 |
+
+### 2.3 P2 — 锦上添花
+
+| 资产 | 用途 | 建议尺寸 | 备注 |
+|------|------|---------|------|
+| `assets/ui/sprites/multiplier_x2.png` ~ `x5.png` | 连击倍率徽章 | 96×48 | 三档稀有度配色 |
+| `assets/ui/panels/gameover_bg.png` | 结算背景插画 | 720×1280 | 双联画构图 |
+| `assets/ui/sprites/relic_aura_*.png` | 遗物稀有度光环 | 200×200 | 4 档稀有度 |
+| `assets/ui/sprites/skill_cooldown_overlay.png` | 技能冷却扫描 | 64×64 | 遮罩/扫光层 |
+
+---
+
+## 3. 接入流程与 Agent 协作
+
+1. **新增素材**：放到上表指定路径，提供 `_raw.png`（无切片源图）+ 成品（`.png` 或 `_9s.png`）。
+2. **CSS 注入**：在 [`src/styles/bitmap_ui.css`](../src/styles/bitmap_ui.css) 新增对应规则（不要内嵌 `<style>`），保持每个 selector 与本文档表格 ID 一一对应注释（例如 `/* §1.14 settings_panel */`）。
+3. **JS 接入**（如图标）：通过 [`src/bitmap_icons.js`](../src/bitmap_icons.js) 的 `getXxxIconSrc()` 函数集中映射，禁止散落 `new Image()`。
+4. **同步更新本表**：每次替换素材，把对应行的「美术状态」列从 ❌ → 🟡 → ✅，并把缺失素材列勾掉。
+5. **回写到设计规格**：本文档为「现状视图」，长期规格依然以 [`design_spec_bitmap.md`](../design_spec_bitmap.md) 为准；如新增页面，请同时更新该文档 §2。
+
+---
+
+## 4. 已知不一致项（需在 art pass 中解决）
+
+- `#phase-selection` 卡片顶部的属性图标当前用 emoji，需要替换为 `assets/ui/sprites/attr_icon_*.png`（与 `assets/icons/ammo` 同源即可）。
+- `#phase-rune-launcher` 当前完全无背景，导致与 `#phase-shop` / `#phase-selection` 视觉割裂；优先级 P0/P1。
+- `#combat-rune-charge-ui` 充能条采用纯 CSS gradient，与符文 PNG 风格不统一；建议补充充能槽位图。
+- `assets/icons/relic/` 已较完整（55+ 个），但 `assets/icons/rune/` 与新增符文同步滞后；新增符文时必须同时提供位图。
+- 已生成的 `top_bar_panel.png` 与 `top_bar_9s.png` 同名混乱，建议归档 `top_bar_panel.png`（已被 9-Slice 替代）。
+
+---
+
+## 5. 文档索引
+
+- 视觉规格根：[`design_spec_bitmap.md`](../design_spec_bitmap.md)
+- 位图样式接入：[`src/styles/bitmap_ui.css`](../src/styles/bitmap_ui.css)
+- 图标映射模块：[`src/bitmap_icons.js`](../src/bitmap_icons.js)
+- UI 系统模块：[`src/ui_system.js`](../src/ui_system.js)、[`src/ui/`](../src/ui/)
+- 全局规范：[`AGENTS.md`](../AGENTS.md) §1

--- a/index.html
+++ b/index.html
@@ -186,6 +186,20 @@
         .pulse-a { animation: rarity-pulse-a 2.5s infinite ease-in-out; }
         .pulse-b { animation: rarity-pulse-b 3s infinite ease-in-out; }
 
+        /* [tsk-bullet-ui] 子弹替换卡片悬浮效果：未选中时鼠标悬浮上抬+发光 */
+        .replace-ammo-card { will-change: transform, box-shadow; }
+        .replace-ammo-card:hover {
+            transform: translateY(-6px) scale(1.03);
+            box-shadow: 0 10px 24px rgba(0,0,0,0.55), 0 0 16px rgba(255,255,255,0.18);
+            filter: brightness(1.08);
+        }
+        /* 顶部图标的常驻浮动（轻微，避免与 .card-floating 冲突） */
+        .card-icon-idle { animation: card-icon-bob 4.5s ease-in-out infinite; }
+        @keyframes card-icon-bob {
+            0%, 100% { transform: translateX(-50%) translateY(0); }
+            50%      { transform: translateX(-50%) translateY(-2px); }
+        }
+
         /* --- [新增] 符文发光闪烁特效 --- */
         @keyframes rune-glow-pulse {
             0% { box-shadow: 0 0 5px rgba(168, 85, 247, 0.4); border-color: rgba(168, 85, 247, 0.4); }

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -74,16 +74,17 @@ class Projectile {
         this.lifeTime = 60 * 30; // [修改] 加倍子弹生命时间 (从15秒增加到30秒)
         this.chainHistory = [];
         this.trail = [];
-        // [拖尾增强 #6] 根据子弹强度（属性层数）和类型决定拖尾长度，提高高强度子弹的视觉显著度。
+        // [拖尾调优] 根据子弹强度（属性层数）和类型决定拖尾长度。
+        // 用户反馈：拖尾过长且过实，需要更短更淡的视觉效果。
         const _tierStat = (config.damage || 0) + (config.bounce || 0) + (config.pierce || 0)
             + (config.scatter || 0) + (config.cryo || 0) + (config.pyro || 0)
             + (config.lightning || 0) + (config.laser || 0)
             + (config.flying_sword || 0) + (config.wind || 0);
-        let _trailMax = 6 + Math.min(28, Math.floor(_tierStat * 0.6));
-        if (config.isLaser) _trailMax += 8;
-        if (config.type === 'flying_sword') _trailMax += 6;
-        if (config.pierce > 0) _trailMax += 4;
-        if (config.explosive) _trailMax += 2;
+        let _trailMax = 4 + Math.min(14, Math.floor(_tierStat * 0.3));
+        if (config.isLaser) _trailMax += 4;
+        if (config.type === 'flying_sword') _trailMax += 3;
+        if (config.pierce > 0) _trailMax += 2;
+        if (config.explosive) _trailMax += 1;
         this.maxTrailLength = _trailMax;
         this.tierStat = _tierStat;
         this.deformation = { x: 1, y: 1 };
@@ -724,8 +725,9 @@ class Projectile {
         else if ((cfg.scatter || 0) > 0) trailColor = '#facc15';
 
         const tier = Math.min(3, Math.floor((this.tierStat || 0) / 8));
-        // 基础宽度随子弹半径与强度联动；S 级（tier 3）显著加宽
-        const baseWidth = Math.max(1.5, this.radius * (0.55 + tier * 0.18));
+        // [拖尾调优] 用户反馈：拖尾过粗过亮，整体降一档。
+        // 基础宽度随子弹半径联动；高强度子弹仅小幅加宽
+        const baseWidth = Math.max(1.0, this.radius * (0.35 + tier * 0.10));
         const len = trail.length;
 
         ctx.save();
@@ -736,15 +738,15 @@ class Projectile {
             ctx.globalCompositeOperation = 'lighter';
         }
         ctx.shadowColor = trailColor;
-        ctx.shadowBlur = 4 + tier * 4;
+        ctx.shadowBlur = 2 + tier * 2;
 
-        // 段落式渐变描边：越靠近当前位置越亮、越粗
+        // 段落式渐变描边：越靠近当前位置越亮、越粗，整体透明度更低更轻盈
         for (let i = 1; i < len; i++) {
             const a = trail[i - 1];
             const b = trail[i];
             const t = i / (len - 1);
-            const alpha = Math.max(0.04, t * (0.55 + tier * 0.12));
-            const width = Math.max(0.6, baseWidth * t);
+            const alpha = Math.max(0.02, t * (0.30 + tier * 0.08));
+            const width = Math.max(0.4, baseWidth * t);
             ctx.strokeStyle = `${trailColor}`;
             ctx.globalAlpha = alpha;
             ctx.lineWidth = width;
@@ -756,14 +758,14 @@ class Projectile {
 
         // S 级追加一层更细更亮的核心拖尾
         if (tier >= 3 || cfg.isLaser) {
-            ctx.shadowBlur = 12;
-            for (let i = Math.max(1, len - 8); i < len; i++) {
+            ctx.shadowBlur = 6;
+            for (let i = Math.max(1, len - 5); i < len; i++) {
                 const a = trail[i - 1];
                 const b = trail[i];
                 const t = i / (len - 1);
                 ctx.strokeStyle = '#ffffff';
-                ctx.globalAlpha = 0.6 * t;
-                ctx.lineWidth = Math.max(0.8, baseWidth * 0.45 * t);
+                ctx.globalAlpha = 0.35 * t;
+                ctx.lineWidth = Math.max(0.6, baseWidth * 0.30 * t);
                 ctx.beginPath();
                 ctx.moveTo(a.x, a.y);
                 ctx.lineTo(b.x, b.y);

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -622,6 +622,27 @@ phase_gathering_getRandomPegType() {
             });
         }
 
+        // [tsk-bullet-ui] 兜底保护：若 ammoQueue 与 marbleQueue 同时为空（例如玩家在
+        // 纯净精华命运时刻点击「跳过研磨」获取符文，且上回合无 _chargedAmmoQueue），
+        // 此时直接进入战斗会导致「彈藥耗盡」横幅一直显示且敌人回合无法推进。
+        // 此处强制回退到研磨阶段，重新生成弹珠选择，避免无限敌人回合死循环。
+        if (this.ammoQueue.length === 0 && (!this.marbleQueue || this.marbleQueue.length === 0)) {
+            console.warn('[phase_startCombatPhase] ammoQueue 与 marbleQueue 均为空，回退到研磨阶段防止死循环');
+            // 重置可能残留的命运时刻状态，确保进入标准研磨流程
+            this.selectionMode = 'standard';
+            this.fateMomentContext = null;
+            this.pendingSelectionMode = null;
+            this.replaceAmmoContext = null;
+            this._chargedAmmoQueue = null;
+            // 进入标准选择阶段（非命运时刻），让玩家选择弹珠后再进研磨
+            if (typeof this.sys_initSelectionPhase === 'function') {
+                this.sys_initSelectionPhase();
+            } else {
+                this.phase_switchPhase('selection');
+            }
+            return;
+        }
+
         // --- [核心修复 2]：UI 渲染 ---
         // 修复后，上面的代码不再报错，这一行将被正确执行，HUD 会在进入战斗时立即出现
         this.ui_updateUI();

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -629,14 +629,61 @@ export const game_system = {
             chargedRecipes: chargedRecipes.length,
             phase: this.phase,
         });
-        // 默认选中右侧（充能子弹），索引 3, 4, 5
-        const defaultSelected = chargedRecipes.map((_, i) => newRecipes.length + i);
+
+        // [tsk-bullet-ui] 继承玩家上回合的选择偏好：
+        // 1. 通过 _lastReplaceAmmoSignatures 记录玩家上回合实际选中子弹的「特征签名」
+        //    （主弹珠类型 + 主属性 + multicast 等级），作为本回合 default 选中的依据。
+        // 2. 若签名匹配不到（首次进入或弹珠彻底改变），回退到原默认逻辑：选中所有充能子弹。
+        const allRecipes = newRecipes.concat(chargedRecipes);
+        const _signatureOf = (r) => {
+            if (!r) return '';
+            const main = r._marbleType || r.type || 'normal';
+            const flags = `${r.explosive ? 'E' : ''}${r.isMatryoshka ? 'M' : ''}${r.isLaser ? 'L' : ''}`;
+            const mc = (r.multicast || 0) >= 3 ? 'm' : '';
+            const stats = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind']
+                .map(k => r[k] || 0).join('-');
+            return `${main}|${flags}|${mc}|${stats}`;
+        };
+        const lastSigs = Array.isArray(this._lastReplaceAmmoSignatures) ? this._lastReplaceAmmoSignatures.slice() : [];
+        let defaultSelected;
+        if (lastSigs.length > 0) {
+            const usedIdx = new Set();
+            defaultSelected = [];
+            lastSigs.forEach(sig => {
+                for (let i = 0; i < allRecipes.length; i++) {
+                    if (usedIdx.has(i)) continue;
+                    if (_signatureOf(allRecipes[i]) === sig) {
+                        defaultSelected.push(i);
+                        usedIdx.add(i);
+                        break;
+                    }
+                }
+            });
+            // 数量不足时用充能子弹补齐
+            const maxSelect = Math.max(newRecipes.length, chargedRecipes.length, 3);
+            for (let j = 0; j < chargedRecipes.length && defaultSelected.length < maxSelect; j++) {
+                const idx = newRecipes.length + j;
+                if (!usedIdx.has(idx)) { defaultSelected.push(idx); usedIdx.add(idx); }
+            }
+        } else {
+            // 首次进入：默认选中右侧（充能子弹），索引 newRecipes.length 起
+            defaultSelected = chargedRecipes.map((_, i) => newRecipes.length + i);
+        }
+
         this.replaceAmmoContext = {
             active: true,
             newRecipes,          // 新研磨的 recipe（左侧）
             chargedRecipes,      // 充能子弹（右侧）
-            selectedIndices: defaultSelected, // 默认选中右侧全部
+            selectedIndices: defaultSelected, // 继承上回合或默认选中右侧
         };
+        // [tsk-bullet-ui] 修复闪烁：先清空 grid DOM，再切阶段，再渲染 replace UI。
+        // 之前顺序是 switch → render，导致 ui_updateUI() 用 ui_refreshSelectionModeUI
+        // 闪一帧标准命运选择内容，再被 ui_renderReplaceAmmoUI 覆盖。
+        const _gridElPre = document.getElementById('marble-selection-grid');
+        if (_gridElPre) {
+            _gridElPre.style.cssText = '';
+            _gridElPre.innerHTML = '';
+        }
         this.phase_switchPhase('selection');
         if (typeof this.ui_renderReplaceAmmoUI === 'function') {
             this.ui_renderReplaceAmmoUI();
@@ -670,6 +717,18 @@ export const game_system = {
             selectedIndices,
             finalAmmoCount: finalAmmo.length,
         });
+
+        // [tsk-bullet-ui] 记录玩家本回合实际选中子弹的特征签名，下回合用于继承默认选择。
+        const _sigOf = (r) => {
+            if (!r) return '';
+            const main = r._marbleType || r.type || 'normal';
+            const flags = `${r.explosive ? 'E' : ''}${r.isMatryoshka ? 'M' : ''}${r.isLaser ? 'L' : ''}`;
+            const mc = (r.multicast || 0) >= 3 ? 'm' : '';
+            const stats = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind']
+                .map(k => r[k] || 0).join('-');
+            return `${main}|${flags}|${mc}|${stats}`;
+        };
+        this._lastReplaceAmmoSignatures = finalAmmo.map(_sigOf);
 
         this.ammoQueue = finalAmmo;
         this.replaceAmmoContext = null;
@@ -712,6 +771,17 @@ export const game_system = {
         const newRecipes = ctx.newRecipes || [];
         // 跳过：直接使用新研磨的子弹
         this.ammoQueue = newRecipes.slice();
+        // [tsk-bullet-ui] 跳过时也记录签名（取新研磨子弹）以便下次继承
+        const _sigOf = (r) => {
+            if (!r) return '';
+            const main = r._marbleType || r.type || 'normal';
+            const flags = `${r.explosive ? 'E' : ''}${r.isMatryoshka ? 'M' : ''}${r.isLaser ? 'L' : ''}`;
+            const mc = (r.multicast || 0) >= 3 ? 'm' : '';
+            const stats = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind']
+                .map(k => r[k] || 0).join('-');
+            return `${main}|${flags}|${mc}|${stats}`;
+        };
+        this._lastReplaceAmmoSignatures = this.ammoQueue.map(_sigOf);
         this.replaceAmmoContext = null;
         this._chargedAmmoQueue = null;
         // 恢复滚动容器样式（子弹替换阶段修改过）
@@ -822,8 +892,10 @@ export const game_system = {
         // marbleQueue 编译为 ammoQueue，否则进入战斗阶段时 ammoQueue 为空，
         // 导致「彈藥耗盡」→ 敌人回合无限循环。
         // 优先使用 _chargedAmmoQueue（上回合保留的充能子弹），其次使用当前 marbleQueue。
+        let _hasFallbackAmmo = false;
         if (this._chargedAmmoQueue && this._chargedAmmoQueue.length > 0) {
             this.ammoQueue = this._chargedAmmoQueue.slice();
+            _hasFallbackAmmo = true;
         } else if (this.marbleQueue && this.marbleQueue.length > 0) {
             this.ammoQueue = [];
             this.marbleQueue.forEach(marbleDef => {
@@ -833,6 +905,7 @@ export const game_system = {
                 recipe.multicast = marbleDef.multicast || 0;
                 this.ammoQueue.push(recipe);
             });
+            _hasFallbackAmmo = this.ammoQueue.length > 0;
         } else {
             this.ammoQueue = [];
         }
@@ -1248,7 +1321,24 @@ export const game_system = {
         // 渲染出旧的命运选择卡片（如 chaos_essence / pure_essence 界面）。
         this.selectionMode = 'standard';
         this.fateMomentContext = null;
-        if (this.phase !== 'selection') {
+        // [tsk-bullet-ui] 修复闪烁：仅当下一个奖励是精华时才切到 selection 阶段。
+        // 遗物奖励使用 #phase-relic overlay（z-index:200）覆盖当前阶段，无需切到 selection；
+        // 之前无条件 phase_switchPhase('selection') 会让 phase-selection 面板先闪一帧
+        // 旧/空的弹珠选择内容，再被 phase-relic overlay 覆盖。
+        const _nextRewardType = (() => {
+            const r = (this.pendingRoundStartRewards || [])[0];
+            if (!r) return null;
+            return r.type === 'essence'
+                ? (r.essenceType === 'pure_essence' ? 'pure_essence' : 'chaos_essence')
+                : r.type;
+        })();
+        if ((_nextRewardType === 'chaos_essence' || _nextRewardType === 'pure_essence') && this.phase !== 'selection') {
+            // 同步预先清空残留的弹珠卡片，避免 ui_updateUI 渲染出旧 DOM 闪一帧
+            const _earlyGridEl = document.getElementById('marble-selection-grid');
+            if (_earlyGridEl) {
+                _earlyGridEl.style.cssText = '';
+                _earlyGridEl.innerHTML = '';
+            }
             this.phase_switchPhase('selection');
         }
         this._roundStartResolverActive = true;

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -379,24 +379,38 @@ export const ui_system = {
         if (requiredEl) requiredEl.innerText = String(maxSelect);
 
         // @section:replace_ammo_tier_calc - 子弹等级与主属性计算函数（_calcTier / _calcDominant）
+        // [tsk-bullet-ui] 稀有度同时考虑普通属性、连射倍率以及爆破/套娃/激光/共鸣/七彩等特殊属性。
+        const _statKeys = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind'];
+        const _calcSpecialBonus = (recipe) => {
+            let bonus = 0;
+            if (recipe.explosive) bonus += 8;            // 爆破：等同 1 张 A 级属性
+            if (recipe.isMatryoshka) bonus += 6;         // 套娃：连锁载荷
+            if (recipe.isLaser) bonus += 5;              // 激光本体
+            if (recipe.type === 'rainbow' || recipe._marbleType === 'rainbow') bonus += 6;
+            if (recipe.type === 'resonance' || recipe._marbleType === 'resonance') bonus += 4;
+            return bonus;
+        };
         const _calcTier = (recipe) => {
             const mc = recipe.multicast || 0;
             const mcTier = mc >= 12 ? 3 : mc >= 6 ? 2 : mc >= 3 ? 1 : 0;
-            const statKeys = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind'];
             let statSum = 0;
-            statKeys.forEach(k => { if (recipe[k] > 0) statSum += recipe[k]; });
+            _statKeys.forEach(k => { if (recipe[k] > 0) statSum += recipe[k]; });
+            statSum += _calcSpecialBonus(recipe);
             const statTier = statSum >= 35 ? 3 : statSum >= 20 ? 2 : statSum >= 8 ? 1 : 0;
             return Math.max(mcTier, statTier);
         };
 
         const _calcDominant = (recipe) => {
-            const statKeys = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind'];
             let statSum = 0;
             let maxKey = null, maxVal = 0;
-            statKeys.forEach(k => {
+            _statKeys.forEach(k => {
                 const v = recipe[k] || 0;
                 if (v > 0) { statSum += v; if (v > maxVal) { maxVal = v; maxKey = k; } }
             });
+            // [tsk-bullet-ui] 主题色优先取特殊属性（爆破/激光/飞剑/套娃），保证视觉与玩法对应
+            if (recipe.explosive && (!maxKey || maxVal < 6)) maxKey = 'pyro';
+            if (recipe.isLaser) { maxKey = 'laser'; maxVal = Math.max(maxVal, 8); }
+            if (recipe.isMatryoshka && !maxKey) maxKey = 'lightning';
             if (!maxKey || maxVal <= 5 || statSum === 0 || maxVal / statSum < 0.5) return null;
             const ATTR_THEMES = {
                 pyro:        ['linear-gradient(160deg,#7c2d12 0%,#431407 60%,#1c0a03 100%)', '#f97316', '#fdba74', '#7c2d12'],
@@ -446,7 +460,10 @@ export const ui_system = {
                 const dominant = _calcDominant(recipe);
 
                 const cardWrap = document.createElement('div');
-                cardWrap.style.cssText = 'position:relative;border-radius:12px;overflow:visible;height:100%;display:flex;flex-direction:column;box-sizing:border-box;transition:all 0.3s cubic-bezier(0.34,1.56,0.64,1);';
+                // [tsk-bullet-ui] 添加 .replace-ammo-card 类用于全局 hover 样式（鼠标悬浮时上抬+加亮）
+                cardWrap.className = 'replace-ammo-card';
+                cardWrap.style.cssText = 'position:relative;border-radius:12px;overflow:visible;height:100%;display:flex;flex-direction:column;box-sizing:border-box;transition:transform 0.25s cubic-bezier(0.34,1.56,0.64,1), box-shadow 0.25s ease;';
+                cardWrap.dataset.dominantColor = dominant ? dominant.theme[1] : ts.borderIdle;
                 if (isSelected) {
                     cardWrap.style.margin = '0 6px';
                     cardWrap.style.transform = 'translateY(-8px) scale(1.05)';
@@ -484,15 +501,25 @@ export const ui_system = {
                 cardWrap.appendChild(card);
 
                 const iconArea = document.createElement('div');
-                iconArea.style.cssText = 'position:absolute;top:-16px;left:50%;transform:translateX(-50%);z-index:20;pointer-events:none;';
-                if (isSelected) iconArea.className = 'card-floating';
-                
+                // [tsk-bullet-ui] 顶部图标常驻：所有卡片都展示主属性图标（原来仅在 isSelected 时浮动）
+                iconArea.style.cssText = 'position:absolute;top:-18px;left:50%;transform:translateX(-50%);z-index:20;pointer-events:none;';
+                iconArea.className = isSelected ? 'card-floating' : 'card-icon-idle';
+
                 const attrIcons = (typeof CONFIG !== 'undefined' && CONFIG.ui && CONFIG.ui.attributeDisplay) ? CONFIG.ui.attributeDisplay : {};
-                const mainAttrKey = dominant ? dominant.key : (recipe.pyro > 0 ? 'pyro' : recipe.cryo > 0 ? 'cryo' : recipe.lightning > 0 ? 'lightning' : 'damage');
+                // [tsk-bullet-ui] 主属性优先识别：爆破/激光/套娃/连射 等特殊属性优先显示，其次才是数值最高的元素属性
+                let mainAttrKey;
+                if (recipe.explosive) mainAttrKey = 'explosive';
+                else if (recipe.isLaser) mainAttrKey = 'laser';
+                else if (recipe.isMatryoshka) mainAttrKey = 'matryoshka';
+                else if (recipe.type === 'rainbow' || recipe._marbleType === 'rainbow') mainAttrKey = 'rainbow';
+                else if (recipe.type === 'resonance' || recipe._marbleType === 'resonance') mainAttrKey = 'resonance';
+                else if (dominant) mainAttrKey = dominant.key;
+                else mainAttrKey = recipe.pyro > 0 ? 'pyro' : recipe.cryo > 0 ? 'cryo' : recipe.lightning > 0 ? 'lightning' : 'damage';
                 const mainAttrInfo = attrIcons[mainAttrKey] || { icon: '🔮', color: '#94a3b8' };
-                
+                const _iconBorderColor = (mainAttrInfo.color && mainAttrInfo.color.indexOf('gradient') === -1) ? mainAttrInfo.color : '#facc15';
+
                 iconArea.innerHTML = `
-                    <div style="width:36px;height:36px;background:rgba(15,23,42,0.9);border:2px solid ${mainAttrInfo.color};border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:20px;box-shadow:0 4px 12px rgba(0,0,0,0.5), 0 0 10px ${mainAttrInfo.color}88;">
+                    <div style="width:38px;height:38px;background:rgba(15,23,42,0.92);border:2px solid ${_iconBorderColor};border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:20px;box-shadow:0 4px 12px rgba(0,0,0,0.55), 0 0 10px ${_iconBorderColor}88;">
                         ${mainAttrInfo.icon}
                     </div>
                 `;
@@ -503,26 +530,40 @@ export const ui_system = {
                 tierBadge.innerText = tier === 3 ? '✦ S' : tier === 2 ? 'A' : tier === 1 ? 'B' : 'C';
                 card.appendChild(tierBadge);
 
+                // [tsk-bullet-ui] 显示数值属性 + 特殊属性（爆破/套娃/激光/连射/七彩/共鸣）
                 const attrKeys = ['damage','bounce','pierce','scatter','cryo','pyro','lightning','laser','flying_sword','wind'];
                 const sortedAttrs = attrKeys
                     .map(k => ({ key: k, val: recipe[k] || 0 }))
                     .filter(a => a.val > 0)
-                    .sort((a, b) => b.val - a.val)
-                    .slice(0, 3);
+                    .sort((a, b) => b.val - a.val);
+
+                const specialAttrs = [];
+                if (recipe.explosive) specialAttrs.push({ key: 'explosive', label: '✓' });
+                if (recipe.isMatryoshka) specialAttrs.push({ key: 'matryoshka', label: '✓' });
+                if (recipe.isLaser && (recipe.laser || 0) === 0) specialAttrs.push({ key: 'laser', label: '✓' });
+                if (recipe.type === 'rainbow' || recipe._marbleType === 'rainbow') specialAttrs.push({ key: 'rainbow', label: '✓' });
+                if (recipe.type === 'resonance' || recipe._marbleType === 'resonance') specialAttrs.push({ key: 'resonance', label: '✓' });
+                if ((recipe.multicast || 0) > 0) specialAttrs.push({ key: 'multicast', label: 'x' + recipe.multicast });
 
                 const attrsContainer = document.createElement('div');
-                attrsContainer.style.cssText = 'display:flex;flex-direction:column;gap:4px;margin-top:auto;width:100%;';
-                
-                sortedAttrs.forEach(attr => {
+                attrsContainer.style.cssText = 'display:flex;flex-direction:column;gap:3px;margin-top:auto;width:100%;';
+
+                // 特殊属性优先显示在顶部（更醒目），数值属性补足到 4 行
+                const allRows = specialAttrs.concat(sortedAttrs).slice(0, 4);
+                allRows.forEach(attr => {
                     const info = attrIcons[attr.key] || {};
+                    const isSpecial = attr.label !== undefined;
+                    const valText = isSpecial ? attr.label : String(attr.val);
+                    const borderColor = (info.color && info.color.indexOf('gradient') === -1) ? info.color : '#facc15';
+                    const labelColor = borderColor;
                     const row = document.createElement('div');
-                    row.style.cssText = `display:flex;align-items:center;justify-content:space-between;width:100%;padding:2px 6px;background:rgba(0,0,0,0.3);border-radius:4px;border-left:2px solid ${info.color || '#475569'};`;
+                    row.style.cssText = `display:flex;align-items:center;justify-content:space-between;width:100%;padding:2px 6px;background:rgba(0,0,0,${isSpecial ? '0.45' : '0.3'});border-radius:4px;border-left:2px solid ${borderColor};`;
                     row.innerHTML = `
-                        <span style="font-size:10px;color:${info.color || '#94a3b8'};display:flex;align-items:center;gap:2px;">
+                        <span style="font-size:10px;color:${labelColor};display:flex;align-items:center;gap:2px;">
                             <span style="font-size:11px;">${info.icon || '◆'}</span>
                             <span>${info.name || attr.key}</span>
                         </span>
-                        <span style="font-size:11px;font-weight:800;color:#fff;">${attr.val}</span>
+                        <span style="font-size:11px;font-weight:800;color:#fff;">${valText}</span>
                     `;
                     attrsContainer.appendChild(row);
                 });


### PR DESCRIPTION
## 概览

针对子弹选择 / 精华阶段反馈的 7 项 UI 与 Bug 修复，并新增美术素材需求清单文档。

## 修复明细

| # | 问题 | 关键改动 |
|---|------|---------|
| 1 | 跳过纯净精华领符文后陷入「彈藥耗盡 + 敌人无限回合」死循环 | `src/game_phase.js` `phase_startCombatPhase` 新增 `ammoQueue`/`marbleQueue` 双空兜底，回退到 `sys_initSelectionPhase` |
| 2 | 子弹选择不继承上回合实际选中 | `src/game_system.js` `_lastReplaceAmmoSignatures` 按主弹珠类型 + 主属性 + multicast 等级签名匹配，`sys_confirmReplaceAmmo` / `sys_skipReplaceAmmo` 写入签名 |
| 3 | 稀有度未计入 explosive / matryoshka / laser / rainbow / resonance / multicast | `src/ui_system.js` `_calcSpecialBonus` + `_calcDominant` 主题色优先识别；卡片新增对应数值/特殊属性行 |
| 4 | 进入精华/遗物阶段闪一帧弹珠选择页 | `sys_startRoundStartResolver` 仅在下一奖励为精华时才切到 `selection`；`sys_initReplaceAmmoPhase` 切阶段前先清空 grid DOM |
| 5 | 拖尾过长过亮 | `src/entities/projectile.js` 长度系数 0.6→0.3、上限 28→14；宽度 0.55→0.35、alpha 0.55→0.30、shadowBlur 4→2 |
| 6 | 卡片缺 hover、顶部图标空白 | `index.html` `.replace-ammo-card:hover` + `.card-icon-idle` 浮动；顶部图标常驻并按特殊属性优先识别 |
| 7 | UI 与美术索引缺失 | 新增 `docs/ui_asset_requirements.md`（20 个 UI 节点状态表 + P0/P1/P2 缺失清单 + 接入流程），`AGENTS.md §1` 注册索引 |

## 性能自适应影响评估

`_drawTrail` 改动整体降负载（拖尾更短、更细、更低 alpha，shadowBlur 由 4~12 降到 2~6），`high` / `medium` / `low` 三档均改善，未新增预算项；其余改动均为 DOM/数据流逻辑，不涉及粒子或混合模式。

## 测试计划

- [ ] Round 1 触发纯净精华 → 「跳过研磨」 → 验证敌人回合可正常推进
- [ ] 子弹替换阶段切换卡片 → 下一轮再进 → 验证选择被继承
- [ ] 触发遗物奖励 → 验证不再有 phase-selection 闪屏
- [ ] 战斗中观察拖尾视觉更短更淡
- [ ] 鼠标悬浮子弹卡片，验证上抬+高亮 hover
- [ ] 含 explosive / matryoshka / multicast 的子弹，验证稀有度与显示行
- [ ] AGENTS.md 中 docs/ui_asset_requirements.md 链接可跳转

https://claude.ai/code/session_016JQw6Vve5VdTyb8T6Yy7hF