### PR TITLE
feat(combat): 围墙清空触发抽奖与精英援军刷新

### DIFF
--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -631,6 +631,9 @@ phase_gathering_getRandomPegType() {
         }
         // [perfect-clear-upgrade] 重置「本回合是否已触发蓄能升级」标志
         this._chargeUpgradeApplied = false;
+        // [in-wall-clear-lottery] 重置「本回合是否已触发围墙清空抽奖」标志
+        this._inWallClearTriggered = false;
+        this._inWallClearLotteryActive = false;
 
         // [bullet-charge-fix] 拍摄本回合实际进入战斗的 ammoQueue 快照，作为下回合
         // 「子弹充能 / 精华触发时的充能子弹」的真实数据源。
@@ -1006,6 +1009,64 @@ phase_gathering_getRandomPegType() {
                     this._ui_checkRunewordBubble();
                 }
             }, 800);
+        }
+    },
+
+/**
+     * @method phase_inWallClearTrigger
+     * @description [in-wall-clear-lottery] 当围墙内（pos.y > 0）的敌人全部死亡时触发：
+     *   1. 清空场上所有子弹（projectiles / sonSwords / burstQueue 等）。
+     *   2. 拍摄当前 ammoQueue 快照作为老虎机抽奖输入，剩余子弹数量作为额外加成。
+     *   3. 弹出「与跳过混沌精华一致」的子弹老虎机，按 (base + 剩余子弹数) 提升属性。
+     *   4. 抽奖期间设置 `_inWallClearLotteryActive` 暂停标志，阻止 `phase_enemy_startLogic` 自动启动。
+     *   5. 抽奖结束后立刻刷出至少 3 排画面外精英援军（强制 jump+haste 词条），随后解除暂停。
+     * 整个流程每回合最多触发一次，由 `_inWallClearTriggered` 守卫。
+     */
+    phase_inWallClearTrigger() {
+        if (this._inWallClearTriggered) return;
+        if (this.gameOver) return;
+        if (this.phase !== 'combat') return;
+        // 已经处于敌人回合（例如手动调试触发），不再覆盖流程
+        if (this.isEnemyTurn) return;
+        this._inWallClearTriggered = true;
+        // 与 perfect-clear-upgrade 互斥：避免后者在同一帧再次升级 ammoQueue
+        this._chargeUpgradeApplied = true;
+
+        const remaining = Array.isArray(this.ammoQueue) ? this.ammoQueue.length : 0;
+        // 抽奖输入：优先使用当前剩余 ammoQueue；若为空（极少数发完才清场），退化到上一回合实际发射的快照
+        let snapshot = (Array.isArray(this.ammoQueue) && this.ammoQueue.length > 0)
+            ? this.ammoQueue.map(r => ({ ...r }))
+            : (Array.isArray(this._lastFiredAmmoSnapshot) ? this._lastFiredAmmoSnapshot.map(r => ({ ...r })) : []);
+
+        // 1. 清空场上所有飞行子弹（projectiles / sonSwords / burstQueue 等）
+        if (typeof this.data_clearProjectiles === 'function') {
+            this.data_clearProjectiles();
+        }
+        // 2. 清空 ammoQueue：让 playerTurnFinished 自然成立，但抽奖标志会阻断敌人回合启动
+        this.ammoQueue = [];
+        if (typeof this.ui_updateAmmoUI === 'function') this.ui_updateAmmoUI();
+        if (typeof this.ui_renderRecipeHUD === 'function') this.ui_renderRecipeHUD();
+
+        // 3. 标记抽奖暂停，开始老虎机
+        this._inWallClearLotteryActive = true;
+        showToast(`🎰 围墙清空！剩余 ${remaining} 发弹药 → 抽奖加成 +${remaining}`);
+
+        const finishLottery = () => {
+            // 4. 抽奖结束 → 刷新至少 3 排带 jump+haste 的精英援军
+            if (typeof this.spawn_spawnEliteJumperRows === 'function') {
+                this.spawn_spawnEliteJumperRows(3);
+                showToast("⚡ 精英援军入场：跳跃 + 极速！");
+                if (audio && typeof audio.playPowerup === 'function') audio.playPowerup();
+            }
+            // 5. 解除暂停，下一帧 phase_combat_update 会自动进入敌人回合
+            this._inWallClearLotteryActive = false;
+        };
+
+        if (typeof this.sys_runInWallClearLottery === 'function' && snapshot.length > 0) {
+            this.sys_runInWallClearLottery(snapshot, remaining, finishLottery);
+        } else {
+            // 无可抽奖子弹：跳过抽奖动画，直接刷援军并解除暂停
+            finishLottery();
         }
     },
 
@@ -1974,9 +2035,16 @@ phase_gathering_getRandomPegType() {
             return; 
         }
 
-        // [perfect-clear-upgrade] 围墙范围内已无敌人但仍有剩余子弹：
-        // 立刻结算，并将剩余子弹的所有可累加属性 +1 后携带到下回合，附带显著的蓄能发光升级特效。
-        // _chargeUpgradeApplied 防止同一回合多次进入此分支（结算流程内仍可能继续 tick）。
+        // [in-wall-clear-lottery] 围墙范围内（pos.y > 0）已无敌人时优先触发抽奖 + 精英援军流程。
+        // 该触发会内部置 `_chargeUpgradeApplied = true`，覆盖原 perfect-clear-upgrade 路径。
+        if (activeEnemies === 0 && this.phase === 'combat' && !this.gameOver
+            && !this._inWallClearTriggered && !this.isEnemyTurn
+            && typeof this.phase_inWallClearTrigger === 'function') {
+            this.phase_inWallClearTrigger();
+        }
+
+        // [perfect-clear-upgrade] 兜底分支：若新机制未启用（如试炼场或抽奖跳过），
+        // 仍然走原蓄能升级流程，将剩余子弹 +1 携带到下回合。
         if (activeEnemies === 0) {
             const hasLeftoverAmmo = this.ammoQueue.length > 0;
             if (hasLeftoverAmmo && !this._chargeUpgradeApplied) {
@@ -2017,6 +2085,8 @@ phase_gathering_getRandomPegType() {
                            !this.isVisualEffectActive;
 
         if (playerTurnFinished && !this.gameOver) {
+            // [in-wall-clear-lottery] 抽奖暂停期间禁止启动敌人回合，等待玩家关闭老虎机覆盖层
+            if (this._inWallClearLotteryActive) return;
             // [回合开始横幅保护] 横幅期间不触发敌人行动，避免与上一回合结束时的敌人行动重复
             if (this._roundStartBannerActive) return;
             // [遗物/命运时刻保护] 遗物或命运时刻 overlay 显示期间，必须等待玩家选择完毕

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -1055,6 +1055,73 @@ export const game_system = {
     },
 
     /**
+     * @method sys_runInWallClearLottery
+     * @description [in-wall-clear-lottery] 围墙内敌人全灭时触发的子弹老虎机抽奖。
+     * 复用 `ui_showChaosBulletSlotMachine` 的视觉与命中规则（与跳过混沌精华的抽奖一致），
+     * 但额外按「剩余子弹数量」放大每个 slot 的提升幅度（incVal = base + bonusCount）。
+     * 抽奖结束后将升级后的子弹携带到下回合（_carryOverAmmo），解除暂停标志，并触发精英援军刷新。
+     * @param {Array<Object>} chargedSnapshot 用于抽奖的子弹快照（每个元素是 recipe 副本）。
+     * @param {number} [bonusCount=0] 抽奖结算时叠加到 incVal 的剩余子弹数量。
+     * @param {Function} [onComplete] 抽奖动画 + 升级应用全部完成后触发的回调。
+     */
+    sys_runInWallClearLottery(chargedSnapshot, bonusCount = 0, onComplete) {
+        const STAT_KEYS = ['damage','bounce','pierce','scatter','multicast','cryo','pyro','lightning','laser','flying_sword','wind'];
+        const ATTR_LABEL = {
+            damage: '伤害', bounce: '反弹', pierce: '穿透', scatter: '散射',
+            multicast: '连射', cryo: '冰', pyro: '火', lightning: '雷',
+            laser: '激光', flying_sword: '飞剑', wind: '风',
+        };
+
+        const charged = Array.isArray(chargedSnapshot) ? chargedSnapshot.map(r => ({ ...r })) : [];
+        if (charged.length === 0) {
+            if (typeof onComplete === 'function') onComplete();
+            return;
+        }
+
+        const slotAttrs = charged.map(recipe => {
+            const avail = STAT_KEYS.filter(k => (recipe[k] || 0) > 0);
+            return avail.length > 0 ? avail : ['damage'];
+        });
+        const finalPicks = slotAttrs.map(arr => arr[Math.floor(Math.random() * arr.length)]);
+        const allSame = finalPicks.length >= 3 && finalPicks.every(p => p === finalPicks[0]);
+        const baseInc = allSame ? 5 : 2;
+        const incVal = baseInc + Math.max(0, bonusCount | 0);
+
+        const applyUpgrade = () => {
+            if (allSame) {
+                const attr = finalPicks[0];
+                charged.forEach(r => { r[attr] = (r[attr] || 0) + incVal; });
+            } else {
+                charged.forEach((r, i) => {
+                    const attr = finalPicks[i];
+                    r[attr] = (r[attr] || 0) + incVal;
+                });
+            }
+            charged.forEach(r => { if ((r.laser || 0) > 0) r.isLaser = true; });
+
+            // 把升级后的子弹携带到下一回合（与 perfect-clear-upgrade 同一通道）
+            this._carryOverAmmo = charged.map(r => {
+                const recipe = { ...r };
+                recipe.finalHits = 0;
+                recipe.multicast = r.multicast || 0;
+                return recipe;
+            });
+
+            if (typeof this.ui_updateAmmoUI === 'function') this.ui_updateAmmoUI();
+            if (typeof this.ui_renderRecipeHUD === 'function') this.ui_renderRecipeHUD();
+            if (typeof this.sys_saveRunState === 'function') this.sys_saveRunState();
+
+            if (typeof onComplete === 'function') onComplete();
+        };
+
+        if (typeof this.ui_showChaosBulletSlotMachine === 'function') {
+            this.ui_showChaosBulletSlotMachine(slotAttrs, finalPicks, ATTR_LABEL, allSame, applyUpgrade);
+        } else {
+            applyUpgrade();
+        }
+    },
+
+    /**
      * @method sys_queueRoundStartReward
      * @description 将下一回合开始需要统一结算的奖励写入队列。
      */

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -647,6 +647,36 @@ export const spawn_system = {
     },
 
 /**
+     * @method spawn_spawnEliteJumperRows
+     * @description [in-wall-clear-lottery] 围墙清空抽奖结算后的强援增援：在画面外栈式生成
+     * 多排敌人，每个新敌人强制带上 ['jump', 'haste'] 双词缀并标记为精英。
+     * 用于「围墙内敌人全灭 → 抽奖 → 敌人回合开局立刻刷新精英援军」的流程。
+     * @param {number} [count=3] - 要生成的精英行数（至少 3）。
+     */
+    spawn_spawnEliteJumperRows(count = 3) {
+        const safeCount = Math.max(3, count | 0);
+        // 生成前记录现有敌人，便于事后筛选新生成的实例并赋予强制词条
+        const before = new Set(this.enemies);
+        for (let i = 0; i < safeCount; i++) {
+            const yPos = this.combatGridTopY - i * this.enemyHeight;
+            this.spawn_spawnEnemyRowAt(yPos, { offScreenEntrance: true });
+        }
+        const newcomers = this.enemies.filter(e => e.active && !before.has(e));
+        newcomers.forEach(e => {
+            // 强制覆盖词条为 jump+haste，并标记精英（含视觉强调）
+            e.affixes = ['jump', 'haste'];
+            e.type = 'elite';
+            // 取消护盾层数残留（spawn_spawnEnemyRowAt 不会给 jump+haste 配护盾，这里只是兜底）
+            if (typeof e.shieldCharges === 'number') e.shieldCharges = 0;
+            this.spawn_createShockwave(e.pos.x, e.pos.y, '#facc15');
+            for (let s = 0; s < 5; s++) {
+                this.spawn_createParticle(e.pos.x, e.pos.y, '#facc15', 'spark');
+            }
+        });
+        return newcomers.length;
+    },
+
+/**
      * @method triggerCloneSpawn
      * @description 触发分身生成的通用逻辑
      */


### PR DESCRIPTION
## Summary
当墙体内部敌人 (`pos.y > 0`) 全部死亡时，新增一条「清屏抽奖 + 精英援军」战斗节奏：

- **清空场上所有飞行子弹**（projectiles / sonSwords / burstQueue 等）。
- **触发与「跳过混沌精华」一致的子弹老虎机抽奖**，并按剩余子弹数量额外增加抽奖属性：`incVal = base + remaining`（三连同款 +5+N，否则 +2+N）。
- 抽奖期间通过 `_inWallClearLotteryActive` **暂停标志**阻止 `phase_enemy_startLogic` 启动，保证抽奖结束才会进入敌人回合。
- 抽奖结束后**立刻刷新至少 3 排画面外精英援军**，并强制赋予 `jump + haste` 双词条。

## 主要改动
- `src/game_phase.js`：新增 `phase_inWallClearTrigger()`；`phase_combat_update` 中加入触发器调用与暂停守卫；`phase_startCombatPhase` 重置回合标志。
- `src/game_system.js`：新增 `sys_runInWallClearLottery(snapshot, bonusCount, onComplete)`，复用 `ui_showChaosBulletSlotMachine`，升级后的子弹通过 `_carryOverAmmo` 携带到下一回合。
- `src/spawn_system.js`：新增 `spawn_spawnEliteJumperRows(count=3)`，栈式画面外生成至少 3 排敌人并强制 `['jump','haste']` 词条。

## 互斥保护
- 触发器内立即设置 `_chargeUpgradeApplied = true`，避免与原 `perfect-clear-upgrade` 在同一帧重复加成；后者保留作为试炼场/UI 缺失场景的兜底。

## Test plan
- [ ] 围墙内仅余 1 个敌人，发射子弹击杀后：场上飞行子弹清空、剩余子弹数 N → 老虎机弹出、加成 = 基础 + N。
- [ ] 抽奖动画期间「ENEMY TURN」不出现；点击「进入战斗」后下一帧立刻触发敌人回合。
- [ ] 敌人回合开始时 3 排新精英已位于画面外向下落入，全部带 jump + haste 词条且 `type='elite'`。
- [ ] 升级后的子弹在下一回合开局自动充能（来自 `_carryOverAmmo`）。
- [ ] 同一回合内多次清屏只触发一次抽奖（`_inWallClearTriggered` 守卫）。
- [ ] 试炼场（`phase === 'training'`）不受影响：触发器直接 return。

https://claude.ai/code/session_01Jez9J3UbKY41HtGQ7e2JEX