### PR TITLE
feat(ui): 收缩符文发射器、移除遗物旋转光环、对齐发射口、补全背景

### DIFF
--- a/docs/ui_asset_requirements.md
+++ b/docs/ui_asset_requirements.md
@@ -32,15 +32,15 @@
 
 | ID | DOM 节点 | 模块/职责 | 美术状态 | 现有素材 | 缺失素材 |
 |----|---------|----------|----------|---------|---------|
-| 1.1 | `#phase-title-container` | 启动标题 / 点击开始 | 🟡 | 文字 + Cinzel 字体 | 标题徽章 PNG、点击「开始按钮」金属底板 |
-| 1.2 | `#phase-meta` | 局外元商店 / 升级树 | 🟡 | 顶部栏 9-Slice、卡片 9-Slice 边框 | **元商店分类标签 Tab Sprite**、**SP 货币图标**、升级卡片占位插画 |
-| 1.3 | `#phase-rune-launcher` | 符文发射器主面板 | ✅ | `rune_launcher_9s.png`、`rune_grid_bg_9s.png`、`rune_slot_idle/hover/filled/highlight.png` | — |
-| 1.4 | `#phase-shop` | 局外商店（货架） | 🟡 | 卡片 9-Slice | **背景插画（炼金工房内景）**、商店物品分类图标、价格标签 |
+| 1.1 | `#phase-title-container` | 启动标题 / 点击开始 | 🟡 | 文字 + Cinzel 字体（背景由 `#phase-meta` 承载） | 标题徽章 PNG、点击「开始按钮」金属底板 |
+| 1.2 | `#phase-meta` | 局外元商店 / 升级树 | 🟡 | 顶部栏 9-Slice、卡片 9-Slice 边框、`relic_overlay_bg.png` 复用底纹 | **元商店分类标签 Tab Sprite**、**SP 货币图标**、升级卡片占位插画 |
+| 1.3 | `#phase-rune-launcher` | 符文发射器主面板 | ✅ | `rune_launcher_9s.png`（已收缩到内层卡片宽度 384px）、`rune_grid_bg_9s.png`、`rune_slot_idle/hover/filled/highlight.png` | — |
+| 1.4 | `#phase-shop` | 局外商店（货架） | 🟡 | 卡片 9-Slice、`replace_ammo_bg.png` 复用炼金工坊底图 | 商店物品分类图标、价格标签 |
 | 1.5 | `#phase-selection` | 弹珠选择 / 子弹替换 / 命运时刻 | ✅ | `replace_ammo_bg.png`、`replace_card_frame_<C/B/A/S>_9s.png`、`replace_card_attr_slot.png`、`skip_btn_metal.png` | — |
 | 1.6 | `#phase-gathering` | 研磨阶段（弹珠台） | 🟡 | `bg_main_canvas.png`、`bg_emitter_zone.png`、`emitter_base.png` | 底部「钉盘外框」装饰 |
 | 1.7 | `#phase-combat` | 战斗阶段（无 DOM 主面板） | ✅ | `bg_main_canvas.png`、`emitter_base.png`、`emitter_charging_0~5.png`（蓄力 6 帧叠加） | — |
 | 1.8 | `#phase-truth-book` | 真理之书 / 图鉴 | 🟡 | `truth_book_bg_9s.png`（已接入背景） | 章节侧标 Tab、属性卡片底板、Boss 头像位 |
-| 1.9 | `#phase-relic` | 遗物选择 overlay | ✅ | `relic_overlay_bg.png`、`relic_aura_<C/B/A/S>.png`、`skip_btn_metal.png` + 已有遗物图标/9-Slice 边框 | — |
+| 1.9 | `#phase-relic` | 遗物选择 overlay | ✅ | `relic_overlay_bg.png`、`skip_btn_metal.png` + 已有遗物图标/9-Slice 边框（**已移除**旋转圆形稀有度光环） | — |
 | 1.10 | `#phase-gameover` | 游戏结束/结算 | 🟡 | `gameover_bg.png`（已接入） | 统计数据卡片 9-Slice、奖励发放动画图层 |
 | 1.11 | `#phase-pause` | 暂停菜单 | ❌ | — | 半透明背景、菜单按钮 9-Slice |
 | 1.12 | `#unified-top-bar` | 顶部状态栏 | ✅ | 9-Slice `top_bar_9s.png` | — |

--- a/index.html
+++ b/index.html
@@ -2840,8 +2840,8 @@
     </div>
 
     <!-- [RUNE] 符文发射器面板 -->
-    <div id="phase-rune-launcher" class="ui-overlay" style="display: none; background: #020617; pointer-events: auto; z-index: 300;">
-        <div class="w-full max-w-md h-full flex flex-col p-6 overflow-y-auto">
+    <div id="phase-rune-launcher" class="ui-overlay" style="display: none; background: rgba(2, 6, 23, 0.92); pointer-events: auto; z-index: 300;">
+        <div class="rune-launcher-card w-full h-full flex flex-col p-6 overflow-y-auto">
             <!-- 顶部导航 -->
             <div class="flex justify-between items-center mb-4">
                 <button onclick="game.ui_closeRuneLauncher()" class="rune-launcher-close-btn text-slate-400 hover:text-white transition-colors">

--- a/src/bitmap_icons.js
+++ b/src/bitmap_icons.js
@@ -193,6 +193,10 @@ export const EMITTER_CHARGING_SRCS = [
     'assets/ui/sprites/emitter_charging_5.png',
 ];
 
+// Canvas 背景位图（战斗 / 研磨阶段共用主底图，发射区单独叠加炼金台层）
+export const BG_MAIN_CANVAS_SRC   = 'assets/ui/backgrounds/bg_main_canvas.png';
+export const BG_EMITTER_ZONE_SRC  = 'assets/ui/backgrounds/bg_emitter_zone.png';
+
 /**
  * 预热 UI 位图（在游戏启动早期调用，避免战斗首帧卡顿）。
  */
@@ -205,6 +209,8 @@ export function preloadUiBitmaps() {
         ORBITAL_LINK_CAP,
         ...ORBITAL_LINK_FLOW,
         ...ORBITAL_INTAKE,
+        BG_MAIN_CANVAS_SRC,
+        BG_EMITTER_ZONE_SRC,
     ];
     paths.forEach(p => getUiBitmap(p));
 }

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -2159,8 +2159,8 @@ export const combat_system = {
                         if (motherBladeMarker) {
                             recallTarget = motherBladeMarker.pos;
                         } else {
-                            // 母剑不存在或未插在敌人身上，回到玩家位置
-                            recallTarget = { x: this.width / 2, y: this.height - 80 };
+                            // 母剑不存在或未插在敌人身上，回到玩家位置（[emitter-port] 对齐到素材上沿发射口）
+                            recallTarget = { x: this.width / 2, y: this.height - 102 };
                         }
                         sword.triggerRecall(recallTarget);
                     }

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -738,9 +738,10 @@ phase_gathering_getRandomPegType() {
                  return;
              }
              if (!this.isEnemyTurn && this.ammoQueue.length > 0 && this.projectiles.length === 0 && this.burstQueue.length === 0) {
-                this.isDragging = true; 
-                this.dragStart = new Vec2(this.width / 2, this.height - 80); 
-                this.dragCurrent = logicPos; 
+                this.isDragging = true;
+                // [emitter-port] 发射口位于 emitter_base.png 上沿（Y 轴上移 22px），与发射器素材的视觉发射口对齐
+                this.dragStart = new Vec2(this.width / 2, this.height - 102);
+                this.dragCurrent = logicPos;
                 this.ui.closeDrawer();
             }
         }
@@ -1364,14 +1365,15 @@ phase_gathering_getRandomPegType() {
             }
         }
         // --- 逻辑更新 ---
-        for (let i = this.burstQueue.length - 1; i >= 0; i--) { 
-            const shot = this.burstQueue[i]; 
-            shot.delay -= timeScale; 
-            if (shot.delay <= 0) { 
-                this.spawn_spawnBullet(this.width/2, this.height-80, shot.vel, shot.recipe, shot.shotId, shot.isLast); 
-                audio.playShoot(); 
-                this.burstQueue.splice(i, 1); 
-            } 
+        for (let i = this.burstQueue.length - 1; i >= 0; i--) {
+            const shot = this.burstQueue[i];
+            shot.delay -= timeScale;
+            if (shot.delay <= 0) {
+                // [emitter-port] 子弹从发射器素材的上沿发射口生成（Y 轴上移 22px）
+                this.spawn_spawnBullet(this.width/2, this.height-102, shot.vel, shot.recipe, shot.shotId, shot.isLast);
+                audio.playShoot();
+                this.burstQueue.splice(i, 1);
+            }
         }
         if (this.waveMomentumTimer > 0) this.waveMomentumTimer -= timeScale;
 
@@ -1722,7 +1724,8 @@ phase_gathering_getRandomPegType() {
             }
             // 拖拽瞄准线
             if (this.isDragging && this.projectiles.length === 0 && this.ammoQueue.length > 0 && this.burstQueue.length === 0) {
-                const start = new Vec2(this.width / 2, this.height - 80);
+                // [emitter-port] 瞄准线起点对齐到发射器素材的上沿发射口
+                const start = new Vec2(this.width / 2, this.height - 102);
                 let force = this.lastMousePos.sub(start);
                 
                 if (force.y < -20) {
@@ -1778,10 +1781,11 @@ phase_gathering_getRandomPegType() {
                     this.ctx.restore();
                 }
             } else if (this.projectiles.length === 0) {
-                const start = new Vec2(this.width / 2, this.height - 80);
+                // [emitter-port] 空仓占位炮台对齐到发射器素材的上沿发射口
+                const start = new Vec2(this.width / 2, this.height - 102);
                 this.ctx.save();
                 this.ctx.translate(start.x, start.y);
-                this.ctx.rotate(-Math.PI / 2); 
+                this.ctx.rotate(-Math.PI / 2);
                 this.ctx.fillStyle = '#475569';
                 this.ctx.beginPath();
                 this.ctx.arc(0, 0, 12, 0, Math.PI * 2);
@@ -1947,7 +1951,9 @@ phase_gathering_getRandomPegType() {
         // 应用与实体层相同的视差偏移
         this.ctx.translate(entityShiftX, entityShiftY);
 
+        // [emitter-port] startPos = 发射器底座视觉中心；portPos = 实际发射口（沿素材上沿）
         const startPos = new Vec2(this.width / 2, this.height - 80);
+        const portPos = new Vec2(startPos.x, startPos.y - 22);
         // [bitmap-emitter] 优先使用 emitter_base.png + emitter_charging_*.png 渲染发射器底座；
         // 位图未加载时 fallback 到原始 arc 椭圆。
         this.render_combat_launcherEmitterBase(this.ctx, startPos.x, startPos.y, this.isChargingShot, this.chargeProgress);
@@ -1957,35 +1963,35 @@ phase_gathering_getRandomPegType() {
             const params = Projectile.calculateVisualParams(nextAmmo, false);
             let previewRotation =  -Math.PI / 2;
             let deformation = {x: 1, y: 1};
-            
+
             if (this.isDragging) {
                 const force = this.dragStart.sub(this.dragCurrent);
                 if (force.mag() > 10) {
                     previewRotation = Math.atan2(force.y, force.x) ;
-                    deformation = {x: 1.15, y: 0.85}; 
+                    deformation = {x: 1.15, y: 0.85};
                 }
             }
             if (this.isChargingShot) {
                 const shake = Math.random() * 2; // 吸收时的剧烈抖动
-                startPos.x += (Math.random()-0.5) * shake;
-                startPos.y += (Math.random()-0.5) * shake;
+                portPos.x += (Math.random()-0.5) * shake;
+                portPos.y += (Math.random()-0.5) * shake;
                 // 核心随着能量吸收变大变亮
                 const absorbScale = 1.0 + this.chargeProgress * 0.3;
                 deformation.x *= absorbScale;
                 deformation.y *= absorbScale;
             }
 
-            //先绘制轨道 (Orbitals) -> 这样它就在炮台下面
+            // 轨道仍以发射器底座为圆心绕飞
             this.render_combat_launcherOrbitals(this.ctx, startPos.x, startPos.y, nextAmmo);
 
-            //后绘制炮台核心 (Visuals) -> 这样它就在上面
-            Projectile.drawVisuals(this.ctx, startPos.x, startPos.y, params.radius, nextAmmo, previewRotation, params.intensity, deformation);
+            // 待发射弹药贴在素材上沿的发射口
+            Projectile.drawVisuals(this.ctx, portPos.x, portPos.y, params.radius, nextAmmo, previewRotation, params.intensity, deformation);
 
         } else {
-            // 空仓状态
+            // 空仓状态：占位圈贴在发射口
             this.ctx.fillStyle = '#1e293b';
             this.ctx.beginPath();
-            this.ctx.arc(startPos.x, startPos.y, 10, 0, Math.PI * 2);
+            this.ctx.arc(portPos.x, portPos.y, 10, 0, Math.PI * 2);
             this.ctx.fill();
             this.ctx.strokeStyle = '#475569';
             this.ctx.stroke();

--- a/src/render_system.js
+++ b/src/render_system.js
@@ -18,6 +18,8 @@ import {
     ORBITAL_INTAKE,
     EMITTER_BASE_SRC,
     EMITTER_CHARGING_SRCS,
+    BG_MAIN_CANVAS_SRC,
+    BG_EMITTER_ZONE_SRC,
 } from './bitmap_icons.js';
 
 export const render_system = {
@@ -28,6 +30,25 @@ export const render_system = {
         this.ctx.clearRect(0, 0, this.width, this.height);
         this.ctx.fillStyle = CONFIG.colors.bg;
         this.ctx.fillRect(0, 0, this.width, this.height);
+        // 主底图位图（已生成 720×1280 暗黑赛博炼金风），未加载完成时回退到纯色底
+        const bgMain = getUiBitmap(BG_MAIN_CANVAS_SRC);
+        if (bgMain) {
+            this.ctx.save();
+            this.ctx.globalAlpha = 0.85;
+            this.ctx.drawImage(bgMain, 0, 0, this.width, this.height);
+            this.ctx.restore();
+        }
+        // 发射器区域（底部 220px 高的炼金台层），仅在战斗 / 研磨阶段叠加
+        if (this.phase === 'combat' || this.phase === 'gathering') {
+            const bgEmitter = getUiBitmap(BG_EMITTER_ZONE_SRC);
+            if (bgEmitter) {
+                const zoneH = 220;
+                this.ctx.save();
+                this.ctx.globalAlpha = 0.9;
+                this.ctx.drawImage(bgEmitter, 0, this.height - zoneH, this.width, zoneH);
+                this.ctx.restore();
+            }
+        }
     },
 
 /**

--- a/src/styles/bitmap_ui.css
+++ b/src/styles/bitmap_ui.css
@@ -140,13 +140,22 @@
     60%       { filter: brightness(1.05) drop-shadow(0 0 5px rgba(239,68,68,0.5)); }
 }
 
-/* #phase-rune-launcher 面板底板 */
-/* [BUGFIX] 保留深色底色，让 9-Slice 图片叠加在深色背景上，中心半透明纹理才能正确显示 */
+/* #phase-rune-launcher 面板底板
+   - 外层 overlay 仅作半透明遮罩（避免 border-image 被拉伸到全屏导致比例失真）
+   - 实际 9-Slice 面板贴在内层 .rune-launcher-card 上，宽度根据背景图比例收缩，
+     保证装饰带与中心石板纹理在视觉上贴合内容区域 */
 #phase-rune-launcher {
-    background: rgba(2, 6, 23, 0.95) !important;
-    border-image-source: url('../../assets/ui/panels/popup_panel_9s.png');
-    border-image-slice: 64 64 64 64 fill;
-    border-image-width: 24px;
+    background: rgba(2, 6, 23, 0.92) !important;
+    align-items: center;
+}
+#phase-rune-launcher > .rune-launcher-card {
+    /* 收缩到与 rune_launcher_9s.png（512×768）比例匹配的宽度，最大 384px，避免在大屏被拉伸 */
+    max-width: min(384px, calc(100vw - 24px));
+    margin-left: auto;
+    margin-right: auto;
+    border-image-source: url('../../assets/ui/panels/rune_launcher_9s.png');
+    border-image-slice: 64 64 96 96 fill;
+    border-image-width: 32px 24px 40px 24px;
     border-image-outset: 0;
     border-image-repeat: stretch;
 }
@@ -293,8 +302,8 @@
 /* =====================================================
    §6.3 古代遗物 overlay（#phase-relic）
    - 整面背景：relic_overlay_bg.png（暗紫炼金阵）
-   - 稀有度光环：relic_aura_<tier>.png 通过 ::before 居中绘制
    - 「跳过」按钮金属底板
+   - [移除] 稀有度旋转圆形光环（relic_aura_*.png + relic-aura-rotate 动画）
    ===================================================== */
 #phase-relic {
     background-image:
@@ -304,48 +313,6 @@
     background-position: center, center !important;
     background-repeat: no-repeat, no-repeat !important;
     background-color: #020617 !important;
-}
-
-/* 让 .relic-card 形成独立堆叠上下文，避免 ::after 的 z-index:-1 透出到 #phase-relic 背景之下 */
-.relic-card {
-    isolation: isolate;
-}
-/* 稀有度光环背板：用 ::after 与 index.html 的 .relic-card.legendary::before（shimmer）共存 */
-.relic-card::after {
-    content: '';
-    position: absolute;
-    inset: -32px;
-    background: url('../../assets/ui/sprites/relic_aura_C.png') center/contain no-repeat;
-    pointer-events: none;
-    opacity: 0.85;
-    z-index: -1;
-    animation: relic-aura-rotate 18s linear infinite;
-}
-.relic-card.rare::after {
-    background-image: url('../../assets/ui/sprites/relic_aura_B.png');
-    opacity: 0.9;
-    animation-duration: 14s;
-}
-.relic-card.epic::after {
-    background-image: url('../../assets/ui/sprites/relic_aura_A.png');
-    opacity: 0.95;
-    animation-duration: 11s;
-}
-.relic-card.legendary::after {
-    background-image: url('../../assets/ui/sprites/relic_aura_S.png');
-    opacity: 1;
-    animation-duration: 8s;
-}
-.relic-card.cursed::after {
-    background-image: url('../../assets/ui/sprites/relic_aura_S.png');
-    opacity: 0.7;
-    filter: hue-rotate(-90deg) brightness(0.8);
-    animation-duration: 10s;
-}
-
-@keyframes relic-aura-rotate {
-    0%   { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
 }
 
 /* 遗物跳过按钮：替换原生纯文字链接为金属底板按钮（按 HTML 内嵌的 button 选择器） */
@@ -452,3 +419,30 @@
     background-repeat: no-repeat, no-repeat !important;
     background-color: #020617 !important;
 }
+
+/* =====================================================
+   §1.4 商店页（#phase-shop）— 复用 replace_ammo_bg.png 的炼金工坊俯视构图
+   ===================================================== */
+#phase-shop {
+    background-image:
+        linear-gradient(180deg, rgba(2,6,23,0.62) 0%, rgba(2,6,23,0.86) 100%),
+        url('../../assets/ui/panels/replace_ammo_bg.png') !important;
+    background-size: cover, cover !important;
+    background-position: center, center !important;
+    background-repeat: no-repeat, no-repeat !important;
+    background-color: #020617 !important;
+}
+
+/* =====================================================
+   §1.2 局外元商店主页（#phase-meta）— 复用 relic_overlay_bg.png 暗紫炼金阵
+   ===================================================== */
+#phase-meta {
+    background-image:
+        linear-gradient(180deg, rgba(2,6,23,0.55) 0%, rgba(2,6,23,0.85) 100%),
+        url('../../assets/ui/panels/relic_overlay_bg.png') !important;
+    background-size: cover, cover !important;
+    background-position: center, center !important;
+    background-repeat: no-repeat, no-repeat !important;
+    background-color: #020617 !important;
+}
+


### PR DESCRIPTION
## Summary
- 移除遗物卡片旋转圆形光环
- 符文发射器面板收缩到背景图比例（max 384px，匹配 rune_launcher_9s.png）
- 战斗发射口上移 22px 对齐 emitter_base.png 上沿（保留底座中心绘制底图与轨道）
- 接入未连接的位图: bg_main_canvas.png + bg_emitter_zone.png；#phase-shop / #phase-meta 复用现成 bg
- 同步更新 docs/ui_asset_requirements.md

## Test plan
- [ ] 战斗阶段子弹/瞄准线起点对齐发射器上沿
- [ ] 属性球轨道仍以底座中心绕飞
- [ ] 符文发射器背景图比例正常，不被拉伸到全屏
- [ ] 遗物选择无旋转圆形光环
- [ ] 商店/元商店主页背景到位

https://claude.ai/code/session_012ghcqZEDG5iNTURLsGyAyA