### PR TITLE
feat(effects): 为中毒敌人添加专属视觉特效

### DIFF
--- a/.cursor/rules/performance.md
+++ b/.cursor/rules/performance.md
@@ -87,6 +87,7 @@ if avgFps > fpsThresholdUp (55):
 | `shardLimit` | 60 | 30 | 12 | 碎片粒子上限 |
 | `sparkLimit` | 100 | 50 | 20 | 通用火星粒子上限（机械类受击电弧、能量泄漏等） |
 | `smokeLimit` | 60 | 25 | 8 | 烟雾粒子上限（狂暴受击烟雾、死亡爆炸等） |
+| `venomLimit` | 60 | 30 | 0 | 毒液粒子上限（中毒敌人漂浮液滴 + 命中爆发；省电模式完全关闭） |
 | `shockwaveLimit` | 20 | 12 | 6 | Shockwave 特效上限 |
 | `waveLimit` | 10 | 6 | 3 | FireWave / HealWave 上限 |
 | `lightningLimit` | 15 | 8 | 4 | LightningBolt 特效上限 |
@@ -114,8 +115,8 @@ if avgFps > fpsThresholdUp (55):
 
 | 函数 | 读取字段 | 行为 |
 |------|---------|------|
-| `spawn_createParticle(x, y, color, type)` | `maxParticles` / `windLimit` / `emberLimit` / `mistLimit` / `shardLimit` / `sparkLimit` / `smokeLimit` | 按粒子类型查询对应上限，超限时跳过创建 |
-| `spawn_pushParticleWithLimit(particle)` | `maxParticles` / `sparkLimit` / `smokeLimit` | 通用粒子推入前检查全局上限及 spark/smoke 独立限制 |
+| `spawn_createParticle(x, y, color, type)` | `maxParticles` / `windLimit` / `emberLimit` / `mistLimit` / `shardLimit` / `sparkLimit` / `smokeLimit` / `venomLimit` | 按粒子类型查询对应上限，超限时跳过创建 |
+| `spawn_pushParticleWithLimit(particle)` | `maxParticles` / `sparkLimit` / `smokeLimit` / `venomLimit` | 通用粒子推入前检查全局上限及 spark/smoke/venom 独立限制 |
 | `spawn_createShockwave(x, y, color)` | `shockwaveLimit` | 超限时跳过创建 |
 | `spawn_createHealWave(x, y, range)` | `waveLimit` | 超限时跳过创建 |
 
@@ -127,6 +128,7 @@ if avgFps > fpsThresholdUp (55):
 | 闪电技能循环（约第 241 行） | `lightningLimit` | 同上 |
 | 燃烧死亡爆炸（约第 3183 行） | `waveLimit` | 超限时跳过 FireWave 创建 |
 | 静电场词条（约第 1802 行） | `lightningLimit` | 超限时跳过 LightningBolt 创建 |
+| 毒素命中粒子爆发（约第 1739 行） | `venomLimit`（经 spawn_createParticle 间接读取） | 叠加毒层时在命中点发射 1~4 颗毒液粒子 |
 
 ### 5.3 伤害计算（`src/combat/damage_calc.js`）
 
@@ -167,6 +169,15 @@ if avgFps > fpsThresholdUp (55):
 | 函数 | 行为 |
 |------|------|
 | `render_perfOverlay()` | 当 `perfQualityLevel !== 'high'` 时，在 Canvas 左上角绘制半透明 FPS 数值和等级标签（均衡/省电） |
+
+### 5.8 毒素状态视觉（`src/entities/enemy.js` → `Enemy.draw` Layer 3.4）
+
+| 位置 | 读取字段 | 行为 |
+|------|---------|------|
+| 毒素叠加层（Layer 3.4，`venomStacks > 0`） | `perfQualityLevel` | `high`：screen 混合径向渐变 + 液滴动画；`medium`：只渐变无液滴；`low`：简单色块无渐变 |
+| 毒液粒子发射（Layer 3.4 末尾） | `venomLimit`（经 `spawn_createParticle` 间接读取） | `high` 档 8% 概率/帧发射漂浮毒液粒子，`medium` 4%，`low` 0%（venomLimit=0 兜底截止） |
+
+> **注意**：Layer 3.4 在 `ctx.clip()` 之后执行，叠加层自动被裁剪到敌人形体内部，无需额外剪切。粒子发射使用世界坐标（`this.pos.x / this.pos.y`），与局部 ctx 变换无关。
 
 ---
 
@@ -218,6 +229,7 @@ if avgFps > fpsThresholdUp (55):
 | 2026-04-16 | 初始实现：FPS 采样器、三档等级预算、粒子/特效/Peg/敌人全面接入、FPS 指示层 |
 | 2026-04-16 | 新增 `sparkLimit`（high:100/medium:50/low:20）和 `smokeLimit`（high:60/medium:25/low:8）两个预算字段；在 `spawn_createParticle` 和 `spawn_pushParticleWithLimit` 中同步接入 spark/smoke 上限检查，防止能量泄漏、机械类受击等高频 spark 场景占用全局粒子预算 |
 | 2026-04-16 | **Arc Boss VFX 性能门控（Task T3 补丁）**：在三档预算表中新增 4 个字段：`arcBossVfxTriCount`（Ouroboros 狂暴三角形数量，high:6/medium:3/low:0）、`arcBossVfxLineCount`（Devourer 引力线数量，high:6/medium:6/low:3）、`arcBossVfxWhiteGrad`（Devourer 深渊核心 lighter 白化叠加开关，high/medium:true/low:false）、`arcBossVfxSuckProb`（Devourer 吸入粒子生成概率，high:0.7/medium:0.5/low:0.3）。在 `enemy.js` Devourer/Ouroboros Layer 6.5 中通过 `game.perfQualityLevel` 动态读取对应字段实施门控。同步更新消费端关联索引（第 5.6 节）。 |
+| 2026-04-30 | **毒素敌人专属特效**：新增 `venomLimit`（high:60/medium:30/low:0）预算字段；新增 `venom` 粒子模式（上浮液滴 + screen 渐变绘制）；在 `enemy.js` Layer 3.4 新增毒素状态视觉（径向渐变叠加 + 液滴流淌动画，三档门控）；在 `combat_system.js` 命中毒素时发射 1~4 颗毒液粒子。消费端关联索引见第 5.1/5.2/5.8 节。 |
 
 ## 9. 性能影响标记规范
 

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -1740,6 +1740,17 @@ export const combat_system = {
                 if (this.spawn_createFloatingText) {
                     this.spawn_createFloatingText(hitX, hitY - 14, `☠️+${stacks}`, '#84cc16');
                 }
+                // @perf-impact: 命中毒素粒子爆发 - 已通过 venomLimit 预算门控
+                if (typeof this.spawn_createParticle === 'function') {
+                    const _vBurst = Math.min(4, 1 + stacks);
+                    for (let _vi = 0; _vi < _vBurst; _vi++) {
+                        this.spawn_createParticle(
+                            hitX + (Math.random() - 0.5) * 8,
+                            hitY + (Math.random() - 0.5) * 8,
+                            '#4ade80', 'venom'
+                        );
+                    }
+                }
             }
         }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1113,6 +1113,7 @@ const CONFIG = {
             shardLimitWind:   20,  // shard 冰渣粒子上限（风属性激活时）
             sparkLimit:      100,  // spark 通用火星粒子上限（含机械类受击电弧、能量泄漏等）
             smokeLimit:       60,  // smoke 烟雾粒子上限（含狂暴受击烟雾等）
+            venomLimit:       60,  // venom 毒液粒子上限（中毒敌人漂浮毒液滴）
             // 特效对象上限（Shockwave / FireWave / HealWave / LightningBolt）
             shockwaveLimit:   20,
             waveLimit:        10,
@@ -1148,6 +1149,7 @@ const CONFIG = {
             shardLimitWind:   10,
             sparkLimit:       50,  // spark 通用火星粒子上限（均衡模式）
             smokeLimit:       25,  // smoke 烟雾粒子上限（均衡模式）
+            venomLimit:       30,  // venom 毒液粒子上限（均衡模式）
             shockwaveLimit:   12,
             waveLimit:         6,
             lightningLimit:    8,
@@ -1179,6 +1181,7 @@ const CONFIG = {
             shardLimitWind:    4,
             sparkLimit:       20,  // spark 通用火星粒子上限（省电模式）
             smokeLimit:        8,  // smoke 烟雾粒子上限（省电模式）
+            venomLimit:        0,  // venom 毒液粒子上限（省电模式：完全关闭，仅保留敌人叠加层）
             shockwaveLimit:    6,
             waveLimit:         3,
             lightningLimit:    4,

--- a/src/core.js
+++ b/src/core.js
@@ -153,7 +153,7 @@ class Game {
         // [Perf] 粒子分模式计数表 - 替代 this.particles.filter(p=>p.mode==='X').length 的 O(N) 扫描
         // 维护契约：所有 push 必走 spawn_createParticle / spawn_pushParticleWithLimit；
         // 所有删除必走 game_phase.js 的两指针压缩循环（同步 -- 计数）。
-        this.particleCounts = { wind_slash: 0, line: 0, ember: 0, mist: 0, shard: 0, spark: 0, smoke: 0 };
+        this.particleCounts = { wind_slash: 0, line: 0, ember: 0, mist: 0, shard: 0, spark: 0, smoke: 0, venom: 0 };
         // [Perf] 粒子对象池 - 复用 Particle 实例，规避每帧 50-100 次 new 触发的 GC 停顿
         this._particlePool = [];
         this.shockwaves = [];

--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -85,6 +85,13 @@ class Particle {
             vel.x = (Math.random() - 0.5) * 0.5; vel.y = -Math.random() * 1.5 - 0.5;
             this.drag = 0.98; this.gravity = -0.02; this.decay = 0.015;
             this.size = Math.random() * 6 + 4; this.life = 1.2;
+        } else if (mode === 'venom') {
+            // 毒液滴：缓慢上浮，轻微横向摆动，半透明绿色液滴
+            vel.x = (Math.random() - 0.5) * 0.6;
+            vel.y = -(Math.random() * 1.2 + 0.4);
+            this.drag = 0.97; this.gravity = -0.04; this.decay = 0.012 + Math.random() * 0.008;
+            this.size = Math.random() * 2.5 + 1.5;
+            this.wobble = Math.random() * Math.PI * 2;
         } else if (mode === 'line') {
             vel.x = 0; vel.y = 0;
             this.drag = 0.98; this.gravity = 0; this.decay = 0.02;
@@ -107,6 +114,10 @@ class Particle {
     update(timeScale) {
         if (this.mode === 'ember') {
             this.pos.x += Math.sin(this.life * 10 + this.wobble) * 0.5 * timeScale;
+        }
+        if (this.mode === 'venom') {
+            // 毒液滴横向正弦摆动，模拟液体漂浮
+            this.pos.x += Math.sin(this.life * 6 + this.wobble) * 0.4 * timeScale;
         }
         // 湍流逻辑：在垂直于速度的方向上产生正弦波动
         if (this.turbulence > 0) {
@@ -222,6 +233,16 @@ class Particle {
             ctx.moveTo(-1, 0);
             ctx.lineTo(1, 0);
             ctx.stroke();
+
+        } else if (this.mode === 'venom') {
+            // @perf-impact: 毒液粒子渐变绘制 - 已通过 venomLimit 预算门控
+            ctx.globalCompositeOperation = 'screen';
+            const vg = ctx.createRadialGradient(0, 0, 0, 0, 0, this.size * 2.2);
+            vg.addColorStop(0, `rgba(200, 255, 180, ${this.life * 0.9})`);
+            vg.addColorStop(0.4, `rgba(74, 222, 128, ${this.life * 0.7})`);
+            vg.addColorStop(1, `rgba(22, 101, 52, 0)`);
+            ctx.fillStyle = vg;
+            ctx.beginPath(); ctx.arc(0, 0, this.size * 2.2, 0, Math.PI * 2); ctx.fill();
 
         } else {
             // 普通粒子 (spark/normal) 直接画圆，不用渐变

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -1538,6 +1538,68 @@ class Enemy {
             ctx.restore();
         }
 
+        // === Layer 3.4: 毒素状态视觉（venomStacks > 0 时显示）===
+        // @perf-impact: 新增毒素叠加层 - high/medium 档用 screen 混合+渐变，low 档仅简单色块
+        if ((this.venomStacks || 0) > 0) {
+            const _vPerfLevel = (typeof game !== 'undefined' && game.perfQualityLevel) || 'high';
+            const _vStacks = this.venomStacks;
+            const _vIntensity = Math.min(1, _vStacks / 10); // 10 层满溢
+            const _vTime = Date.now() / 1000;
+            // 毒素层数越多，脉冲越快
+            const _vPulse = (Math.sin(_vTime * (1.0 + _vIntensity * 1.5) + this.visualSeed * 4) + 1) * 0.5;
+            const _vBaseAlpha = 0.15 + _vIntensity * 0.3;
+            const _vPulseAlpha = _vBaseAlpha * (0.7 + _vPulse * 0.3);
+
+            ctx.save();
+            if (_vPerfLevel !== 'low') {
+                // high / medium: screen 混合 + 径向渐变，模拟内部毒液发光
+                ctx.globalCompositeOperation = 'screen';
+                const _vGrad = ctx.createRadialGradient(0, 0, 0, 0, 0, Math.max(w, h) * 0.7);
+                _vGrad.addColorStop(0, `rgba(134, 239, 172, ${_vPulseAlpha * 0.8})`);
+                _vGrad.addColorStop(0.5, `rgba(74, 222, 128, ${_vPulseAlpha * 0.5})`);
+                _vGrad.addColorStop(1, `rgba(22, 101, 52, 0)`);
+                ctx.fillStyle = _vGrad;
+                ctx.beginPath(); ctx.arc(0, 0, Math.max(w, h) * 0.7, 0, Math.PI * 2); ctx.fill();
+
+                // 毒液滴动画：沿边缘流淌的绿色液滴点（高性能档额外绘制）
+                if (_vPerfLevel === 'high') {
+                    const _dropCount = Math.min(5, 2 + Math.floor(_vStacks / 3));
+                    ctx.globalCompositeOperation = 'screen';
+                    for (let _di = 0; _di < _dropCount; _di++) {
+                        const _dSeed = this.visualSeed * 7 + _di * 1.618;
+                        // 液滴沿敌人下边缘滴落
+                        const _dX = (Math.sin(_dSeed) * 0.4) * w;
+                        const _dRise = ((_vTime * 0.4 + _dSeed) % 1);
+                        const _dY = h * 0.5 - _dRise * h * 1.2;
+                        if (_dY < -h * 0.5 - 6) continue;
+                        const _dAlpha = Math.sin(_dRise * Math.PI) * 0.7 * _vIntensity;
+                        if (_dAlpha <= 0) continue;
+                        ctx.globalAlpha = _dAlpha;
+                        ctx.fillStyle = '#4ade80';
+                        ctx.beginPath();
+                        ctx.ellipse(_dX, _dY, 2.5, 3.5, 0, 0, Math.PI * 2);
+                        ctx.fill();
+                    }
+                }
+            } else {
+                // low: 简单半透明色块，无渐变
+                ctx.globalAlpha = _vPulseAlpha * 0.4;
+                ctx.fillStyle = '#4ade80';
+                ctx.fillRect(-w/2, -h/2, w, h);
+            }
+            ctx.restore();
+
+            // 粒子发射：低概率从敌人顶部漂出毒液粒子（省电模式 venomLimit=0 会自然截止）
+            if (typeof game !== 'undefined' && typeof game.spawn_createParticle === 'function') {
+                const _emitProb = _vPerfLevel === 'high' ? 0.08 : (_vPerfLevel === 'medium' ? 0.04 : 0);
+                if (Math.random() < _emitProb * _vIntensity) {
+                    const _px = this.pos.x + (Math.random() - 0.5) * w;
+                    const _py = this.pos.y + this.bumpOffsetY - h * 0.3;
+                    game.spawn_createParticle(_px, _py, '#4ade80', 'venom');
+                }
+            }
+        }
+
         // === Layer 3.5: 内部词缀特效（严格裁剪在方块内，所有词缀统一处理）===
         if (this.affixes.length > 0) {
             const t35 = Date.now() / 1000;

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -1100,6 +1100,7 @@ export const spawn_system = {
         }
         if (mode === 'spark' && counts.spark >= (_budget.sparkLimit ?? 100)) return null;
         if (mode === 'smoke' && counts.smoke >= (_budget.smokeLimit ?? 60)) return null;
+        if (mode === 'venom' && counts.venom >= (_budget.venomLimit ?? 30)) return null;
 
         const pool = this._particlePool;
         let p;
@@ -1143,6 +1144,7 @@ export const spawn_system = {
         }
         if (mode === 'spark' && counts.spark >= (_budget.sparkLimit ?? 100)) return false;
         if (mode === 'smoke' && counts.smoke >= (_budget.smokeLimit ?? 60)) return false;
+        if (mode === 'venom' && counts.venom >= (_budget.venomLimit ?? 30)) return false;
 
         this.particles.push(p);
         if (counts[mode] !== undefined) counts[mode]++;


### PR DESCRIPTION
## Summary

- 新增 `venom` 粒子模式（缓慢上浮液滴，正弦摆动，screen 渐变绘制）
- Layer 3.4 毒素叠加层（venomStacks > 0 时绿色发光，三档门控）
- 命中毒层时喷射 1~4 颗毒液粒子
- 新增 venomLimit 预算（high:60 / medium:30 / low:0）全流程接入

## 性能自适应影响评估

- `high`: screen 径向渐变 + 液滴流淌动画 + 8%/帧粒子发射
- `medium`: 仅渐变叠加，粒子 4%/帧
- `low`: 纯色块，无渐变，venomLimit=0 完全关闭粒子

[perf-impact]