### PR TITLE
balance(runeword): 词条平衡调整 + 新增「化弹为剑」词条

### DIFF
--- a/.cursor/rules/runeword_index.md
+++ b/.cursor/rules/runeword_index.md
@@ -21,7 +21,7 @@
 
 | ID | 名称 | 符文组合 | 效果摘要 |
 |---|---|---|---|
-| `runeword_flame_sword` | 炎光剑影 | `rune_pyro_1` × 1 + `rune_pierce_1` × 1 + `rune_pyro_2` × 1 | 穿透敌人时，有概率召唤一道火焰剑光 |
+| `runeword_flame_sword` | 炎光剑影 | `rune_pyro_1` × 1 + `rune_pierce_1` × 1 + `rune_pyro_2` × 1 | 子母飞剑/普通子弹穿透时在命中点生成火焰剑光 AOE 伤害（非爆炸），并对范围内敌人额外升温 |
 | `runeword_armor_piercing_meteor` | 穿甲流星 | `rune_pierce_2` × 1 + `rune_scatter_1` × 1 + `rune_pierce_1` × 1 | 散射出的子弹丸继承 100% 的穿透层数；每级散射子弹伤害额外 +15%；与炎光剑影联动时散射子弹也可触发剑光 |
 | `runeword_blazing_beam` | 炽热光线 | `rune_pyro_1` × 1 + `rune_laser_1` × 1 + `rune_laser_2` × 1 | 激光照射敌人时，每 0.5 秒额外提升敌人温度 |
 | `runeword_lightning_shield` | 雷电护盾 | `rune_lightning_2` × 1 + `rune_bounce_2` × 1 + `rune_bounce_1` × 1 | 弹珠弹射时有概率在自身周围生成静电场 |
@@ -35,11 +35,12 @@
 | `runeword_sword_resonance` | 剑意共鸣 | `rune_pierce_1` × 3 | 解锁飞剑变异；穿透弹珠碰撞穿透钉子时有70% 概率变异为飞剑钉子 |
 | `runeword_storm_resonance` | 风暴共鸣 | `rune_bounce_1` × 3 | 解锁风属性变异；反弹弹珠碰撞反弹钉子时有70% 概率变异为风属性钉子 |
 
-### 1.4 特殊召唤词条（1 个，Task: 召剑之语）
+### 1.4 特殊召唤词条（2 个：召剑之语 / 化弹为剑）
 
 | ID | 名称 | 符文组合 | 效果摘要 |
 |---|---|---|---|
-| `runeword_son_sword_summon` | 召剑之语 | `rune_pierce_2` × 1 + `rune_pierce_1` × 1 + `rune_bounce_1` × 1 | 弹珠每次命中敌人时，有 30% 概率在命中位置召唤一把三级子飞剑；子飞剑继承弹珠属性，遵循原有规则（自动索敌、100% 伤害共鸣、完整属性效果）；词条等级提升时召唤概率额外 +15% |
+| `runeword_son_sword_summon` | 召剑之语 | `rune_pierce_2` × 1 + `rune_pierce_1` × 1 + `rune_bounce_1` × 1 | 弹珠每次命中敌人时，有 7% 概率在命中位置召唤一把三级子飞剑；子飞剑继承弹珠属性（火/冰/雷）；词条等级提升时概率额外 +3%、子飞剑伤害额外 +7% |
+| `runeword_bullet_to_sword` | 化弹为剑 | `rune_pierce_1` × 2 + `rune_bounce_1` × 1 | 首轮发射的子弹被替换为一把子飞剑（取消连射），原连射层数转化为子飞剑攻击次数（maxAttacks = multicast + 1）；词条等级 1/2/3 对应子飞剑 Lv1/Lv2/Lv3 |
 
 ### 1.5 成长型低级词条（6 个，Task A 新增）
 
@@ -47,8 +48,8 @@
 |---|---|---|---|
 | `runeword_bloodthirst_edge` | 嗜血初锋 | `rune_pierce_1` × 2 + `rune_pyro_1` × 1 | 每次击杀敌人，全局基础伤害永久 +1；冰霜与火焰属性层数降低 30% |
 | `runeword_scatter_matrix` | 散射矩阵 | `rune_bounce_1` × 2 + `rune_lightning_1` × 1 | 连射次数全部转化为散射层数；基础伤害降低 25%，散射夹角缩小 70% |
-| `runeword_focused_fire` | 专注射击 | `rune_laser_1` × 2 + `rune_pierce_1` × 1 | 将所有弹跳和连射层数转化为基础伤害；伤害有 20% 概率暴击造成 200% 伤害 |
-| `runeword_mass_collapse` | 质量坍缩 | `rune_bounce_1` × 2 + `rune_pyro_1` × 1 | 强制获得爆炸属性（范围减半）；每清空 1 层连射/散射，爆炸范围 +10% |
+| `runeword_focused_fire` | 专注射击 | `rune_cryo_1` × 2 + `rune_pierce_1` × 1 | 将所有弹跳和连射层数转化为基础伤害；伤害有 20% 概率暴击造成 200% 伤害（不再依赖激光符文） |
+| `runeword_mass_collapse` | 质量坍缩 | `rune_bounce_1` × 2 + `rune_pyro_1` × 1 | 强制获得爆炸属性（范围减半）；只清空所有散射层数（连射保留），每清空 1 层散射爆炸范围 +10% |
 | `runeword_kinetic_decay` | 动能衰变 | `rune_bounce_1` × 2 + `rune_pierce_1` × 1 | 子弹初始获得 25% 伤害加成；每次命中后加成乘以 (1 - 7%) 衰减（最低衰减至 0%） |
 | `runeword_echo_shot` | 回响射击 | `rune_scatter_1` × 2 + `rune_bounce_1` × 1 | 子弹首次击中敌人时，有 25% 概率按原角度额外发射一颗单发子弹 |
 
@@ -77,7 +78,12 @@
 | `mass_collapse` | 质量坍缩 | `src/combat_system.js` 约第 2375 行（配方应用） | `activeRunewordEffects['mass_collapse']`, `finalRecipe._explosionRadiusMult` |
 | `kinetic_decay` | 动能衰变 | `src/entities/projectile.js` 命中逻辑 | `activeRunewordEffects['kinetic_decay']`, `finalRecipe._kineticDecayBonus`, `finalRecipe._kineticDecayRate` |
 | `echo_shot` | 回响射击 | `src/entities/projectile.js` 首次命中逻辑 | `activeRunewordEffects['echo_shot']`, `finalRecipe._echoShotChance`, `projectile._echoShotFired` |
-| `son_sword_summon` | 召剑之语 | `src/combat_system.js` `combat_damageEnemy` 命中后处理段 | `activeRunewordEffects['son_sword_summon']`；触发时调用 `combat_flyingSword_addSon(hitX, hitY, null, 3, swordConfig, 0)` + `combat_flyingSword_assignTarget(enemy)` |
+| `son_sword_summon` | 召剑之语 | `src/combat_system.js` `combat_damageEnemy` 命中后处理段 | `activeRunewordEffects['son_sword_summon']`；params 包含 `triggerChance`/`swordLevel`/`damageMultiplier`，触发时调用 `combat_flyingSword_addSon(hitX, hitY, null, 3, swordConfig, 0)` + `combat_flyingSword_assignTarget(enemy)`；子飞剑伤害 = `bullet.damage × damageMultiplier` |
+| `flame_sword` | 炎光剑影 | `src/combat_system.js` 约第 1762 行（穿透命中后段） | `activeRunewordEffects['flame_sword']`；改为生成 AOE 伤害（非爆炸）：在命中点对 `radius` 范围内敌人造成 `damage × damageRatio` 火属性伤害并升温 `damage × tempDamageRatio` |
+| `mass_collapse` | 质量坍缩 | `src/combat_system.js` 约第 2483 行（配方应用） | `activeRunewordEffects['mass_collapse']`；只清空 `finalRecipe.scatter`（连射保留），`_explosionRadiusMult = baseRadiusRatio + scatter × radiusBonusPerLayer` |
+| `lightning_shield` | 雷电护盾 | `src/combat_system.js` 约第 1791 行 | `activeRunewordEffects['lightning_shield']`；静电场对范围内敌人造成 AOE 伤害并施加感电；命中后**强制以 `chainChanceBonus = 1.0` 调用 `combat_lightning_triggerChain`**，必定触发闪电链 |
+| `frost_nova` | 冰霜新星 | `src/combat_system.js` `combat_triggerFrostNova`；`src/entities/projectile.js` 弹跳 hook | `activeRunewordEffects['frost_nova']`；命中敌人按其当前 `freezeChance = min(100, abs(temp))/2` 链式触发新星，`probMult` 每次链式调用减半，`chainDepth ≤ 8` 安全上限 |
+| `bullet_to_sword` | 化弹为剑 | `src/combat_system.js` 约第 2510 行（recipe 注入）；`src/spawn_system.js` `spawn_spawnBullet` 入口处理 | `activeRunewordEffects['bullet_to_sword']`；写入 `_replaceWithSonSword=true`、`_sonSwordLevel=level`，并在 burst 调度处跳过多重射击；spawn_spawnBullet 入口检测后调用 `combat_flyingSword_addSon` + 自动猎杀 |
 
 ## 3. 词条激活机制
 
@@ -116,3 +122,6 @@
 | `_kineticDecayRate` | number (0~1) | `kinetic_decay` | Projectile 命中 |
 | `_echoShotChance` | number (0~1) | `echo_shot` | Projectile 首次命中（回响子弹中此字段强制为 0，防止无限循环） |
 | `_echoShotFired` | boolean | `echo_shot` | Projectile 实例内部标记（非 recipe 字段），防止同一子弹重复触发 |
+| `_pierceDecayReduction` | number (0~1) | 穿透共鸣 (T2/T3) | 全局穿透衰减消费段（`combat_damageEnemy` 约第 1530 行）：每次穿透命中伤害衰减 35%（最低 15%），`pierceDecayReduction` 减小衰减率 |
+| `_replaceWithSonSword` | boolean | `bullet_to_sword` | `spawn_spawnBullet` 入口判断；触发后改为生成一把 SonSword 而非常规弹丸 |
+| `_sonSwordLevel` | number (1~3) | `bullet_to_sword` | `spawn_spawnBullet` 入口；对应生成的子飞剑等级（词条等级 → 子飞剑 Lv） |

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -1528,6 +1528,21 @@ export const combat_system = {
             }
         }
 
+        // --- [穿透衰减] 每次穿透命中后，伤害衰减 35%（保底 15%），穿透共鸣可减小衰减率 ---
+        // 实现：以已发生的穿透次数 piercesUsed 为指数衰减；_pierceDecayReduction 由 spawn_system.js
+        // 在生成 Projectile 时根据穿透共鸣等级注入（T2: 0.2，T3: 0.4）。
+        if (config.pierce > 0 && projectile.piercesLeft !== undefined && config.type !== 'flying_sword') {
+            const piercesUsed = Math.max(0, config.pierce - projectile.piercesLeft);
+            if (piercesUsed > 0) {
+                const baseDecayRate = 0.35;
+                const decayReduction = Math.min(0.95, Math.max(0, config._pierceDecayReduction || 0));
+                const effectiveDecayRate = baseDecayRate * (1 - decayReduction);
+                const retentionPerHit = 1 - effectiveDecayRate;
+                const decayMult = Math.max(0.15, Math.pow(retentionPerHit, piercesUsed));
+                dmg = dmg * decayMult;
+            }
+        }
+
         // --- [新增] 确定伤害来源类型 (用于统计图表颜色) ---
         let sourceType = 'main';
         if (config.isScatterChild) sourceType = 'scatter';
@@ -1748,7 +1763,7 @@ export const combat_system = {
         };
         const damageColor = colorMap[damageType] || '#ffffff';
 
-        // [Agent D] 炎光剑影词条 Hook：穿透命中时有概率召唤飞剑
+        // [词条 Hook] 炎光剑影：子母飞剑或普通子弹穿透命中时，命中点生成剑光 AOE 伤害（非爆炸）
         // [穿甲流星联动] 当穿甲流星激活时，散射子弹（isScatterChild=true）继承了穿透层数，
         // 因此也应该能触发炎光剑影效果，故此处放开 isCopy 限制（仅针对散射子弹）
         const armorPiercingActive = this.activeRunewordEffects && this.activeRunewordEffects['armor_piercing_meteor'];
@@ -1758,29 +1773,30 @@ export const combat_system = {
                 const triggerChance = (flameSwordFx.params && flameSwordFx.params.triggerChance) || 0;
                 const damageRatio = (flameSwordFx.params && flameSwordFx.params.damageRatio) || 0.5;
                 // @section:damage_runeword_hooks - 符文词条 Hook 注入点
-                // [修复 检查点3] 读取 tempDamageRatio，用于穿透命中时对敌人额外升温
+                // tempDamageRatio：剑光范围内的敌人额外升温（baseDamage * tempDamageRatio）
                 const tempDamageRatio = (flameSwordFx.params && flameSwordFx.params.tempDamageRatio) || 0;
+                const slashRadius = (flameSwordFx.params && flameSwordFx.params.radius) || 110;
                 if (Math.random() < triggerChance) {
-                    // 生成一把火系飞剑，目标为当前被穿透的敌人
-                    const swordConfig = {
-                        damage: Math.ceil(config.damage * damageRatio),
-                        pyro: Math.max(1, config.pyro || 1),
-                        cryo: 0, lightning: 0, wind: 0,
-                        multicast: 0
-                    };
-                    const flameSwordLvl = this.variantLevels ? (this.variantLevels.flying_sword || 1) : 1;
-                    this.combat_flyingSword_addSon(hitX, hitY, null, flameSwordLvl, swordConfig, 0);
-                    this.combat_flyingSword_assignTarget(enemy);
-                    // [修复 检查点3] 额外升温：baseDamage * tempDamageRatio
-                    if (tempDamageRatio > 0) {
-                        const tempAmount = config.damage * tempDamageRatio;
-                        enemy.applyTemp(tempAmount);
-                    }
-                    // [修复 检查点4] 添加 SlashAnim 视觉特效（火焰橙色），与其他飞剑命中特效保持一致
+                    // 复用穿透剑光的 AOE 形态：在命中位置生成一道剑光，对范围内所有敌人造成火属性伤害
+                    const slashDmg = Math.max(1, Math.ceil(config.damage * damageRatio));
+                    const tempAmount = config.damage * tempDamageRatio;
+                    const novaCenter = new Vec2(hitX, hitY);
+                    this.enemies.forEach(other => {
+                        if (other.active && other.pos.dist(novaCenter) < slashRadius) {
+                            const slashResult = other.takeDamage(slashDmg);
+                            this.combat_recordDamage(slashResult.actualDamage, 'pyro', 'main', shotId);
+                            if (slashResult.killed) this.spawn_addScore(other.maxHp);
+                            if (tempAmount > 0) other.applyTemp(tempAmount);
+                            other._pyroHitThisRound = true;
+                        }
+                    });
+                    // 视觉表现：剑光 + 火星 + 浮动文字
                     const slashAngle = Math.random() * Math.PI * 2;
-                    this.spawn_pushParticleWithLimit(new SlashAnim(hitX, hitY, slashAngle, 0.5, '#f97316'));
-                    this.spawn_createParticle(hitX, hitY, '#f97316', 'spark');
-                    this.spawn_createFloatingText(hitX, hitY - 20, '剑光!', '#f97316');
+                    this.spawn_pushParticleWithLimit(new SlashAnim(hitX, hitY, slashAngle, 0.9, '#f97316'));
+                    for (let i = 0; i < 6; i++) {
+                        this.spawn_createParticle(hitX, hitY, '#f97316', 'spark');
+                    }
+                    this.spawn_createFloatingText(hitX, hitY - 20, '🔥剑光!', '#f97316');
                 }
             }
         }
@@ -1820,6 +1836,11 @@ export const combat_system = {
                             if (this.lightningBolts.length < CONFIG.performance[this.perfQualityLevel || 'high'].lightningLimit) {
                                 this.lightningBolts.push(new LightningBolt(hitX, hitY, ne.pos.x, ne.pos.y));
                             }
+                            // [加强] 静电场击中后 100% 触发闪电链（chainChanceBonus = 1 强制 p>=1）
+                            if (ne.active) {
+                                const chainLevel = Math.max(1, (config.lightning || 0) || 1);
+                                this.combat_lightning_triggerChain(ne, staticDmg, [], chainLevel, shotId, 1.0);
+                            }
                         }
                     });
                     this.spawn_createFloatingText(hitX, hitY - 20, '⚡静电场!', '#c084fc');
@@ -1833,12 +1854,13 @@ export const combat_system = {
         if (!projectile.isCopy && config.type !== 'flying_sword' && !config.wind) {
             const sonSwordSummonFx = this.activeRunewordEffects && this.activeRunewordEffects['son_sword_summon'];
             if (sonSwordSummonFx) {
-                const triggerChance = (sonSwordSummonFx.params && sonSwordSummonFx.params.triggerChance) || 0.30;
+                const triggerChance = (sonSwordSummonFx.params && sonSwordSummonFx.params.triggerChance) || 0.07;
                 const swordLevel = (sonSwordSummonFx.params && sonSwordSummonFx.params.swordLevel) || 3;
+                const damageMultiplier = (sonSwordSummonFx.params && sonSwordSummonFx.params.damageMultiplier) || 1.0;
                 if (Math.random() < triggerChance) {
-                    // 子飞剑继承弹珠属性（火/冰/雷），遵循原有规则
+                    // 子飞剑继承弹珠属性（火/冰/雷），遵循原有规则；伤害按词条等级倍率缩放
                     const swordConfig = {
-                        damage: config.damage,
+                        damage: Math.max(1, Math.ceil(config.damage * damageMultiplier)),
                         pyro: config.pyro || 0,
                         cryo: config.cryo || 0,
                         lightning: config.lightning || 0,
@@ -2476,15 +2498,14 @@ export const combat_system = {
             }
 
             // 4. 质量坍缩 (mass_collapse)
-            // 计算 layersCleared = multicast + scatter，清零两者
+            // 仅清零 finalRecipe.scatter（连射层数保留）
             // 设置 finalRecipe.explosive = true
             // @section:fire_projectile_spawn - 子弹实体生成与属性注入
             // 将 _explosionRadiusMult = baseRadiusRatio + layersCleared * radiusBonusPerLayer 写入配方
             const massCollapseFx = this.activeRunewordEffects['mass_collapse'];
             if (massCollapseFx) {
                 const { baseRadiusRatio, radiusBonusPerLayer } = massCollapseFx.params;
-                const layersCleared = (finalRecipe.multicast || 0) + (finalRecipe.scatter || 0);
-                finalRecipe.multicast = 0;
+                const layersCleared = (finalRecipe.scatter || 0);
                 finalRecipe.scatter = 0;
                 finalRecipe.explosive = true;
                 finalRecipe._explosionRadiusMult = baseRadiusRatio + layersCleared * radiusBonusPerLayer;
@@ -2505,6 +2526,17 @@ export const combat_system = {
             if (echoShotFx) {
                 const { triggerChance } = echoShotFx.params;
                 finalRecipe._echoShotChance = triggerChance;
+            }
+
+            // 7. 化弹为剑 (bullet_to_sword)
+            // 将子弹替换为一把子飞剑，连射次数转化为子飞剑攻击次数
+            const bulletToSwordFx = this.activeRunewordEffects['bullet_to_sword'];
+            if (bulletToSwordFx) {
+                const swordLevel = Math.max(1, Math.min(3, Math.floor(bulletToSwordFx.params.swordLevel || 1)));
+                finalRecipe._replaceWithSonSword = true;
+                finalRecipe._sonSwordLevel = swordLevel;
+                // 保留 multicast 数值供 SonSword 构造函数读取（maxAttacks = multicast + 1），
+                // 但下方的 burstQueue 多次发射会通过 _replaceWithSonSword 标记跳过。
             }
         }
         // --- [符文词条-A] 拦截逻辑结束 ---
@@ -2535,16 +2567,18 @@ export const combat_system = {
         // 但 focused_fire/mass_collapse/multicast_to_scatter 等词条会将 multicast 清零，
         // 导致 recipe.multicast=0 传入状态机时 totalDuration 计算错误。
         finalRecipe._originalMulticast = this.currentSession ? (this.currentSession.multicast || 0) : (finalRecipe.multicast || 0);
-        const isOnlyOne = !(finalRecipe.multicast > 0 && finalRecipe.type != 'flying_sword' && !finalRecipe.wind);
-        this.burstQueue.push({ delay: 0, vel: vel, recipe: finalRecipe, shotId: shotId, isLast: isOnlyOne }); 
-        
+        // [词条 Hook] 化弹为剑：取消连射，连射次数将作为子飞剑攻击次数
+        const isReplacedSword = !!finalRecipe._replaceWithSonSword;
+        const isOnlyOne = isReplacedSword || !(finalRecipe.multicast > 0 && finalRecipe.type != 'flying_sword' && !finalRecipe.wind);
+        this.burstQueue.push({ delay: 0, vel: vel, recipe: finalRecipe, shotId: shotId, isLast: isOnlyOne });
+
         // 多重射击
-        if (finalRecipe.multicast > 0 && finalRecipe.type != 'flying_sword' && !finalRecipe.wind) {
-            for(let i=1; i<=finalRecipe.multicast; i++) { 
+        if (!isReplacedSword && finalRecipe.multicast > 0 && finalRecipe.type != 'flying_sword' && !finalRecipe.wind) {
+            for(let i=1; i<=finalRecipe.multicast; i++) {
                 const isLastInBurst = (i === finalRecipe.multicast);
-                this.burstQueue.push({ delay: i * 20, vel: vel, recipe: finalRecipe, shotId: shotId, isLast: isLastInBurst }); 
-            } 
-        } 
+                this.burstQueue.push({ delay: i * 20, vel: vel, recipe: finalRecipe, shotId: shotId, isLast: isLastInBurst });
+            }
+        }
     },
 
 /**
@@ -2800,6 +2834,68 @@ export const combat_system = {
      *   触发条件：irradiation 词条（持续照射累积伤害）或 blazing_beam 词条（持续升温）激活时启动。
      * @param {number} timeScale - 当前帧时间缩放（通常为 1）
      */
+    /**
+     * @method combat_triggerFrostNova
+     * @description 在指定位置触发一次冰霜新星：对范围内敌人造成冰属性伤害与降温，
+     *   并按敌人当前冻结概率进行链式触发（每次链式触发概率减半，避免无限链）。
+     * @param {Vec2} centerPos - 新星中心位置
+     * @param {Object} sourceConfig - 触发源配方（用于计算 novaDmg = damage * damageRatio）
+     * @param {Object} novaParams - 来自 frost_nova 词条的 effectiveParams（radius/tempDrop/damageRatio）
+     * @param {number} probMult - 链式触发概率倍率（每次链式调用减半，初始 = 1.0）
+     * @param {number} chainDepth - 当前链深度，仅用于安全限制，避免极端递归
+     */
+    combat_triggerFrostNova(centerPos, sourceConfig, novaParams, probMult = 1.0, chainDepth = 0) {
+        if (!centerPos || !novaParams) return;
+        if (chainDepth > 8) return; // 安全上限，防止极端情况下无限递归
+
+        const novaRadius = novaParams.radius || 80;
+        const tempDrop = novaParams.tempDrop || 10;
+        const damageRatio = novaParams.damageRatio || 0.30;
+        const baseDmg = (sourceConfig && sourceConfig.damage) || 0;
+        const novaDmg = Math.max(1, Math.floor(baseDmg * damageRatio));
+
+        // 视觉特效：冰蓝冲击波
+        this.spawn_createShockwave(centerPos.x, centerPos.y, '#06b6d4');
+        for (let i = 0; i < 8; i++) {
+            this.spawn_createParticle(centerPos.x, centerPos.y, '#a5f3fc', 'shard');
+        }
+
+        // 收集本次将链式触发的命中点（先扫描完再触发，避免遍历期间敌人状态被反复改写）
+        const chainPositions = [];
+
+        this.enemies.forEach(ne => {
+            if (!ne.active) return;
+            if (centerPos.dist(ne.pos) >= novaRadius) return;
+
+            ne.applyTemp(-tempDrop);
+            ne._cryoHitThisRound = true;
+
+            if (novaDmg > 0) {
+                const novaResult = ne.takeDamage(novaDmg);
+                this.combat_recordDamage(novaResult.actualDamage, 'cryo', 'main', null);
+                if (novaResult.killed && typeof this.spawn_addScore === 'function') {
+                    this.spawn_addScore(ne.maxHp);
+                }
+            }
+
+            // 按敌人当前冻结概率进行链式触发；每次链式调用概率倍率减半
+            const freezeChancePct = Math.min(100, Math.abs(ne.temp || 0)) / 2; // 0~50（百分比）
+            const chainProb = (freezeChancePct / 100) * probMult;
+            if (chainProb > 0 && Math.random() < chainProb) {
+                chainPositions.push(new Vec2(ne.pos.x, ne.pos.y));
+            }
+        });
+
+        if (typeof this.spawn_createFloatingText === 'function') {
+            this.spawn_createFloatingText(centerPos.x, centerPos.y - 20, '❄️ FROST NOVA!', '#a5f3fc');
+        }
+
+        // 链式触发（每次概率减半），独立 sourceConfig，伤害基数沿用原始 baseDmg
+        chainPositions.forEach(p => {
+            this.combat_triggerFrostNova(p, sourceConfig, novaParams, probMult * 0.5, chainDepth + 1);
+        });
+    },
+
     // --- [修复] 剑刃风暴定期更新逻辑 ---
     combat_bladeStorm_update(timeScale) {
         const bladeStormFx = this.activeRunewordEffects && this.activeRunewordEffects['blade_storm'];

--- a/src/entities.js
+++ b/src/entities.js
@@ -3494,6 +3494,9 @@ class SonSword {
              if (isInside) {
                  this.dashTimer = this.dashOvershoot;
                  // [修复] 冲刺中持续检查碰撞，但每个敌人只造成一次伤害
+                 // [平衡] 三级子飞剑冲刺剑痕命中（除主目标外）仅触发 20% 的伤害与属性效果
+                 const isLevel3 = this.level >= 3;
+                 const markRatio = 0.20;
                  for (let e of enemies) {
                      if (e.active && !this.hitEnemiesInDash.has(e)) {
                          const dx = this.pos.x - e.pos.x;
@@ -3502,11 +3505,22 @@ class SonSword {
                          const hitDist = (e.width/2 + 15);
                          if (distSq < hitDist * hitDist) {
                              this.hitEnemiesInDash.add(e);
-                             game.combat_damageEnemy(e, { config: this.config, pos: this.pos, isCopy: true });
+                             const isMark = (e !== this.passingThroughEnemy);
+                             let cfgForHit = this.config;
+                             if (isLevel3 && isMark) {
+                                 cfgForHit = {
+                                     ...this.config,
+                                     damage: Math.max(1, Math.ceil((this.config.damage || 0) * markRatio)),
+                                     pyro: Math.floor((this.config.pyro || 0) * markRatio),
+                                     cryo: Math.floor((this.config.cryo || 0) * markRatio),
+                                     lightning: Math.floor((this.config.lightning || 0) * markRatio)
+                                 };
+                             }
+                             game.combat_damageEnemy(e, { config: cfgForHit, pos: this.pos, isCopy: true });
                              // [限制] SlashAnim 受全局粒子上限约束
                              game.spawn_pushParticleWithLimit(new SlashAnim(this.pos.x, this.pos.y, this.angle, 0.4));
                              audio.playSlash();
-                             
+
                              // [新增] 冲刺中击中敌人也消耗攻击次数
                              this.attacksLeft--;
                              if (this.attacksLeft <= 0) {

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -333,41 +333,23 @@ class Projectile {
                 // ─────────────────────────────────────────────────────────────────────
                 // [词条 Hook] 冰霜新星（frost_nova）
                 // 效果：每经过 bounceInterval 次弹跳，触发一次冰霜新星（范围冰冻）
-                // 实现：维护 this._frostNovaBounceCount 计数器，每次弹跳时自增
+                // 加强：被新星命中的敌人按其当前冻结概率额外触发一次新星，链式触发概率每次减半。
+                // 链式逻辑由 combat_triggerFrostNova 实现，确保与首次触发表现一致。
                 // ─────────────────────────────────────────────────────────────────────
                 if (typeof game !== 'undefined' && game.activeRunewordEffects) {
                     const frostNovaEffect = game.activeRunewordEffects['frost_nova'];
                     if (frostNovaEffect) {
                         if (!this._frostNovaBounceCount) this._frostNovaBounceCount = 0;
                         this._frostNovaBounceCount++;
-                        // 参数字段：requiredBounces（触发所需弹跳次数）、radius（范围）、tempDrop（降温量）、damageRatio（伤害比例）
                         const requiredBounces = Math.max(1, Math.floor(frostNovaEffect.params.requiredBounces || 5));
-                        if (this._frostNovaBounceCount % requiredBounces === 0) {
-                            // 触发冰霜新星：对周围所有敌人施加冰冻状态
-                            const novaRadius = frostNovaEffect.params.radius || 80;
-                            const tempDrop = frostNovaEffect.params.tempDrop || 10;
-                            const damageRatio = frostNovaEffect.params.damageRatio || 0.30;
-                            const novaDmg = Math.max(1, Math.floor(this.config.damage * damageRatio));
-                            // 视觉特效：冰蓝冲击波
-                            game.spawn_createShockwave(this.pos.x, this.pos.y, '#06b6d4');
-                            for (let i = 0; i < 8; i++) {
-                                game.spawn_createParticle(this.pos.x, this.pos.y, '#a5f3fc', 'shard');
-                            }
-                            // 对范围内所有敌人施加冰冻和伤害
-                            game.enemies.forEach(ne => {
-                                if (ne.active && this.pos.dist(ne.pos) < novaRadius) {
-                                    ne.applyTemp(-tempDrop);
-                                    ne._cryoHitThisRound = true; // 标记冰属性命中（供元素聚变使用）
-                                    // 附加冰霜伤害
-                                    if (novaDmg > 0) {
-                                        const novaResult = ne.takeDamage(novaDmg);
-                                        game.combat_recordDamage(novaResult.actualDamage, 'cryo', 'main', null);
-                                    }
-                                }
-                            });
-                            game.spawn_createFloatingText(
-                                this.pos.x, this.pos.y - 20,
-                                `❄️ FROST NOVA!`, '#a5f3fc'
+                        if (this._frostNovaBounceCount % requiredBounces === 0
+                            && typeof game.combat_triggerFrostNova === 'function') {
+                            game.combat_triggerFrostNova(
+                                new Vec2(this.pos.x, this.pos.y),
+                                this.config,
+                                frostNovaEffect.params || {},
+                                1.0,
+                                0
                             );
                         }
                     }
@@ -564,8 +546,8 @@ class Projectile {
 
     performSlashAttack(target, enemies) {
         const angle = Math.random() * Math.PI * 2;
-        const length = 160; 
-        const width = 40;   
+        const length = 160;
+        const width = 40;
         const center = target.pos;
         const halfLen = length / 2;
         const dir = new Vec2(Math.cos(angle), Math.sin(angle));
@@ -574,7 +556,7 @@ class Projectile {
 
         if (typeof game !== 'undefined') {
             let slashColor = CONFIG.colors.flying_sword || '#0ea5e9';
-            if (this.config.lightning > 0) slashColor = '#c084fc'; 
+            if (this.config.lightning > 0) slashColor = '#c084fc';
             else if (this.config.pyro > 0) slashColor = '#f97316';
             else if (this.config.cryo > 0) slashColor = '#06b6d4';
             // [限制] SlashEffect 受全局粒子上限约束
@@ -582,29 +564,39 @@ class Projectile {
             audio.playSlash();
         }
 
+        // [平衡] 三级子飞剑的剑痕仅对非主目标触发 20% 的伤害与属性效果
+        const swordLevel = (this.config.level || 1);
+        const isLevel3 = swordLevel >= 3;
+        const markRatio = 0.20;
+
         enemies.forEach(other => {
             if (!other.active) return;
             const E = other.pos;
-            const AB = p2.sub(p1);      
-            const AE = E.sub(p1);       
+            const AB = p2.sub(p1);
+            const AE = E.sub(p1);
             const lenSq = AB.dot(AB);
             let t = (lenSq === 0) ? -1 : AE.dot(AB) / lenSq;
             t = Math.max(0, Math.min(1, t));
             const closest = p1.add(AB.mult(t));
-            const dist = E.dist(closest); 
+            const dist = E.dist(closest);
             const hitRadius = (other.width / 2) + (width / 2);
             if (dist < hitRadius) {
                 const fsCfg = CONFIG.mechanics.flying_sword;
+                const isMark = (other !== target);
+                const ratio = (isLevel3 && isMark) ? markRatio : 1.0;
                 const slashConfig = {
                     ...this.config,
-                    damage: Math.ceil(this.config.damage * fsCfg.dashDamageMult)
+                    damage: Math.max(1, Math.ceil(this.config.damage * fsCfg.dashDamageMult * ratio)),
+                    pyro: Math.floor((this.config.pyro || 0) * ratio),
+                    cryo: Math.floor((this.config.cryo || 0) * ratio),
+                    lightning: Math.floor((this.config.lightning || 0) * ratio)
                 };
                 game.combat_damageEnemy(other, {
                     config: slashConfig,
-                    pos: closest, 
+                    pos: closest,
                     isCopy: true
                 });
-                if (other !== target) {
+                if (isMark) {
                     other.addSwordMark(1);
                 }
             }

--- a/src/rune_config.js
+++ b/src/rune_config.js
@@ -284,9 +284,9 @@ const RUNEWORD_DB = [
         name: '炎光剑影',
         effectId: 'flame_sword',
         pattern: ['rune_pyro_1', 'rune_pierce_1', 'rune_pyro_2'],
-        effect_desc: '【穿透系】穿透敌人时，有概率召唤一道火焰剑光。',
-        baseParams: { triggerChance: 0.30, damageRatio: 0.60, tempDamageRatio: 0.10 },
-        perLevelParams: { triggerChance: 0.10, damageRatio: 0, tempDamageRatio: 0.05 }
+        effect_desc: '【穿透系】子母飞剑穿透敌人时，命中点生成一道剑光 AOE 伤害（非爆炸），并对范围内敌人额外升温。',
+        baseParams: { triggerChance: 0.30, damageRatio: 0.60, tempDamageRatio: 0.10, radius: 110 },
+        perLevelParams: { triggerChance: 0.10, damageRatio: 0.10, tempDamageRatio: 0.05, radius: 15 }
     },
     {
         id: 'runeword_armor_piercing_meteor',
@@ -375,7 +375,7 @@ const RUNEWORD_DB = [
         id: 'runeword_focused_fire',
         name: '专注射击',
         effectId: 'focused_fire',
-        pattern: ['rune_laser_1', 'rune_pierce_1', 'rune_laser_1'],
+        pattern: ['rune_cryo_1', 'rune_pierce_1', 'rune_cryo_1'],
         effect_desc: '将所有弹跳和连射层数转化为基础伤害。伤害有 20% 概率暴击，造成 200% 伤害。',
         baseParams: { critChance: 0.20, critDamage: 2.0 },
         perLevelParams: { critChance: 0.10, critDamage: 0.5 }
@@ -385,7 +385,7 @@ const RUNEWORD_DB = [
         name: '质量坍缩',
         effectId: 'mass_collapse',
         pattern: ['rune_bounce_1', 'rune_pyro_1', 'rune_bounce_1'],
-        effect_desc: '强制获得爆炸属性（范围减半）。清空连射与散射，每清空 1 层，爆炸范围 +10%。',
+        effect_desc: '强制获得爆炸属性（范围减半）。清空所有散射层数，每清空 1 层散射，爆炸范围 +10%。',
         baseParams: { baseRadiusRatio: 0.5, radiusBonusPerLayer: 0.10 },
         perLevelParams: { baseRadiusRatio: 0.2, radiusBonusPerLayer: 0.05 }
     },
@@ -414,9 +414,20 @@ const RUNEWORD_DB = [
         name: '召剑之语',
         effectId: 'son_sword_summon',
         pattern: ['rune_pierce_2', 'rune_pierce_1', 'rune_bounce_1'],
-        effect_desc: '【特殊系】弹珠每次命中敌人时，有 30% 概率在命中位置召唤一把三级子飞剑。子飞剑遵循原有规则：自动索敌、全伤害共鸣（100%）、完整属性效果（火/冰/雷）。词条等级提升时，召唤概率额外 +15%。',
-        baseParams: { triggerChance: 0.30, swordLevel: 3 },
-        perLevelParams: { triggerChance: 0.15, swordLevel: 0 }
+        effect_desc: '【特殊系】弹珠每次命中敌人时，有 7% 概率在命中位置召唤一把三级子飞剑。子飞剑继承弹珠属性（火/冰/雷）。词条等级提升时，召唤概率 +3%，子飞剑伤害额外 +7%。',
+        baseParams: { triggerChance: 0.07, swordLevel: 3, damageMultiplier: 1.0 },
+        perLevelParams: { triggerChance: 0.03, swordLevel: 0, damageMultiplier: 0.07 }
+    },
+
+    // ---- 特殊变换词条 (Task: 化弹为剑) ----
+    {
+        id: 'runeword_bullet_to_sword',
+        name: '化弹为剑',
+        effectId: 'bullet_to_sword',
+        pattern: ['rune_pierce_1', 'rune_bounce_1', 'rune_pierce_1'],
+        effect_desc: '【穿透系】首轮发射的子弹被替换为子飞剑（取消连射）。原连射层数转化为子飞剑攻击次数。词条等级对应子飞剑等级（Lv1/Lv2/Lv3）。',
+        baseParams: { swordLevel: 1 },
+        perLevelParams: { swordLevel: 1 }
     }
 ];
 

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -1161,20 +1161,51 @@ export const spawn_system = {
 
         // 初始化伤害统计结构 (支持二维统计: 伤害类型 -> 来源类型)
         if (!this.shotDamageMap.has(shotId)) {
-            this.shotDamageMap.set(shotId, { 
-                total: 0, 
-                projectileCount: 0, 
-                destroyedCount: 0, 
+            this.shotDamageMap.set(shotId, {
+                total: 0,
+                projectileCount: 0,
+                destroyedCount: 0,
                 // 修改：byAttr 存储为二维对象 { 'pyro': { 'main': 0, 'scatter': 0 }, ... }
-                byAttr: {} 
+                byAttr: {}
             });
-            
+
             // 绑定到当前 Game 实例的临时变量，供 UI 实时显示
             this.currentShotDamage = 0;
-            this.currentShotDamageByAttr = {}; 
+            this.currentShotDamageByAttr = {};
         }
-        
+
         const shotStats = this.shotDamageMap.get(shotId);
+
+        // [词条 Hook] 化弹为剑（bullet_to_sword）
+        // 将首轮发射的子弹替换为一把子飞剑，自动索敌；连射层数→子飞剑攻击次数（maxAttacks=multicast+1）
+        if (recipe._replaceWithSonSword) {
+            const swordLevel = Math.max(1, Math.min(3, Math.floor(recipe._sonSwordLevel || 1)));
+            const swordConfig = {
+                ...recipe,
+                type: 'flying_sword',
+                wind: 0,
+                scatter: 0,
+                level: swordLevel
+            };
+            if (typeof this.combat_flyingSword_addSon === 'function') {
+                const beforeCount = this.sonSwords.length;
+                this.combat_flyingSword_addSon(x, y, null, swordLevel, swordConfig, 0);
+                // 让新生成的子飞剑自动猎杀（仅作用于刚刚追加的剑）
+                if (this.sonSwords.length > beforeCount) {
+                    const newSword = this.sonSwords[this.sonSwords.length - 1];
+                    if (newSword) {
+                        newSword.isAutoHunting = true;
+                        if (typeof newSword.searchForTarget === 'function' && this.enemies && this.enemies.length > 0) {
+                            newSword.searchForTarget(this.enemies);
+                        }
+                    }
+                }
+                if (typeof this.spawn_createFloatingText === 'function') {
+                    this.spawn_createFloatingText(x, y - 30, '⚔️化弹为剑!', '#a78bfa');
+                }
+            }
+            return;
+        }
 
         // [关键] 属性优先级：飞剑 > 激光
         // 如果是飞剑，优先处理飞剑逻辑

--- a/src/systems.js
+++ b/src/systems.js
@@ -1062,7 +1062,7 @@ const TRAINING_SCENARIOS = {
             runewordLevel: 1,
             name: '冰霜新星',
             icon: '💠',
-            desc: '[冰霜系] 彈珠每彈跳 5 次，釋放一次冰霜新星，造成冰屬性傷害並降溫。建議使用高彈跳屬性子彈測試。',
+            desc: '[冰霜系] 彈珠每彈跳 5 次，釋放一次冰霜新星，造成冰屬性傷害並降溫；被冰霜新星击中的敌人按当前冻结概率链式触发新一轮新星，每次链式概率减半。建議配合高彈跳与低温敵人測試链式触发。',
             setup: (game) => {
                 const w = game.enemyWidth, h = game.enemyHeight, top = game.combatGridTopY;
                 for (let r = 0; r < 3; r++) {
@@ -1132,7 +1132,7 @@ const TRAINING_SCENARIOS = {
             runewordLevel: 1,
             name: '專注射擊',
             icon: '🎯',
-            desc: '[專注系] 將所有彈跳和連射層數轉化為基礎傷害。傷害有 20% 機率暴擊，造成 200% 傷害。建護配合高彈跳屬性測試。',
+            desc: '[專注系] 符文配方已改为「寒冰 + 穿刺」（不再依赖激光）。將所有彈跳和連射層數轉化為基礎傷害；傷害有 20% 機率暴擊，造成 200% 傷害。建議配合高彈跳屬性測試。',
             setup: (game) => {
                 const x = 2.5 * game.enemyWidth + game.enemyWidth / 2;
                 const y = game.combatGridTopY + 1 * game.enemyHeight + game.enemyHeight / 2;
@@ -1153,7 +1153,7 @@ const TRAINING_SCENARIOS = {
             runewordLevel: 1,
             name: '質量崩塌',
             icon: '💣',
-            desc: '[爆炸系] 強制獲得爆炸屬性（範圍減半）。清空連射與散射，每清空 1 層，爆炸範圍 +10%。建護配合高連射/散射屬性測試。',
+            desc: '[爆炸系] 強制獲得爆炸屬性（範圍減半）。仅清空所有散射層數（連射保留），每清空 1 層散射爆炸範圍 +10%。建議配合高散射屬性測試。',
             setup: (game) => {
                 const w = game.enemyWidth, h = game.enemyHeight, top = game.combatGridTopY;
                 for (let r = 0; r < 3; r++) {
@@ -1271,7 +1271,7 @@ const TRAINING_SCENARIOS = {
             runewordLevel: 1,
             name: '炎光劍影',
             icon: '🔥',
-            desc: '[穿透系] 穿透敵人時，有 30% 機率召喚一道火焰劍光。建護配合高穿透屬性測試。',
+            desc: '[穿透系] 子母飞剑/普通子彈穿透敵人時，有 30% 機率在命中位置生成一道剑光 AOE 伤害（非爆炸），并对范围内敌人额外升温。建議配合高穿透與高伤害子彈測試。',
             setup: (game) => {
                 const x = 2.5 * game.enemyWidth + game.enemyWidth / 2;
                 for (let i = 0; i < 4; i++) {
@@ -1411,7 +1411,7 @@ const TRAINING_SCENARIOS = {
             runewordLevel: 1,
             name: '雷電護盾',
             icon: '🛡️',
-            desc: '[復合系] 彈珠彈射時有 15% 機率在自身周圍生成靜電場。建護配合高彈跳屬性測試。',
+            desc: '[復合系] 彈珠彈射時有 15% 機率在自身周圍生成靜電場；被靜電場击中的敌人 100% 觸發闪电链。建議配合高彈跳/低层闪电属性測試。',
             setup: (game) => {
                 const w = game.enemyWidth, h = game.enemyHeight, top = game.combatGridTopY;
                 game.enemies.push(
@@ -1486,6 +1486,47 @@ const TRAINING_SCENARIOS = {
             bulletConfig: { damage: 20, bounce: 8, pierce: 0, scatter: 0, multicast: 0, pyro: 0, cryo: 0, lightning: 0, wind: 0, isLaser: false, isMatryoshka: false, type: 'normal' },
             demoAction: (game, tg) => {
                 const vel = new Vec2(3, -15);
+                game.spawn_spawnBullet(game.width / 2, game.height - 100, vel, { ...tg.bulletConfig }, null, true);
+            }
+        },
+        {
+            id: 'rw_bullet_to_sword',
+            categoryId: 'runeword',
+            runewordId: 'runeword_bullet_to_sword',
+            runewordLevel: 1,
+            name: '化彈為劍',
+            icon: '⚔️',
+            desc: '[穿透系] 首輪發射的子彈被替換為一把子飛劍（取消連射），原連射層數轉為子飛劍攻擊次數；詞條等級對應子飛劍等級（Lv1/Lv2/Lv3）。建議搭配高連射屬性測試攻擊次數。',
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight, top = game.combatGridTopY;
+                for (let r = 0; r < 3; r++) {
+                    for (let c = 1; c < 5; c++) {
+                        game.enemies.push(new Enemy((c + 0.5) * w + w/2, top + r * h + h/2, 60, 60, 600));
+                    }
+                }
+            },
+            bulletConfig: { damage: 20, bounce: 0, pierce: 1, scatter: 0, multicast: 4, pyro: 0, cryo: 0, lightning: 0, wind: 0, isLaser: false, isMatryoshka: false, type: 'normal' },
+            demoAction: (game, tg) => {
+                // 通过 fireBulletWithEffects 走正规流程，确保 bullet_to_sword 词条 hook 被应用：
+                // 子弹被替换为一把子飞剑，maxAttacks = multicast + 1 = 5
+                tg.fireBulletWithEffects(tg.bulletConfig);
+            }
+        },
+        {
+            id: 'rw_pierce_decay',
+            categoryId: 'attribute',
+            name: '穿透衰減',
+            icon: '📉',
+            desc: '[平衡] 穿透子弹每次穿透命中后伤害衰减 35%（最低保留 15% 基础伤害）；穿透共鸣 T2/T3 可降低衰减率（T2 -20%，T3 -40%）。建议配合高穿透层数子弹测试逐次衰减。',
+            setup: (game) => {
+                const x = 2.5 * game.enemyWidth + game.enemyWidth / 2;
+                for (let i = 0; i < 6; i++) {
+                    game.enemies.push(new Enemy(x, game.combatGridTopY + i * game.enemyHeight + game.enemyHeight / 2, 60, 60, 800));
+                }
+            },
+            bulletConfig: { damage: 100, bounce: 0, pierce: 8, scatter: 0, multicast: 0, pyro: 0, cryo: 0, lightning: 0, wind: 0, isLaser: false, isMatryoshka: false, type: 'normal' },
+            demoAction: (game, tg) => {
+                const vel = new Vec2(0, -15);
                 game.spawn_spawnBullet(game.width / 2, game.height - 100, vel, { ...tg.bulletConfig }, null, true);
             }
         },

--- a/src/ui/rune_launcher.js
+++ b/src/ui/rune_launcher.js
@@ -1285,7 +1285,7 @@ export const rune_launcher_system = {
                 const radius = calc('radius');
                 const ratio = Math.round(calc('damageRatio') * 100);
                 const tempDrop = calc('tempDrop');
-                return `每弹跳 ${bounces} 次释放冰霜新星，范围 ${radius}px，冒冰伤害 ${ratio}%，降温 ${tempDrop}`;
+                return `每弹跳 ${bounces} 次释放冰霜新星，范围 ${radius}px，冰伤害 ${ratio}%，降温 ${tempDrop}；被命中敌人按当前冻结概率链式触发新星（每次链式概率减半）`;
             }
             case 'thunderstorm': {
                 const decay = Math.round(calc('decayBonus') * 100);
@@ -1307,7 +1307,8 @@ export const rune_launcher_system = {
                 const chance = Math.round(calc('triggerChance') * 100);
                 const ratio = Math.round(calc('damageRatio') * 100);
                 const tempRatio = Math.round(calc('tempDamageRatio') * 100);
-                return `穿透触发率 ${chance}%，剑光伤害 ${ratio}%，附加火焰伤害 ${tempRatio}%`;
+                const radius = Math.round(calc('radius') || 110);
+                return `子母剑穿透触发率 ${chance}%，剑光 AOE 范围 ${radius}px，伤害 ${ratio}%，附加升温 ${tempRatio}%`;
             }
             case 'armor_piercing_meteor': {
                 const bonus = Math.round(calc('damageBonus') * 100);
@@ -1323,7 +1324,7 @@ export const rune_launcher_system = {
                 const chance = Math.round(calc('triggerChance') * 100);
                 const ratio = Math.round(calc('damageRatio') * 100);
                 const stacks = calc('shockStacks');
-                return `弹跳触发率 ${chance}%，静电场伤害 ${ratio}%，附加 ${stacks} 层闪电`;
+                return `弹跳触发率 ${chance}%，静电场伤害 ${ratio}%，附加 ${stacks} 层闪电；被静电场击中后必定触发闪电链`;
             }
             case 'blade_storm': {
                 const radius = calc('radius');
@@ -1334,6 +1335,27 @@ export const rune_launcher_system = {
             case 'elemental_fusion': {
                 const ratio = Math.round(calc('trueDamageRatio') * 100);
                 return `元素聚变爆炸，真实伤害 = 敌人最大血量 × ${ratio}%`;
+            }
+            case 'focused_fire': {
+                const chance = Math.round(calc('critChance') * 100);
+                const dmg = Math.round(calc('critDamage') * 100);
+                return `所有弹跳/连射层数转化为基础伤害；${chance}% 暴击率，造成 ${dmg}% 伤害`;
+            }
+            case 'mass_collapse': {
+                const baseRatio = Math.round(calc('baseRadiusRatio') * 100);
+                const perLayer = Math.round(calc('radiusBonusPerLayer') * 100);
+                return `强制爆炸（基础范围 ${baseRatio}%）；清空所有散射，每清空 1 层散射爆炸范围 +${perLayer}%`;
+            }
+            case 'son_sword_summon': {
+                const chance = Math.round(calc('triggerChance') * 100);
+                const lv = calc('swordLevel') || 3;
+                const dmgBonus = Math.round((calc('damageMultiplier') - 1) * 100);
+                return `命中触发率 ${chance}%，召唤一把 Lv${lv} 子飞剑（伤害继承 ${100 + dmgBonus}%）`;
+            }
+            case 'bullet_to_sword': {
+                const lv = calc('swordLevel') || 1;
+                const cap = Math.min(3, Math.max(1, lv));
+                return `首轮发射的子弹替换为 Lv${cap} 子飞剑（取消连射），原连射层数转为子飞剑攻击次数`;
             }
             default:
                 return '';


### PR DESCRIPTION
## Summary

按用户需求批量调整词条平衡 + 新增 1 个特殊词条。

### 词条调整
- **专注射击**：移除激光符文，配方改为「寒冰×2 + 穿刺」
- **炎光剑影**：不再召唤子飞剑，改为复用子母剑穿透敌人时的 AOE 伤害（非爆炸），并对范围内敌人额外升温
- **三级子飞剑剑痕**：对非主目标仅触发 20% 的伤害与属性效果
- **召剑之语**：触发概率降至 7%（升级 +3%），新增 damageMultiplier（升级 +7% 子飞剑伤害）
- **质量坍缩**：仅清空散射层数（连射保留），每清空 1 层散射爆炸范围 +10%
- **穿透衰减**（新机制）：每次穿透命中后伤害衰减 35%（最低保留 15%），穿透共鸣 T2/T3 减小衰减率
- **雷电护盾**：静电场击中后 100% 触发闪电链
- **冰霜新星**：被命中敌人按当前冻结概率链式触发新一轮新星，链式概率每次减半，深度上限 8 层

### 新增词条
- **化弹为剑** (runeword_bullet_to_sword)：配方 rune_pierce_1×2 + rune_bounce_1×1。首轮发射的子弹被替换为子飞剑（取消连射），原连射层数 → 子飞剑攻击次数；词条等级 1/2/3 对应子飞剑 Lv1/Lv2/Lv3。

### 同步更新
- src/ui/rune_launcher.js 动态描述
- src/systems.js 试炼场场景
- .cursor/rules/runeword_index.md 文档与字段索引

## Test plan

- [x] 全部 JS 文件通过 node --check 语法校验
- [x] node tests/validate_scenarios.js 41/41 通过
- [ ] 浏览器实机：穿透衰减 / 化弹为剑 / 冰霜新星链式 / 雷电护盾闪电链