### PR TITLE
fix(combat): 修正战斗阶段瞄准引导线与实际发射角度不一致

### DIFF
--- a/src/game_system.js
+++ b/src/game_system.js
@@ -1913,7 +1913,10 @@ export const game_system = {
 
         if (this.isDragging) {
             this.isDragging = false;
-            const cannonPos = new Vec2(this.width / 2, this.height - 80);
+            // [emitter-port] 发射方向必须以发射口为原点（Y 轴上移 22px），
+            // 与瞄准引导线（game_phase.js:1812）和子弹生成位置（game_phase.js:1457）一致，
+            // 否则瞄准线与实际发射角度会因 22px 视差产生偏差。
+            const cannonPos = new Vec2(this.width / 2, this.height - 102);
             const targetPos = this.lastMousePos;
             const aimVector = targetPos.sub(cannonPos);
             if (aimVector.y < -20) {


### PR DESCRIPTION
## 问题
战斗阶段拖拽瞄准时，松手发射的实际弹道与显示的引导线方向不重合，存在一个轻微但可见的角度偏差。

## 根因
发射器视觉布局拆成「炮台底座」`(width/2, height-80)` 与位于其正上方 22px 的「发射口」`(width/2, height-102)` 两层（`game_phase.js:2065-2067`）。

| 位置 | 使用的原点 | 是否一致 |
|---|---|---|
| 拖拽起始 (`game_phase.js:768`) | `height-102` 发射口 | ✓ |
| 引导线起点 (`game_phase.js:1812`) | `height-102` 发射口 | ✓ |
| 子弹生成位置 (`game_phase.js:1457`) | `height-102` 发射口 | ✓ |
| 速度方向计算 (`game_system.js:1916`) | **`height-80` 炮台底座** | ✗ |

由于速度方向用炮台底座作原点计算，但子弹却在发射口位置生成，存在 22px 的视差，导致引导线方向与实际弹道角度不一致。

## 修复
将 `input_handleInputEnd` 中的 `cannonPos` 从 `height-80` 改为 `height-102`，使速度方向、引导线起点、子弹生成位置三者均以发射口为原点。