### PR TITLE
perf(loading): 启动时预解码核心位图，消除首次绘制抖动

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,6 +45,7 @@ import { calc_utils } from './calc_utils.js';
 import { tutorial_system } from './tutorial_system.js';
 import { game_over_mixin } from './ui/game_over.js';
 import { preloadAllSprites } from './render/sprite_renderer.js'; // [Phase 5B] 预加载所有 Sprite Sheet
+import { preloadAllIcons } from './render/preload_icons.js';     // 预解码 HUD/符文/遗物图标，消除首次 decode 抖动
 
 // ==================== 延迟音频初始化 ====================
 let _audioInitialized = false;
@@ -316,6 +317,8 @@ class Game {
         this._perfUpTimer = 0;
         // [Phase 5B] 预加载所有 Sprite Sheet（在游戏循环开始前触发异步加载）
         preloadAllSprites();
+        // 并行预解码 HUD / 抽符 / 商店图标，避免首次出现时的 decode 抖动
+        preloadAllIcons();
         // 启动游戏主循环
         this.sys_loop();
     }

--- a/src/render/preload_icons.js
+++ b/src/render/preload_icons.js
@@ -1,0 +1,70 @@
+/**
+ * src/render/preload_icons.js — HUD/抽符/商店图标的预解码模块
+ *
+ * 职责：
+ * - 在游戏启动时并行触发 AMMO/RUNE/RELIC 三张映射表中所有 PNG 的下载与解码
+ * - 维护一个 src → HTMLImageElement 缓存，避免后续 <img> 元素首次出现时的 decode 抖动
+ * - 失败不抛异常，单张图片失败不影响其他图标（fallback 仍可由调用方处理）
+ *
+ * 设计原则：
+ * - 不暴露 Promise 等待 API：HUD/UI 层依然可以照常用 <img src=...>，
+ *   浏览器 HTTP 缓存命中时会立即可用；而 decode 已经在启动时完成，
+ *   首次实际渲染就不会再触发同步 decode。
+ * - 总体积极小（~0.6 MB，<80 张）：一次性预加载收益 > 复杂度。
+ *
+ * @module render/preload_icons
+ */
+
+import { AMMO_ICON_MAP, RUNE_ICON_MAP, RELIC_ICON_MAP } from '../bitmap_icons.js';
+
+/** 预解码后的图片缓存，src → HTMLImageElement（其它模块可读取，但 <img> 标签会自然命中 HTTP 缓存，无需手动接入）。 */
+const _iconCache = new Map();
+
+/**
+ * 异步预热单张图片：触发下载 + decode，缓存到 _iconCache。
+ * 静默失败（控制台 warn 一次），不影响后续调用方的 fallback 逻辑。
+ * @param {string} src
+ * @returns {Promise<void>}
+ */
+function _warmupIcon(src) {
+    if (!src || _iconCache.has(src)) return Promise.resolve();
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = async () => {
+            try { if (img.decode) await img.decode(); } catch (_) { /* 忽略 decode 异常 */ }
+            _iconCache.set(src, img);
+            resolve();
+        };
+        img.onerror = () => {
+            // 单张失败不阻塞整体预热流程
+            console.warn(`[preload_icons] 图标加载失败，跳过: ${src}`);
+            resolve();
+        };
+        img.src = src;
+    });
+}
+
+/**
+ * 预加载所有 HUD / 抽符 / 商店相关的图标。
+ * 在游戏启动时调用一次，与 preloadAllSprites 并行触发，不阻塞主循环启动。
+ * @returns {Promise<void>} 仅供测试场景 await，运行时无需等待
+ */
+export function preloadAllIcons() {
+    const all = new Set();
+    for (const map of [AMMO_ICON_MAP, RUNE_ICON_MAP, RELIC_ICON_MAP]) {
+        for (const src of Object.values(map)) {
+            if (src) all.add(src);
+        }
+    }
+    const tasks = [];
+    for (const src of all) tasks.push(_warmupIcon(src));
+    const promise = Promise.all(tasks).then(() => {
+        console.log(`[preload_icons] 预加载 ${_iconCache.size}/${all.size} 个图标`);
+    });
+    return promise;
+}
+
+/** 调试/测试用：返回当前已预热的图标数量。 */
+export function getPreloadedIconCount() {
+    return _iconCache.size;
+}

--- a/src/render/sprite_renderer.js
+++ b/src/render/sprite_renderer.js
@@ -35,7 +35,12 @@ function _loadImage(src) {
     if (_imageCache.has(src)) return Promise.resolve(_imageCache.get(src));
     return new Promise((resolve, reject) => {
         const img = new Image();
-        img.onload  = () => { _imageCache.set(src, img); resolve(img); };
+        img.onload  = async () => {
+            // 等待解码完成，避免首次 drawImage 时同步 decode 造成的帧抖动
+            try { if (img.decode) await img.decode(); } catch (_) { /* 忽略，回退到隐式 decode */ }
+            _imageCache.set(src, img);
+            resolve(img);
+        };
         img.onerror = () => reject(new Error(`SpriteRenderer: 图片加载失败 → ${src}`));
         img.src = src;
     });


### PR DESCRIPTION
## Summary

针对位图加载路径做了**最小侵入**的两处优化，目标是消除"首次出现该资源时的同步 decode 抖动"，无需引入加载进度条 UI。

- **`SpriteRenderer._loadImage`**：图片 `onload` 后追加 `await img.decode()`，让 `ready=true` 等价于"已解码可立即绘制"。敌人/Boss 首次出现帧不再因同步 decode 卡顿。
- **新增 `src/render/preload_icons.js`**：启动时遍历 `AMMO_ICON_MAP / RUNE_ICON_MAP / RELIC_ICON_MAP`，并行触发 `new Image() + img.decode()` 共 ~80 张（生产体积 <1 MB），HUD 弹药 / 抽符面板 / 商店遗物首次渲染不再有 decode 空白。
- **`core.js`**：在已有 `preloadAllSprites()` 之后并行调用 `preloadAllIcons()`，不阻塞主循环启动；单图失败仅 `console.warn`，不影响其他资源。

## 设计取舍

- 不引入显式加载进度条：核心运行时位图总量约 30 MB，且现有矢量 fallback 已保证首帧不卡死，进度条收益与开发成本不成正比。
- UI 面板（border-image / background-image，~25 MB）保持浏览器原生懒加载——CSS selector 命中时才请求，避免无谓预热。
- 后期 Boss Sprite Sheet 维持 `preloadAllSprites()` 的全量预加载（仅 4.65 MB），简单可靠；如未来体积膨胀可改为按 stage 分阶段预热。

## Test plan

- [x] `node --check` 验证三处文件语法
- [x] 静态服务器 200 验证模块路径可达
- [ ] 浏览器手动验证：DevTools Network 面板观察启动时图标并行请求；战斗首次刷新 UI 无空白帧
- [ ] 性能自适应影响评估：本改动不新增粒子/混合模式/shadowBlur，对 CONFIG.performance 三档预算无影响

https://claude.ai/code/session_01RSfZnuoNApcihu8LeFeZ7H