### PR TITLE
feat(relic): v2 即时感重塑 - 12 个遗物的运行时钩子与流程改造

### DIFF
--- a/docs/relic_system_design.md
+++ b/docs/relic_system_design.md
@@ -42,3 +42,78 @@
 2. **Phase 5**: 修改 `src/config.js` 标记强力遗物；修改 `src/core.js` 添加计数器；修改 `src/ui/shop.js` 实现推荐逻辑和 UI 渲染。
 3. **Phase 6**: 修改 `index.html` 添加标签、Tip 和稀有遗物的动画样式。
 4. **Phase 7**: 提交代码并更新规范文档。
+
+---
+
+## 5. v2 即时感重塑（2026-04-29）
+
+### 5.1 背景与问题
+
+旧版大量遗物机制都是在选中后通过 `sys_queueRoundStartReward({ type: 'chaos_essence' })` "立刻触发一次混沌精华"，依赖钉板的固定流程把"获得=立刻强"的反馈具象化。当钉板从「每回合固定流程」改为「掉落物触发」后：
+
+- 钉板触发时机和频率不可预测，遗物的副作用反馈变得"不及时"。
+- 玩家选完遗物后的体感弱化为"等下一次掉落才生效"。
+- 大部分钉板遗物（维度碎片、空间凿子、涌潮系列、阵形系列）都受影响。
+
+### 5.2 v2 新增/修改遗物清单
+
+> 数据源：`src/config.js` `RELIC_DB` 末尾的「即时战斗强化遗物（v2 即时感重塑）」分组。
+
+| ID | 名称 | 稀有度 | 类型 | 关键钩子位置 |
+|---|---|---|---|---|
+| `hunter_instinct` | 猎人本能 | rare | 战斗被动 | `combat_system.js` `combat_damageEnemy`：在 `enemy.takeDamage` 之前对场上 hp 最低敌人 ×1.25 |
+| `rune_resonance_core` | 符文共鸣核 | rare | 击杀奖励 | `combat_system.js` `combat_runeCharge_onHit`：击杀 +0.08 充能 |
+| `mirror_magazine` | 镜像弹夹 | rare | 一次性 | `ui/shop.js` `ui_selectRelic`：复制 `ammoQueue` 中评分最高的子弹至队尾 |
+| `doomsday_timer` | 末日计时器 | rare | 回合开始 | `game_phase.js` `phase_finalizeRound`（round++ 之后）→ `combat_system.js` `relic_runRoundStartHooks` |
+| `echo_reverberation` | 余韵回响 | rare | 钉板编译 | `calc_utils.js` `calc_compileCollectionToRecipe`：单属性 ≥10 层时 +1 |
+| `element_injector` | 元素注入器 | epic | 一次性 | `ui/shop.js` `ui_selectRelic`：删除 `ammoQueue` 最强/最弱，幸存者属性翻倍 |
+| `chaos_burst` | 混沌爆发 | cursed | 掉落联动 | `game_system.js` `sys_dropFieldLoot`：混沌精华掉落时全场固定真实伤害 round×2 |
+| `attribute_protocol` | 属性协议 | rare | 发射时 | `combat_system.js` `combat_fireNextShot`：4 种以上属性时按子弹自身属性数 +damage |
+| `mortal_burst` | 殒命爆裂 | rare | 击杀联动 | `combat_system.js` killed 块：max(2, maxHp×10%) AOE 真实伤害 |
+| `corridor_arc` | 回廊电弧 | epic | 墙撞 + 回合开始 | `entities/projectile.js` `_applyMove`（左右墙壁 +1 闪电层）+ `relic_runRoundStartHooks`（紧贴墙壁 50% 触发电弧） |
+| `chaos_pact` | 混沌契约 | cursed | 永久 + 流程 | `ui/shop.js`（拾取时给 3 稀有符文 + 设置 `chaosPactDamageMult=2`）+ `game_phase.js` `phase_startGatheringPhase`（直接跳过研磨）+ `combat_fireNextShot`（伤害倍率应用） |
+| `greedy_wheel` | 贪婪轮盘 | cursed | 发射时 | `combat_system.js` `combat_fireNextShot`：multicast 折算为 +damage×0.5/层；末尾按 75% 概率向 `burstQueue` 追加一次重发射 |
+| `energy_shield`（修改） | 力場護盾 | cursed | 墙壁联动 | `entities/projectile.js` `_applyMove`：所有墙体（左/右/顶/底）都消耗 1 次反弹或穿透 |
+
+### 5.3 状态字段
+
+新增的 game 实例字段（`sys_resetGame` / `sys_saveRunState` / `sys_loadRunState` 三处都已对齐）：
+
+| 字段 | 默认值 | 说明 |
+|---|---|---|
+| `chaosPactDamageMult` | `1` | 混沌契约的永久伤害倍率，发射时应用到 `finalRecipe.damage` |
+| 子弹 recipe `_isGreedyReFire` | `false` | 贪婪轮盘 75% 重发射时标记，避免在 `combat_fireNextShot` 内重复折算 multicast |
+| 子弹 recipe `_attributeProtocolBonus` | `undefined` | 调试用，记录属性协议本次发射叠加的伤害值 |
+| 敌人 `_mortalBurstTriggered` | `false` | 殒命爆裂连锁防递归 |
+
+### 5.4 评分算法（_scoreRecipeStrength）
+
+镜像弹夹 / 元素注入器使用同一评分公式：
+
+```
+score(r) = r.damage
+        + (r.cryo + r.pyro + r.lightning + r.laser + r.wind + r.bounce + r.pierce + r.scatter + r.flying_sword)
+        + r.multicast × 2
+        + (r.explosive ? 3 : 0)
+        + (r.isLaser ? 2 : 0)
+```
+
+定义在 `src/ui/shop.js` 文件顶部。`recipe_countAttributeKinds` 同文件导出，供属性协议跨模块复用。
+
+### 5.5 边界情况记录
+
+- **元素注入器**：ammoQueue 长度为 2 时仅删除最弱、保留最强并翻倍；长度为 1 时直接对其翻倍。
+- **混沌契约**：第一回合 `_lastFiredAmmoSnapshot` 不存在，自动用 `CONFIG.gameplay.baseDamage` 兜底生成 3 颗基础子弹。
+- **回廊电弧**：`ammoQueue` 为空时使用回合数兜底；闪电链伤害近似为 `stacks × maxDmg × 0.33`，避免重写完整闪电链算法。
+- **力場護盾诅咒**：bounce/pierce 都耗尽后，墙壁碰撞直接销毁子弹。这意味着无 bounce/pierce 子弹现在贴墙就消失（设计预期内的诅咒代价）。
+- **殒命爆裂**：通过 `enemy._mortalBurstTriggered` 防止 AOE 互相触发的链反应循环。AOE 范围取 `max(60, enemy.width × 2)`。
+- **混沌爆发**：仅在 `queuedReward.type === 'chaos_essence'` 时触发，`pure_essence` / `relic` 不触发。
+
+### 5.6 设计目标对照
+
+| 旧问题 | v2 解决方式 |
+|---|---|
+| 选完遗物要等钉板触发才有反馈 | mirror_magazine / element_injector / chaos_pact 在 `ui_selectRelic` 内立即修改 `ammoQueue` 或 `chaosPactDamageMult`，下次发射就能看到变化 |
+| 遗物效果跟回合频率脱钩 | doomsday_timer / corridor_arc 直接挂在 `phase_finalizeRound` 的 round++ 钩子，**强制每回合开始有反馈** |
+| 击杀效率与遗物无关 | hunter_instinct / rune_resonance_core / mortal_burst 都直接走击杀通路，杀得越快越爽 |
+| 钉板触发的副作用价值不可控 | chaos_burst 把"掉落混沌精华"本身变成全屏伤害事件，与新的掉落驱动正向耦合 |

--- a/docs/ui_asset_requirements.md
+++ b/docs/ui_asset_requirements.md
@@ -266,3 +266,57 @@
 ---
 
 > **维护提示**：本节列出的所有素材若已接入，**必须**把 §1 表对应行的状态从 🟡/❌ 升到 ✅，并在 §2 表中划掉对应条目，避免双向漂移。
+
+---
+
+## 7. v2 即时感重塑遗物 UI 需求清单（2026-04-29）
+
+> 设计来源：[`docs/relic_system_design.md`](relic_system_design.md) §5。本节列出 13 个新增/修改遗物对应的 UI 与美术资产需求，按 P0/P1/P2 优先级分级。
+>
+> **接入路径**：所有遗物图标统一放至 `assets/icons/relic/<id>.png`，并在 [`src/bitmap_icons.js`](../src/bitmap_icons.js) 的 `RELIC_ICON_MAP` 中注册映射，命中后自动取代 `RELIC_DB[i].icon` 的 emoji fallback。
+
+### 7.1 P0 — 遗物图标位图（必须完成）
+
+| 遗物 ID | 名称 | 占位 emoji | 图标尺寸 | 视觉建议 |
+|---|---|---|---|---|
+| `hunter_instinct` | 猎人本能 | 🎯 | 64×64 | 红色十字准星叠加血滴；冷色金属外框 |
+| `rune_resonance_core` | 符文共鸣核 | 💠 | 64×64 | 紫色结晶核心 + 共鸣波纹环（与 `relic_aura_<tier>.png` 协调） |
+| `mirror_magazine` | 镜像弹夹 | 🪞 | 64×64 | 双子弹折射镜面，左右对称构图 |
+| `doomsday_timer` | 末日计时器 | ⏱️ | 64×64 | 黑金沙漏 + 红色秒针；刻度盘隐约可见骷髅 |
+| `echo_reverberation` | 余韵回响 | 🔔 | 64×64 | 钟形 + 多重声波同心圆，淡金色 |
+| `element_injector` | 元素注入器 | 💉 | 64×64 | 玻璃试管中三色液体（火/冰/雷）旋绕，**epic 紫边** |
+| `chaos_burst` | 混沌爆发 | 💥 | 64×64 | 紫色裂纹球 + 边缘湍流，**cursed 红黑边** |
+| `attribute_protocol` | 属性协议 | 🧬 | 64×64 | DNA 双螺旋，每节点带不同元素颜色 |
+| `mortal_burst` | 殒命爆裂 | 🎆 | 64×64 | 橙色辐射状爆破图案，中心骷髅剪影 |
+| `corridor_arc` | 回廊电弧 | ⚡ | 64×64 | 紫色雷电从左右两侧向中心汇聚，**epic 紫边** |
+| `chaos_pact` | 混沌契约 | 🩸 | 64×64 | 血色羊皮纸卷轴 + 红色封蜡，**cursed 红黑边** |
+| `greedy_wheel` | 贪婪轮盘 | 🎲 | 64×64 | 金色赌轮 + 暗黑齿轮镂空，**cursed 红黑边** |
+
+### 7.2 P1 — 战斗内即时反馈（提升打击感）
+
+这些资产用于让 v2 遗物的"即时生效"在战斗画面中可见，玩家能直接感知"刚拿到=立刻强"。
+
+| 资产 | 用途 | 建议尺寸 | 接入位置 |
+|---|---|---|---|
+| `assets/ui/sprites/hunter_target_marker.png` | 猎人本能：场上 hp 最低敌人头顶的"狩猎目标"红色十字标记 | 32×32（透明 PNG） | `render_system.js` 敌人渲染层；逐帧由 `combat_damageEnemy` 中查到的 lowestHpEnemy 决定 |
+| `assets/ui/sprites/doomsday_target_pulse.png` | 末日计时器：被命中的敌人头顶 1.0s 红色脉冲圈 | 96×96 | `relic_runRoundStartHooks` 触发后通过粒子系统播放 |
+| `assets/ui/sprites/chaos_burst_shockwave.png` | 混沌爆发：全屏冲击波贴图（紫色环） | 720×720 | `sys_dropFieldLoot` 触发时全屏 0.4s 闪烁 |
+| `assets/ui/sprites/corridor_arc_chain.png` | 回廊电弧：左右墙到敌人的电弧贴图（4 帧动画） | 64×128 | `relic_runRoundStartHooks` 触发时绘制 |
+| `assets/ui/sprites/mortal_burst_aoe.png` | 殒命爆裂：击杀位置的橙色 AOE 圈（一次性扩散） | 128×128 | killed 块内调用 |
+| `assets/ui/sprites/wall_lightning_charge.png` | 力場護盾 / 回廊电弧：墙撞瞬间火花 | 64×64 | `_applyMove` 内 `handleRelicWallHit` 触发 |
+| `assets/ui/sprites/echo_reverb_ring.png` | 余韵回响：编译时单属性 ≥10 层的环形提示（3 帧扩散） | 96×96 | 在 `phase_finalizeRound` 编译完成后由 hud 层短暂显示 |
+
+### 7.3 P2 — 提示与教程
+
+| 资产 | 用途 | 备注 |
+|---|---|---|
+| `index.html` 内新增遗物的 `recommendTip` 文案 | 已写入 `RELIC_DB`，仅前 3 次遗物选择显示 | 已完成（hunter_instinct / rune_resonance_core / doomsday_timer / attribute_protocol / mortal_burst） |
+| 真理之书新条目（13 个 v2 遗物） | 图鉴覆盖；自动从 `RELIC_DB` 读取 | 需检查 `truth-book` 是否自动同步 |
+| `assets/ui/banners/relic_v2_intro_banner.png` | v2 遗物首次出现时的引导横幅（可选） | 600×200，与 `round_banner_*.png` 同风格 |
+
+### 7.4 已知 UI 联动改造点
+
+1. **稀有度光环**：`mirror_magazine`、`element_injector`、`corridor_arc` 三档稀有度（rare / epic / epic）需要确保 `relic_aura_<tier>.png` 已正确按 rarity 字段分配。
+2. **诅咒系遗物边框**：`chaos_burst` / `chaos_pact` / `greedy_wheel` 的 `rarity: 'cursed'` 需要走 `relic_aura_cursed.png`；如果当前 RELIC_AURA 仅有 C/B/A/S 四档，需补充 cursed 配色（建议黑红血纹）。
+3. **存档兼容**：`chaosPactDamageMult` 已加入 `sys_saveRunState` / `sys_loadRunState`；旧存档读档时默认为 `1`，无破坏性。
+4. **图标 emoji fallback**：所有 v2 遗物的 emoji 均已在 `RELIC_DB` 内定义，位图缺失时不会阻塞 UI。

--- a/src/calc_utils.js
+++ b/src/calc_utils.js
@@ -327,6 +327,17 @@ export const calc_utils = {
         if (recipe.laser > 0) {
             recipe.isLaser = true;
         }
+
+        // --- [遗物 Hook] 余韵回响 (echo_reverberation) ---
+        // 触发钉板时，单一属性收集到 10 层及以上，自动额外再 +1 层（每属性每次只触发一次）
+        if (this.ownedRelics && this.ownedRelics.includes('echo_reverberation')) {
+            const echoKeys = ['cryo', 'pyro', 'lightning', 'laser', 'wind', 'damage'];
+            for (const k of echoKeys) {
+                if ((recipe[k] || 0) >= 10) {
+                    recipe[k] = (recipe[k] || 0) + 1;
+                }
+            }
+        }
         return recipe;
     },
 };

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -1728,6 +1728,18 @@ export const combat_system = {
             isCrit = true;
             dmg = dmg * critDamage;
         }
+        // --- [遗物 Hook] 猎人本能 (hunter_instinct)：场上血量最低的敌人受伤害 +25% ---
+        if (this.ownedRelics && this.ownedRelics.includes('hunter_instinct')) {
+            let lowestHpEnemy = null;
+            let lowestHp = Infinity;
+            for (const e of this.enemies) {
+                if (!e || !e.active) continue;
+                if (e.hp < lowestHp) { lowestHp = e.hp; lowestHpEnemy = e; }
+            }
+            if (lowestHpEnemy === enemy) {
+                dmg = dmg * 1.25;
+            }
+        }
         // [修改] 调用 takeDamage 时传入 projectile 作为源，用于方向判定
         const damageResult = enemy.takeDamage(dmg, projectile);
         
@@ -2171,6 +2183,32 @@ export const combat_system = {
                 shotId: shotId
             });
 
+            // --- [遗物 Hook] 殒命爆裂 (mortal_burst) ---
+            // 击杀时在敌人位置爆炸，对附近敌人造成 max(2, maxHp*10%) 的固定真实伤害
+            if (this.ownedRelics && this.ownedRelics.includes('mortal_burst') && !enemy._mortalBurstTriggered) {
+                enemy._mortalBurstTriggered = true; // 防止穿透/AOE 链反应触发死循环
+                const burstDmg = Math.max(2, Math.floor((enemy.maxHp || 0) * 0.10));
+                const burstRadius = Math.max(60, (enemy.width || 40) * 2);
+                const cx = enemy.pos.x;
+                const cy = enemy.pos.y;
+                // 爆炸视觉粒子
+                for (let i = 0; i < 8; i++) {
+                    this.spawn_createParticle(cx, cy, '#fb923c', 'spark');
+                }
+                if (typeof this.spawn_createFloatingText === 'function') {
+                    this.spawn_createFloatingText(cx, cy - 20, `殒命爆裂 ${burstDmg}`, '#fb923c');
+                }
+                for (const other of this.enemies) {
+                    if (!other || !other.active || other === enemy) continue;
+                    const dx = (other.pos.x - cx);
+                    const dy = (other.pos.y - cy);
+                    if (dx * dx + dy * dy <= burstRadius * burstRadius) {
+                        const aoeResult = other.takeDamage(burstDmg);
+                        if (aoeResult && aoeResult.killed) this.spawn_addScore(other.maxHp);
+                    }
+                }
+            }
+
             // [新增] 子剑回收逻辑：如果敌人被杀，插在上面的子剑需要回收
             if (enemy.stuckSwords && enemy.stuckSwords.length > 0) {
                 enemy.stuckSwords.forEach(sword => {
@@ -2553,6 +2591,44 @@ export const combat_system = {
             }
         }
 
+        // --- [遗物 Hook] 属性协议 (attribute_protocol) ---
+        // 弹药配方含 4 种以上不同属性时，每颗子弹基础伤害 + 该子弹自身属性种类数
+        if (this.ownedRelics && this.ownedRelics.includes('attribute_protocol')) {
+            // 统计 ammoQueue 中所有属性种类合集
+            const queueKinds = new Set();
+            const ATTR_KEYS = ['cryo','pyro','lightning','laser','wind','bounce','pierce','scatter','flying_sword'];
+            for (const r of (this.ammoQueue || [])) {
+                for (const k of ATTR_KEYS) if (r && r[k] && r[k] > 0) queueKinds.add(k);
+            }
+            if (queueKinds.size >= 4) {
+                let selfKinds = 0;
+                for (const k of ATTR_KEYS) if (finalRecipe[k] && finalRecipe[k] > 0) selfKinds++;
+                if (selfKinds > 0) {
+                    finalRecipe.damage = (finalRecipe.damage || 0) + selfKinds;
+                    finalRecipe._attributeProtocolBonus = selfKinds;
+                }
+            }
+        }
+
+        // --- [遗物 Hook] 贪婪轮盘 (greedy_wheel) ---
+        // 1. multicast 折算为伤害（每层 +damage * 0.5），随后清零
+        // 2. 设置 _greedyWheelReFireChance = 0.75，由 burstQueue 末端的逻辑读取
+        if (this.ownedRelics && this.ownedRelics.includes('greedy_wheel') && !finalRecipe._isGreedyReFire) {
+            const layers = finalRecipe.multicast || 0;
+            if (layers > 0) {
+                const baseDmg = finalRecipe.damage || 1;
+                finalRecipe.damage = Math.ceil(baseDmg + baseDmg * 0.5 * layers);
+                finalRecipe.multicast = 0;
+            }
+            finalRecipe._greedyWheelReFire = true;
+        }
+
+        // --- [遗物 Hook] 混沌契约 (chaos_pact) ---
+        // 永久子弹伤害 ×2（chaosPactDamageMult 由 ui_selectRelic 在拾取时设置）
+        if (this.chaosPactDamageMult && this.chaosPactDamageMult > 1) {
+            finalRecipe.damage = Math.ceil((finalRecipe.damage || 1) * this.chaosPactDamageMult);
+        }
+
         // --- [Task 3.2] 触发UI动画 - 改为 EventBus 事件，由 hud.js 监听 ---
         eventBus.emit(EVENT_TYPES.UI_AMMO_FIRED, {});
         this.ui_renderRecipeHUD();
@@ -2580,6 +2656,15 @@ export const combat_system = {
             for(let i=1; i<=finalRecipe.multicast; i++) {
                 const isLastInBurst = (i === finalRecipe.multicast);
                 this.burstQueue.push({ delay: i * 20, vel: vel, recipe: finalRecipe, shotId: shotId, isLast: isLastInBurst });
+            }
+        }
+
+        // [遗物 Hook] 贪婪轮盘 (greedy_wheel)：每次发射后 75% 概率追加一次相同 recipe 的发射
+        // 通过 burstQueue 直接追加，spawn_spawnBullet 不会再回到 combat_fireNextShot，因此天然不会再次触发本效果
+        if (this.ownedRelics && this.ownedRelics.includes('greedy_wheel') && !finalRecipe._isGreedyReFire) {
+            if (Math.random() < 0.75) {
+                const reFireRecipe = { ...finalRecipe, _isGreedyReFire: true };
+                this.burstQueue.push({ delay: 30, vel: vel, recipe: reFireRecipe, shotId: shotId, isLast: true });
             }
         }
     },
@@ -3059,6 +3144,73 @@ export const combat_system = {
         eventBus.emit(EVENT_TYPES.UI_HIT_PROGRESS, { val, target });
     },
 
+    // ==================== [v2 即时感重塑] 遗物回合开始钩子 ====================
+
+    /**
+     * @method relic_runRoundStartHooks
+     * @description 由 phase_finalizeRound 在 round++ 之后调用。
+     *   - 末日计时器 (doomsday_timer)：对场上随机一个敌人造成 (round × 5) 固定真实伤害
+     *   - 回廊电弧 (corridor_arc)：对紧贴左右墙壁的敌人各 50% 概率触发闪电链
+     *     · 链层数 = 当前回合数
+     *     · 链伤害 = 当前 ammoQueue 前三颗子弹中最大基础伤害
+     */
+    relic_runRoundStartHooks() {
+        if (!this.ownedRelics) return;
+
+        // --- 末日计时器 ---
+        if (this.ownedRelics.includes('doomsday_timer')) {
+            const candidates = (this.enemies || []).filter(e => e && e.active && e.hp > 0);
+            if (candidates.length > 0) {
+                const target = candidates[Math.floor(Math.random() * candidates.length)];
+                const dmg = (this.round || 1) * 5;
+                const result = target.takeDamage(dmg);
+                if (typeof this.spawn_createFloatingText === 'function') {
+                    this.spawn_createFloatingText(target.pos.x, target.pos.y - 24, `末日 ${dmg}`, '#fbbf24');
+                }
+                if (result && result.killed && typeof this.spawn_addScore === 'function') {
+                    this.spawn_addScore(target.maxHp);
+                }
+            }
+        }
+
+        // --- 回廊电弧（回合开始边界电弧） ---
+        if (this.ownedRelics.includes('corridor_arc')) {
+            const wallThreshold = 40; // 紧贴墙壁的像素阈值
+            const ammo = this.ammoQueue || [];
+            // 取前三颗子弹中基础伤害最高的值
+            let maxDmg = 0;
+            for (let i = 0; i < Math.min(3, ammo.length); i++) {
+                if (ammo[i] && (ammo[i].damage || 0) > maxDmg) maxDmg = ammo[i].damage;
+            }
+            if (maxDmg <= 0) maxDmg = (this.round || 1); // 兜底：用回合数作为伤害
+            const stacks = this.round || 1;
+            const w = this.width || 720;
+            for (const e of (this.enemies || [])) {
+                if (!e || !e.active || e.hp <= 0) continue;
+                const nearLeft = e.pos.x <= wallThreshold;
+                const nearRight = e.pos.x >= (w - wallThreshold);
+                if (!nearLeft && !nearRight) continue;
+                if (Math.random() < 0.5) {
+                    // 直接对该敌人造成层数加成的固定伤害；为避免重写完整闪电链，
+                    // 这里以 stacks × maxDmg / 3 作为合理近似的链伤害。
+                    const arcDmg = Math.max(1, Math.floor(stacks * maxDmg * 0.33));
+                    const result = e.takeDamage(arcDmg);
+                    if (typeof this.spawn_createFloatingText === 'function') {
+                        this.spawn_createFloatingText(e.pos.x, e.pos.y - 18, `电弧 ${arcDmg}`, '#a78bfa');
+                    }
+                    for (let i = 0; i < 6; i++) {
+                        if (typeof this.spawn_createParticle === 'function') {
+                            this.spawn_createParticle(e.pos.x, e.pos.y, '#d8b4fe', 'spark');
+                        }
+                    }
+                    if (result && result.killed && typeof this.spawn_addScore === 'function') {
+                        this.spawn_addScore(e.maxHp);
+                    }
+                }
+            }
+        }
+    },
+
     // ==================== 充能符文系统 ====================
 
     /**
@@ -3109,7 +3261,12 @@ export const combat_system = {
             multiplier = 2;
         }
 
-        const chargeAmount = BASE_CHARGE * multiplier;
+        let chargeAmount = BASE_CHARGE * multiplier;
+
+        // [遗物 Hook] 符文共鸣核：每次击杀额外 +8% 充能
+        if (isKill && this.ownedRelics && this.ownedRelics.includes('rune_resonance_core')) {
+            chargeAmount += 0.08;
+        }
 
         // 累加充能值
         this.runeChargeValue = Math.min(1.0, (this.runeChargeValue || 0) + chargeAmount);

--- a/src/config.js
+++ b/src/config.js
@@ -1254,8 +1254,8 @@ const RELIC_DB = [
     //  1. 粉色钉子遗物
     { id: 'pink_slime', name: '粉紅凝膠', icon: '💗', desc: '收集階段：出現 3 個高彈性粉色釘子 (可疊加)。立刻觸發一次混沌精華。', rarity: 'common', effect: 'pink_peg_up', maxStacks: 5},
 
-    //  2. 战斗底部反弹墙
-    { id: 'energy_shield', name: '力場護盾', icon: '🛡️', desc: '戰鬥階段：底部邊界可消耗彈性/穿透次數來反彈子彈。', rarity: 'cursed', effect: 'combat_wall' ,maxStacks: 1},
+    //  2. 战斗底部反弹墙（诅咒：所有墙体都消耗反弹/穿透）
+    { id: 'energy_shield', name: '力場護盾', icon: '🛡️', desc: '戰鬥階段：底部邊界可反彈子彈。但子彈觸碰任何墻體（左/右/頂/底）都會額外消耗一次反彈或穿透次數。', rarity: 'cursed', effect: 'combat_wall' ,maxStacks: 1},
 
     //  3. 特殊槽解锁 (三种槽位)
     { id: 'unlock_recall', name: '時光沙漏', icon: '⏳', desc: '收集階段：解鎖 [回溯槽] 的出現 (若無槽位則+1)。立刻觸發一次混沌精華。', rarity: 'rare', effect: 'unlock_slot', slotType: 'recall' ,maxStacks: 1},
@@ -1373,6 +1373,145 @@ const RELIC_DB = [
         desc: '战斗阶段：距离失败线越近，所有子弹伤害加成越高。距离 0 格 +50%，1 格 +25%，2 格 +12.5%，3 格以上无加成。',
         rarity: 'cursed',
         effect: 'desperation_damage',
+        maxStacks: 1
+    },
+
+    // ==================== 即时战斗强化遗物（v2 即时感重塑）====================
+    // 设计目标：摆脱"立刻触发混沌精华"的钉板依赖，将"拿到=立刻强"的体感转移到战斗/弹药/掉落维度。
+
+    // 猎人本能：血量最低的敌人始终被标记为"狩猎目标"，命中时伤害 +25%
+    {
+        id: 'hunter_instinct',
+        name: '猎人本能',
+        icon: '🎯',
+        desc: '战斗阶段：场上血量最低的敌人始终被标记为「狩猎目标」，子弹命中该目标时伤害 +25%。',
+        rarity: 'rare',
+        effect: 'hunter_instinct',
+        maxStacks: 1,
+        recommended: true,
+        tags: ['伤害提升', '集火'],
+        recommendTip: '聚焦残血敌人，单点击杀效率大幅提升！'
+    },
+    // 符文共鸣核：每次击杀，符文充能条额外 +8%
+    {
+        id: 'rune_resonance_core',
+        name: '符文共鸣核',
+        icon: '💠',
+        desc: '战斗阶段：子弹每次击杀敌人，符文充能条额外 +8%。',
+        rarity: 'rare',
+        effect: 'rune_resonance_core',
+        maxStacks: 1,
+        recommended: true,
+        tags: ['符文加速', '击杀奖励'],
+        recommendTip: '击杀越多，符文充能越快，构筑成型速度暴增！'
+    },
+    // 镜像弹夹：获得后立即将当前 ammoQueue 中伤害最高的子弹复制一份加入队列末尾
+    {
+        id: 'mirror_magazine',
+        name: '镜像弹夹',
+        icon: '🪞',
+        desc: '获得后立刻将本回合弹药队列中伤害最高的子弹复制一份，加入队列末尾。',
+        rarity: 'rare',
+        effect: 'mirror_magazine',
+        maxStacks: 2
+    },
+    // 末日计时器：每回合开始时，场上随机一个敌人受到 round×5 的固定伤害
+    {
+        id: 'doomsday_timer',
+        name: '末日计时器',
+        icon: '⏱️',
+        desc: '每回合开始时，对场上随机一个敌人造成 (回合数 × 5) 的固定真实伤害。',
+        rarity: 'rare',
+        effect: 'doomsday_timer',
+        maxStacks: 1,
+        recommended: true,
+        tags: ['持续伤害', '回合奖励'],
+        recommendTip: '每回合自动削血，越打到后面伤害越夸张！'
+    },
+    // 余韵回响：触发钉板时，单一属性收集到 10 层以上时，额外再收集 1 层
+    {
+        id: 'echo_reverberation',
+        name: '余韵回响',
+        icon: '🔔',
+        desc: '触发钉板时，若单一属性收集到 10 层以上，自动额外再收集 1 层（每种属性每次钉板仅触发一次）。',
+        rarity: 'rare',
+        effect: 'echo_reverberation',
+        maxStacks: 1
+    },
+    // 元素注入器：获得后立即删除当前 ammoQueue 中最强和最弱的子弹，剩下那颗属性翻倍
+    {
+        id: 'element_injector',
+        name: '元素注入器',
+        icon: '💉',
+        desc: '获得后立刻删除本回合弹药队列中最强和最弱的两颗子弹，剩下那颗子弹的所有属性层数翻倍。',
+        rarity: 'epic',
+        effect: 'element_injector',
+        maxStacks: 1
+    },
+    // 混沌爆发：掉落混沌精华时，立刻全屏伤害 round×2
+    {
+        id: 'chaos_burst',
+        name: '混沌爆发',
+        icon: '💥',
+        desc: '战斗阶段：每次敌人掉落混沌精华时，立刻对全场所有敌人造成 (回合数 × 2) 的固定真实伤害。',
+        rarity: 'cursed',
+        effect: 'chaos_burst',
+        maxStacks: 1
+    },
+    // 属性协议：弹药配方含 4 种以上不同属性时，所有子弹基础伤害 +{该子弹携带属性种类数}
+    {
+        id: 'attribute_protocol',
+        name: '属性协议',
+        icon: '🧬',
+        desc: '若本回合弹药配方包含 4 种以上不同属性，每颗子弹的基础伤害 + 该子弹自身携带的属性种类数。',
+        rarity: 'rare',
+        effect: 'attribute_protocol',
+        maxStacks: 1,
+        recommended: true,
+        tags: ['多元素', '伤害提升'],
+        recommendTip: '属性越杂越强，鼓励混搭流派！'
+    },
+    // 殒命爆裂：击杀敌人时，对附近敌人造成被杀敌人最大血量 10%（最小 2）的固定伤害
+    {
+        id: 'mortal_burst',
+        name: '殒命爆裂',
+        icon: '🎆',
+        desc: '战斗阶段：每当敌人被击杀，在死亡位置爆炸，对附近敌人造成该敌人最大血量 10%（最小 2）的固定真实伤害。',
+        rarity: 'rare',
+        effect: 'mortal_burst',
+        maxStacks: 1,
+        recommended: true,
+        tags: ['连锁清场', '群伤'],
+        recommendTip: '击杀越凶，连锁爆炸越强！高血量精英死亡时清场尤为爽快。'
+    },
+    // 回廊电弧：撞击左右墙壁获得闪电属性；每回合开始对靠墙敌人发动闪电链
+    {
+        id: 'corridor_arc',
+        name: '回廊电弧',
+        icon: '⚡',
+        desc: '子弹每次撞击左/右墙壁，获得 +1 层闪电属性。每回合开始时，紧贴左右墙壁的敌人各有 50% 概率被闪电链击中（层数 = 回合数，伤害 = 当前弹药中三颗子弹的最高基础伤害）。',
+        rarity: 'epic',
+        effect: 'corridor_arc',
+        maxStacks: 1
+    },
+    // 混沌契约（诅咒）：无法研磨弹珠（精华只能跳过），但所有子弹伤害 ×2，立即获得 3 个稀有符文
+    {
+        id: 'chaos_pact',
+        name: '混沌契约',
+        icon: '🩸',
+        desc: '【诅咒】无法进行研磨阶段，获得精华只能选择跳过。【收益】立刻获得 3 个随机稀有符文，所有子弹伤害永久 ×2。',
+        rarity: 'cursed',
+        effect: 'chaos_pact',
+        maxStacks: 1
+    },
+    // 贪婪轮盘（诅咒）：发射时 multicast 折算为伤害（每层 +damage×0.5），每发 75% 概率再发射一次
+    {
+        id: 'greedy_wheel',
+        name: '贪婪轮盘',
+        icon: '🎲',
+        desc: '【诅咒】子弹发射时，所有连射 (multicast) 层数清零并按每层 +(基础伤害 × 0.5) 折算为固定伤害。【收益】每次发射后有 75% 概率自动再发射一次（再发射不会再触发本效果）。',
+        rarity: 'cursed',
+        effect: 'greedy_wheel',
         maxStacks: 1
     },
 ];

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -423,12 +423,35 @@ class Projectile {
 
     _applyMove(vel, width, height, spawnCallback) {
         this.pos = this.pos.add(vel);
-        
+
         // [优化] 在 Demo 模式下强制开启底墙
         const hasBottomWall = (this.game && this.game.isDemo) ? true : game.hasCombatWall;
 
-        if (this.pos.x < this.radius) { 
-            this.pos.x = this.radius; this.vel.x = Math.abs(this.vel.x); 
+        // --- [v2 即时感重塑] 遗物墙壁联动统一处理函数 ---
+        // 1. 回廊电弧 (corridor_arc)：撞击左/右墙壁时 +1 层闪电属性（写入 this.config.lightning）
+        // 2. 力场护盾诅咒 (energy_shield)：所有墙壁都消耗 1 次反弹或穿透；耗尽则销毁子弹
+        // 返回 true 表示子弹被销毁（调用方应直接 return）
+        const handleRelicWallHit = (side) => {
+            const g = (typeof game !== 'undefined') ? game : null;
+            if (!g || !g.ownedRelics) return false;
+            if ((side === 'left' || side === 'right') && g.ownedRelics.includes('corridor_arc')) {
+                this.config.lightning = (this.config.lightning || 0) + 1;
+            }
+            if (g.ownedRelics.includes('energy_shield')) {
+                if ((this.bouncesLeft || 0) > 0) {
+                    this.bouncesLeft--;
+                } else if ((this.piercesLeft || 0) > 0) {
+                    this.piercesLeft--;
+                } else {
+                    this.destroy(spawnCallback);
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if (this.pos.x < this.radius) {
+            this.pos.x = this.radius; this.vel.x = Math.abs(this.vel.x);
             if (this.config.wind && this.isLast && typeof game !== 'undefined') game.combat_wind_addAnchor(this.pos.x, this.pos.y, this.config.damage, this.config);
             const angle = Math.abs(Math.atan2(this.vel.x, this.vel.y));
             if (angle < (10 * Math.PI / 180)) {
@@ -444,9 +467,10 @@ class Projectile {
                 game.triggerScreenShake(wallShake);
             }
             this.hitCooldowns.clear();
+            if (handleRelicWallHit('left')) return;
         }
-        if (this.pos.x > width - this.radius) { 
-            this.pos.x = width - this.radius; this.vel.x = -Math.abs(this.vel.x); 
+        if (this.pos.x > width - this.radius) {
+            this.pos.x = width - this.radius; this.vel.x = -Math.abs(this.vel.x);
             if (this.config.wind && this.isLast && typeof game !== 'undefined') game.combat_wind_addAnchor(this.pos.x, this.pos.y, this.config.damage, this.config);
             const angle = Math.abs(Math.atan2(this.vel.x, this.vel.y));
             if (angle < (10 * Math.PI / 180)) {
@@ -462,6 +486,7 @@ class Projectile {
                 game.triggerScreenShake(wallShake);
             }
             this.hitCooldowns.clear();
+            if (handleRelicWallHit('right')) return;
         }
         // [修复] 顶部边界使用 combatGridTopY 计算真实反弹墙位置，与绘制位置保持一致
         // 绘制层：wallTopY = combatGridTopY - enemyHeight/2（见 game_phase.js）
@@ -469,8 +494,8 @@ class Projectile {
         const topBound = (typeof game !== 'undefined' && game.combatGridTopY != null && game.enemyHeight != null)
             ? (game.combatGridTopY - game.enemyHeight / 2 + this.radius)
             : this.radius;
-        if (this.pos.y < topBound) { 
-            this.pos.y = topBound; this.vel.y = Math.abs(this.vel.y); 
+        if (this.pos.y < topBound) {
+            this.pos.y = topBound; this.vel.y = Math.abs(this.vel.y);
             if (this.config.wind && this.isLast && typeof game !== 'undefined') game.combat_wind_addAnchor(this.pos.x, this.pos.y, this.config.damage, this.config);
             if(this.config.bounce > 0) this.deformation = { x: 1.3, y: 0.7 };
             // [打击感] 反弹顶墙壁：低频大幅震动 (已降低 40%)
@@ -478,13 +503,15 @@ class Projectile {
                 const wallShake = (2 + Math.min(1, this.config.damage / 20) * 5) * 0.6; // 1.2~4.2px
                 game.triggerScreenShake(wallShake);
             }
+            if (handleRelicWallHit('top')) return;
         }
         if (this.pos.y > height - this.radius) {
             if (hasBottomWall) {
                 this.pos.y = height - this.radius; this.vel.y = -Math.abs(this.vel.y);
                 if (this.config.wind && this.isLast && typeof game !== 'undefined') game.combat_wind_addAnchor(this.pos.x, this.pos.y, this.config.damage, this.config);
-                
-                // [修复] 底部护盾反弹不消耗反弹次数
+
+                // [修复] 底部护盾反弹不消耗反弹次数（旧逻辑）；
+                // [v2 力场护盾诅咒] 现在所有墙壁都会消耗 bounce/pierce，由 handleRelicWallHit 统一处理
                 if(this.config.bounce > 0) this.deformation = { x: 1.3, y: 0.7 };
                 // [打击感] 反弹底墙壁：低频大幅震动 (已降低 40%)
                 if (typeof game !== 'undefined' && game.triggerScreenShake) {
@@ -492,6 +519,7 @@ class Projectile {
                     game.triggerScreenShake(wallShake);
                 }
                 this.hitCooldowns.clear();
+                if (handleRelicWallHit('bottom')) return;
             } else {
                 this.destroy(spawnCallback);
             }

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -91,7 +91,29 @@ export const game_phase = {
                 shots: this.shotDamageHistory.map(s => ({ total: s.total, byAttr: { ...s.byAttr } }))
             });
         }
-        
+
+        // --- [遗物 Hook] 混沌契约 (chaos_pact)：跳过研磨阶段，直接进入战斗 ---
+        // 规则：契约持有者无法进行研磨；ammoQueue 复用上一回合的子弹快照，没有则用默认基础子弹兜底。
+        if (this.ownedRelics && this.ownedRelics.includes('chaos_pact')) {
+            const baseDmg = (CONFIG && CONFIG.gameplay && CONFIG.gameplay.baseDamage) || 1;
+            const defaultRecipe = () => ({
+                damage: baseDmg, bounce: 0, pierce: 0, scatter: 0, explosive: false,
+                isMatryoshka: false, isLaser: false, nestedPayload: null, chainPayload: null,
+                multicast: 0, flying_sword: 0, cryo: 0, pyro: 0, lightning: 0, laser: 0,
+                wind: 0, level: 1, type: 'normal'
+            });
+            const snapshot = this._lastFiredAmmoSnapshot;
+            if (snapshot && snapshot.length > 0) {
+                this.ammoQueue = snapshot.map(r => ({ ...r }));
+            } else {
+                this.ammoQueue = [defaultRecipe(), defaultRecipe(), defaultRecipe()];
+            }
+            if (typeof showToast === 'function') showToast('混沌契约：跳过研磨，直接进入战斗！');
+            if (typeof this.phase_startCombatPhase === 'function') this.phase_startCombatPhase();
+            else this.phase_switchPhase('combat');
+            return;
+        }
+
         this.phase_switchPhase('gathering');
         requestAnimationFrame(() => {
             this.ui_updateUICache();
@@ -1282,6 +1304,12 @@ phase_gathering_getRandomPegType() {
         this.roundDamage = 0;
         eventBus.emit(EVENT_TYPES.UI_ROUND_NUM_UPDATE, { round: this.round });
         document.getElementById("round-num").innerText = this.round;
+
+        // --- [遗物 Hook] 末日计时器 (doomsday_timer) & 回廊电弧 (corridor_arc) 回合开始触发 ---
+        // 在 round++ 之后立即结算，使用新回合数作为伤害基数。
+        if (typeof this.relic_runRoundStartHooks === 'function') {
+            this.relic_runRoundStartHooks();
+        }
         // [DropV2] 紧急救援冷却计数器逐回合递减
         if (this.emergencyCooldown > 0) this.emergencyCooldown--;
         // [tsk-f35c6d10] 移除旧的小 Toast 回合提示，改由 sys_showRoundStartBanner 提供更醒目的大字居中提示

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -405,6 +405,8 @@ export const game_system = {
         this._roundStartBannerActive = false; // 重置横幅保护标志
         // 重置 炼金火药管平坦伤害加成
         this.flatDamageBonus = 0;
+        // [v2 即时感重塑] 重置 混沌契约伤害倍率
+        this.chaosPactDamageMult = 1;
         // 重置 敌人动作后符文领取标志
         this._runeClaimPending = false;
         // [难度平衡] 重置战后高压因子
@@ -1490,6 +1492,22 @@ export const game_system = {
         } else {
             showToast('🎪 敌人掉落了混沌精華，將在下回合開始觸發命運時刻');
         }
+
+        // --- [遗物 Hook] 混沌爆发 (chaos_burst) ---
+        // 当掉落物为混沌精华时，对全场所有敌人造成 (回合数 × 2) 的固定真实伤害
+        if (queuedReward.type === 'chaos_essence' && this.ownedRelics && this.ownedRelics.includes('chaos_burst')) {
+            const burstDmg = (this.round || 1) * 2;
+            for (const e of (this.enemies || [])) {
+                if (!e || !e.active || e === enemy) continue;
+                const r = e.takeDamage(burstDmg);
+                if (typeof this.spawn_createFloatingText === 'function') {
+                    this.spawn_createFloatingText(e.pos.x, e.pos.y - 18, `混沌爆发 ${burstDmg}`, '#a855f7');
+                }
+                if (r && r.killed && typeof this.spawn_addScore === 'function') this.spawn_addScore(e.maxHp);
+            }
+            if (typeof this.triggerScreenShake === 'function') this.triggerScreenShake(8);
+        }
+
         return queuedReward;
     },
 
@@ -2306,6 +2324,8 @@ export const game_system = {
                 slotCount: this.slotCount || 1,
                 marbleSizeBonus: this.marbleSizeBonus || 0,
                 flatDamageBonus: this.flatDamageBonus || 0,
+                // [v2 即时感重塑] 混沌契约伤害倍率（持久化避免存档读档后丢失）
+                chaosPactDamageMult: this.chaosPactDamageMult || 1,
                 // 符文
                 runeInventory: (this.runeInventory || []).slice(),
                 runeGrid: (this.runeGrid || Array(9).fill(null)).slice(),
@@ -2420,6 +2440,7 @@ export const game_system = {
             this.slotCount = state.slotCount || 1;
             this.marbleSizeBonus = state.marbleSizeBonus || 0;
             this.flatDamageBonus = state.flatDamageBonus || 0;
+            this.chaosPactDamageMult = state.chaosPactDamageMult || 1;
 
             // --- 恢复符文 ---
             this.runeInventory = (state.runeInventory || []).slice();

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -19,6 +19,37 @@ import { showToast } from '../entities.js';
 import { eventBus } from '../event_bus.js';
 import { getRelicIconSrc } from '../bitmap_icons.js'; // [Phase 5A Task 5.A7] 位图遗物图标
 
+// ==================== [v2 即时感重塑] 子弹评分与属性操作辅助函数 ====================
+// 这些工具函数被 mirror_magazine / element_injector 调用以判定"最强/最弱"子弹与属性翻倍。
+// 评分采用：基础伤害 + 各属性层数加权 + multicast 加成的简单线性叠加，足以稳定排序。
+
+const _ATTR_KEYS = ['cryo', 'pyro', 'lightning', 'laser', 'wind', 'bounce', 'pierce', 'scatter', 'flying_sword'];
+
+function _scoreRecipeStrength(r) {
+    if (!r) return -Infinity;
+    let s = (r.damage || 0);
+    for (const k of _ATTR_KEYS) s += (r[k] || 0);
+    s += (r.multicast || 0) * 2;
+    if (r.explosive) s += 3;
+    if (r.isLaser) s += 2;
+    return s;
+}
+
+function _doubleRecipeAttrs(r) {
+    if (!r) return;
+    for (const k of _ATTR_KEYS) {
+        if (typeof r[k] === 'number' && r[k] > 0) r[k] *= 2;
+    }
+}
+
+// 工具函数：统计 recipe 中实际持有的"属性种类数"（attribute_protocol 使用）
+export function recipe_countAttributeKinds(r) {
+    if (!r) return 0;
+    let n = 0;
+    for (const k of _ATTR_KEYS) if (r[k] && r[k] > 0) n++;
+    return n;
+}
+
 /**
  * 商店渲染方法集合
  * 通过 bind(this) 组合模式作为实例方法注入到 Game 实例
@@ -308,7 +339,7 @@ export const shop_system = {
             const boost = relic.boost || 10;
             if (!this.unlockedWeights) this.unlockedWeights = {};
             if (!this.guaranteedNextRound) this.guaranteedNextRound = [];
-            
+
             keys.forEach(key => {
                 const current = this.unlockedWeights[key] || 0;
                 this.unlockedWeights[key] = current === 0 ? boost : current + Math.floor(boost * 1.5);
@@ -320,6 +351,62 @@ export const shop_system = {
                 this.sys_queueRoundStartReward({ type: 'chaos_essence', source: 'relic', sourceRelicId: relic.id, sourceRelicName: relic.name, round: this.round });
             }
         }
+
+        // ==================== [v2 即时感重塑] 新遗物即时效果分支 ====================
+        // 大部分被动遗物（猎人本能/符文共鸣核/末日计时器/余韵回响/混沌爆发/属性协议/殒命爆裂/回廊电弧/贪婪轮盘）
+        // 只需要 ownedRelics 标记，运行时由 combat_system / projectile / round_start 钩子读取。
+        // 这里仅处理需要"立即修改局内状态"的几个：mirror_magazine / element_injector / chaos_pact。
+        if (relic.effect === 'mirror_magazine') {
+            // 立即将 ammoQueue 中"最强"那颗子弹（按 _scoreRecipeStrength 评分）复制一份加入末尾
+            const queue = this.ammoQueue || [];
+            if (queue.length > 0) {
+                let bestIdx = 0;
+                let bestScore = -Infinity;
+                for (let i = 0; i < queue.length; i++) {
+                    const s = _scoreRecipeStrength(queue[i]);
+                    if (s > bestScore) { bestScore = s; bestIdx = i; }
+                }
+                const cloned = JSON.parse(JSON.stringify(queue[bestIdx]));
+                queue.push(cloned);
+                if (window.showToast) showToast(`镜像弹夹：复制了一颗强力子弹！`);
+            } else {
+                if (window.showToast) showToast(`镜像弹夹：当前无弹药可复制，下回合自动失效。`);
+            }
+        } else if (relic.effect === 'element_injector') {
+            // 删除 ammoQueue 中最强和最弱的子弹，剩下那颗的所有属性层数翻倍
+            const queue = this.ammoQueue || [];
+            if (queue.length >= 3) {
+                const scored = queue.map((r, i) => ({ i, score: _scoreRecipeStrength(r) }));
+                scored.sort((a, b) => a.score - b.score);
+                const minIdx = scored[0].i;
+                const maxIdx = scored[scored.length - 1].i;
+                const removeSet = new Set([minIdx, maxIdx]);
+                const remaining = [];
+                for (let i = 0; i < queue.length; i++) {
+                    if (!removeSet.has(i)) remaining.push(queue[i]);
+                }
+                remaining.forEach(_doubleRecipeAttrs);
+                this.ammoQueue = remaining;
+                if (window.showToast) showToast(`元素注入器：剩余子弹属性层数翻倍！`);
+            } else if (queue.length === 2) {
+                // 边界：仅 2 颗，删除最弱，保留最强并翻倍
+                const s0 = _scoreRecipeStrength(queue[0]);
+                const s1 = _scoreRecipeStrength(queue[1]);
+                const survivor = s0 >= s1 ? queue[0] : queue[1];
+                _doubleRecipeAttrs(survivor);
+                this.ammoQueue = [survivor];
+                if (window.showToast) showToast(`元素注入器：仅 2 颗子弹，强者属性翻倍！`);
+            } else if (queue.length === 1) {
+                _doubleRecipeAttrs(queue[0]);
+                if (window.showToast) showToast(`元素注入器：唯一子弹属性翻倍！`);
+            }
+        } else if (relic.effect === 'chaos_pact') {
+            // 立即获得 3 个随机稀有符文 + 设置永久伤害倍率
+            this._grantRunesByRarity('rare', 3);
+            this.chaosPactDamageMult = (this.chaosPactDamageMult || 1) * 2.0;
+            if (window.showToast) showToast(`混沌契约已签订！子弹伤害 ×2，但研磨阶段被禁用。`);
+        }
+        // ============================================================================
 
         this.ui_closeRelicSelection();
     },


### PR DESCRIPTION
为解决钉板从固定流程改为掉落驱动后遗物效果延迟的体感问题，新增/修改 13 个遗物，让"拿到=立刻强"的反馈直接绑定到战斗、弹药、击杀、回合开始、墙壁碰撞、掉落事件等不同维度。

设计文档：docs/relic_system_design.md §5
UI 清单：docs/ui_asset_requirements.md §7

新增 12 个遗物：hunter_instinct / rune_resonance_core / mirror_magazine / doomsday_timer / echo_reverberation / element_injector / chaos_burst / attribute_protocol / mortal_burst / corridor_arc / chaos_pact / greedy_wheel

修改 1 个：energy_shield 升级为诅咒（所有墙体消耗 bounce/pierce）

测试：node --check 全部通过；validate_scenarios 41/41 通过。

https://claude.ai/code/session_017YfhCQe1xT1FMK7czEMNg3