### PR TITLE
feat: 5个遗物视觉特效 + 弹夹逻辑修正 (doomsday_timer / hunter_instinct / mortal_burst / mirror_magazine / element_injector)

### DIFF
--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -2217,13 +2217,35 @@ export const combat_system = {
                 const burstRadius = Math.max(60, (enemy.width || 40) * 2);
                 const cx = enemy.pos.x;
                 const cy = enemy.pos.y;
-                // 爆炸视觉粒子
-                for (let i = 0; i < 8; i++) {
-                    this.spawn_createParticle(cx, cy, '#fb923c', 'spark');
+
+                // 殒命爆裂特效：橙红爆炸主题，体现尸体爆炸的暴烈感
+                // 1. 中心火焰波扩散（FireWave 橙红）
+                if (this.fireWaves) {
+                    this.fireWaves.push(new FireWave(cx, cy));
                 }
+                // 2. 双层冲击波（橙 → 深红，表现爆炸冲击与火焰余波）
+                if (typeof this.spawn_createShockwave === 'function') {
+                    this.spawn_createShockwave(cx, cy, '#fb923c');
+                    setTimeout(() => { if (this.spawn_createShockwave) this.spawn_createShockwave(cx, cy, '#b91c1c'); }, 100);
+                }
+                // 3. 大量橙红 ember 余烬粒子（焦碎感）
+                for (let i = 0; i < 14; i++) {
+                    if (typeof this.spawn_createParticle === 'function') {
+                        const p = this.spawn_createParticle(cx + (Math.random() - 0.5) * 20, cy + (Math.random() - 0.5) * 15, i % 3 === 0 ? '#fbbf24' : '#fb923c', 'ember');
+                        if (p) { p.vel.x = (Math.random() - 0.5) * 3; p.vel.y = -(Math.random() * 3.5 + 0.5); }
+                    }
+                }
+                // 4. spark 碎片（爆炸飞溅）
+                for (let i = 0; i < 10; i++) {
+                    if (typeof this.spawn_createParticle === 'function') {
+                        this.spawn_createParticle(cx, cy, i % 2 === 0 ? '#f97316' : '#fcd34d', 'spark');
+                    }
+                }
+                // 5. 浮动文字：骷髅 + 伤害（体现"殒命"主题）
                 if (typeof this.spawn_createFloatingText === 'function') {
-                    this.spawn_createFloatingText(cx, cy - 20, `殒命爆裂 ${burstDmg}`, '#fb923c');
+                    this.spawn_createFloatingText(cx, cy - 28, `💀 爆裂 ${burstDmg}`, '#fb923c');
                 }
+
                 for (const other of this.enemies) {
                     if (!other || !other.active || other === enemy) continue;
                     const dx = (other.pos.x - cx);
@@ -3217,10 +3239,35 @@ export const combat_system = {
             if (candidates.length > 0) {
                 const target = candidates[Math.floor(Math.random() * candidates.length)];
                 const dmg = (this.round || 1) * 5;
+                const cx = target.pos.x;
+                const cy = target.pos.y;
                 const result = target.takeDamage(dmg);
-                if (typeof this.spawn_createFloatingText === 'function') {
-                    this.spawn_createFloatingText(target.pos.x, target.pos.y - 24, `末日 ${dmg}`, '#fbbf24');
+
+                // 末日时钟特效：深红/黑金主题，模拟末日倒计时敲响
+                // 1. 三层扩散冲击波（血红 → 暗金 → 黑紫，错峰营造"钟声震颤"感）
+                if (typeof this.spawn_createShockwave === 'function') {
+                    this.spawn_createShockwave(cx, cy, '#dc2626');
+                    setTimeout(() => { if (this.spawn_createShockwave) this.spawn_createShockwave(cx, cy, '#854d0e'); }, 80);
+                    setTimeout(() => { if (this.spawn_createShockwave) this.spawn_createShockwave(cx, cy, '#4c1d95'); }, 160);
                 }
+                // 2. 向上漂浮的血红 ember 余烬粒子（模拟爆炸灰烬飞散）
+                for (let i = 0; i < 10; i++) {
+                    if (typeof this.spawn_createParticle === 'function') {
+                        const p = this.spawn_createParticle(cx + (Math.random() - 0.5) * 30, cy + (Math.random() - 0.5) * 20, '#dc2626', 'ember');
+                        if (p) { p.vel.x = (Math.random() - 0.5) * 2.5; p.vel.y = -(Math.random() * 3 + 1); }
+                    }
+                }
+                // 3. 黑金 spark 碎片四溅（钟面碎裂感）
+                for (let i = 0; i < 8; i++) {
+                    if (typeof this.spawn_createParticle === 'function') {
+                        this.spawn_createParticle(cx, cy, i % 2 === 0 ? '#fbbf24' : '#1c1917', 'spark');
+                    }
+                }
+                // 4. 浮动文字：骷髅图标 + 伤害数值，暗红色强调末日感
+                if (typeof this.spawn_createFloatingText === 'function') {
+                    this.spawn_createFloatingText(cx, cy - 36, `☠️ 末日 -${dmg}`, '#dc2626');
+                }
+
                 if (result && result.killed && typeof this.spawn_addScore === 'function') {
                     this.spawn_addScore(target.maxHp);
                 }

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1831,7 +1831,7 @@ phase_gathering_getRandomPegType() {
             // ------------------------------------
 
             // C. 绘制游戏实体
-            let activeEnemies = 0; 
+            let activeEnemies = 0;
             let anyEnemyMoving = false;
             this.enemies.forEach(e => {
                 if (e.active) {
@@ -1846,6 +1846,76 @@ phase_gathering_getRandomPegType() {
                     if (Math.abs(e.pos.y - e.dropTargetY) > 1) anyEnemyMoving = true;
                 }
             });
+
+            // [猎人本能] 绘制持续标记特效：找到血量最低的活跃敌人并渲染动态瞄准十字准星
+            if (this.ownedRelics && this.ownedRelics.includes('hunter_instinct')) {
+                let hunterTarget = null;
+                let lowestHp = Infinity;
+                for (const e of this.enemies) {
+                    if (e && e.active && e.hp > 0 && e.pos.y > 0) {
+                        if (e.hp < lowestHp) { lowestHp = e.hp; hunterTarget = e; }
+                    }
+                }
+                if (hunterTarget) {
+                    const tx = hunterTarget.pos.x;
+                    const ty = hunterTarget.pos.y;
+                    const ew = (hunterTarget.width || 40) * 0.5;
+                    const eh = (hunterTarget.height || 40) * 0.5;
+                    // 动画参数：基于时间的脉动/旋转
+                    const now = Date.now();
+                    const pulse = (Math.sin(now / 200) + 1) / 2;       // 0→1 脉动
+                    const spin = (now / 800) % (Math.PI * 2);           // 慢速旋转
+                    const innerR = (ew + 4) + pulse * 4;                // 动态内径
+                    const outerR = innerR + 10 + pulse * 3;
+                    const alpha = 0.65 + pulse * 0.35;
+
+                    this.ctx.save();
+                    this.ctx.translate(tx, ty);
+                    this.ctx.rotate(spin);
+                    this.ctx.globalCompositeOperation = 'lighter';
+
+                    // 外圈 — 橙红渐变光环
+                    const grad = this.ctx.createRadialGradient(0, 0, innerR * 0.7, 0, 0, outerR);
+                    grad.addColorStop(0, `rgba(239,68,68,0)`);
+                    grad.addColorStop(0.5, `rgba(239,68,68,${alpha * 0.4})`);
+                    grad.addColorStop(1, `rgba(239,68,68,0)`);
+                    this.ctx.fillStyle = grad;
+                    this.ctx.beginPath();
+                    this.ctx.arc(0, 0, outerR, 0, Math.PI * 2);
+                    this.ctx.fill();
+
+                    // 主光环边线
+                    this.ctx.strokeStyle = `rgba(239,68,68,${alpha})`;
+                    this.ctx.lineWidth = 2;
+                    this.ctx.shadowColor = '#ef4444';
+                    this.ctx.shadowBlur = _sb(8 + pulse * 6);
+                    this.ctx.beginPath();
+                    this.ctx.arc(0, 0, innerR, 0, Math.PI * 2);
+                    this.ctx.stroke();
+
+                    // 四条角缺口准星线（每条 120° 间隔断口，形成 4 段弧）
+                    const segAngles = [0, Math.PI * 0.5, Math.PI, Math.PI * 1.5];
+                    const segSpan = Math.PI * 0.32;
+                    this.ctx.lineWidth = 2.5;
+                    this.ctx.strokeStyle = `rgba(251,113,133,${alpha})`;
+                    for (const sa of segAngles) {
+                        this.ctx.beginPath();
+                        this.ctx.arc(0, 0, innerR + 6, sa - segSpan / 2, sa + segSpan / 2);
+                        this.ctx.stroke();
+                    }
+
+                    // 中心十字（短划线）
+                    const crossLen = 5 + pulse * 2;
+                    this.ctx.lineWidth = 1.5;
+                    this.ctx.strokeStyle = `rgba(239,68,68,${alpha * 0.9})`;
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(-crossLen, 0); this.ctx.lineTo(crossLen, 0);
+                    this.ctx.moveTo(0, -crossLen); this.ctx.lineTo(0, crossLen);
+                    this.ctx.stroke();
+
+                    this.ctx.restore();
+                }
+            }
 
             if (this.input_checkDefeat()) {
                 this.gameOver = true;

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -72,8 +72,12 @@ export const shop_system = {
         // 2. 准备遗物池
         // 过滤掉玩家已经拥有的遗物 (this.ownedRelics)
         const fateMomentRewardIds = new Set(['chaos_essence', 'pure_essence']);
+        // 开局义务选择（run_start）时排除需要现有弹药序列才能生效的遗物
+        const isRunStart = options.source === 'run_start';
+        const ammoRequiredRelics = new Set(['mirror_magazine', 'element_injector']);
         let pool = RELIC_DB.filter(r => {
             if (fateMomentRewardIds.has(r.id)) return false;
+            if (isRunStart && ammoRequiredRelics.has(r.id)) return false;
             const count = (this.ownedRelics || []).filter(id => id === r.id).length;
             const max = r.maxStacks || 1;
             return count < max;
@@ -357,9 +361,12 @@ export const shop_system = {
         // 只需要 ownedRelics 标记，运行时由 combat_system / projectile / round_start 钩子读取。
         // 这里仅处理需要"立即修改局内状态"的几个：mirror_magazine / element_injector / chaos_pact。
         if (relic.effect === 'mirror_magazine') {
-            // 立即将 ammoQueue 中"最强"那颗子弹（按 _scoreRecipeStrength 评分）复制一份加入末尾
-            const queue = this.ammoQueue || [];
-            if (queue.length > 0) {
+            // 立即将当前子弹序列中"最强"那颗子弹复制一份加入末尾。
+            // 优先操作 ammoQueue（战斗中已发射序列），回退到 _chargedAmmoQueue（命运选择后充能序列）。
+            const liveQueue = (this.ammoQueue && this.ammoQueue.length > 0) ? this.ammoQueue : null;
+            const chargedQueue = (this._chargedAmmoQueue && this._chargedAmmoQueue.length > 0) ? this._chargedAmmoQueue : null;
+            const queue = liveQueue || chargedQueue;
+            if (queue) {
                 let bestIdx = 0;
                 let bestScore = -Infinity;
                 for (let i = 0; i < queue.length; i++) {
@@ -370,11 +377,15 @@ export const shop_system = {
                 queue.push(cloned);
                 if (window.showToast) showToast(`镜像弹夹：复制了一颗强力子弹！`);
             } else {
-                if (window.showToast) showToast(`镜像弹夹：当前无弹药可复制，下回合自动失效。`);
+                if (window.showToast) showToast(`镜像弹夹：当前无弹药可复制。`);
             }
         } else if (relic.effect === 'element_injector') {
-            // 删除 ammoQueue 中最强和最弱的子弹，剩下那颗的所有属性层数翻倍
-            const queue = this.ammoQueue || [];
+            // 删除当前子弹序列中最强和最弱的子弹，剩下那颗的所有属性层数翻倍。
+            // 优先操作 ammoQueue，回退到 _chargedAmmoQueue。
+            const liveQueue = (this.ammoQueue && this.ammoQueue.length > 0) ? this.ammoQueue : null;
+            const chargedQueue = (this._chargedAmmoQueue && this._chargedAmmoQueue.length > 0) ? this._chargedAmmoQueue : null;
+            const usingCharged = !liveQueue && !!chargedQueue;
+            const queue = liveQueue || chargedQueue || [];
             if (queue.length >= 3) {
                 const scored = queue.map((r, i) => ({ i, score: _scoreRecipeStrength(r) }));
                 scored.sort((a, b) => a.score - b.score);
@@ -386,7 +397,8 @@ export const shop_system = {
                     if (!removeSet.has(i)) remaining.push(queue[i]);
                 }
                 remaining.forEach(_doubleRecipeAttrs);
-                this.ammoQueue = remaining;
+                if (usingCharged) { this._chargedAmmoQueue = remaining; }
+                else { this.ammoQueue = remaining; }
                 if (window.showToast) showToast(`元素注入器：剩余子弹属性层数翻倍！`);
             } else if (queue.length === 2) {
                 // 边界：仅 2 颗，删除最弱，保留最强并翻倍
@@ -394,11 +406,14 @@ export const shop_system = {
                 const s1 = _scoreRecipeStrength(queue[1]);
                 const survivor = s0 >= s1 ? queue[0] : queue[1];
                 _doubleRecipeAttrs(survivor);
-                this.ammoQueue = [survivor];
+                if (usingCharged) { this._chargedAmmoQueue = [survivor]; }
+                else { this.ammoQueue = [survivor]; }
                 if (window.showToast) showToast(`元素注入器：仅 2 颗子弹，强者属性翻倍！`);
             } else if (queue.length === 1) {
                 _doubleRecipeAttrs(queue[0]);
                 if (window.showToast) showToast(`元素注入器：唯一子弹属性翻倍！`);
+            } else {
+                if (window.showToast) showToast(`元素注入器：当前无弹药可注入。`);
             }
         } else if (relic.effect === 'chaos_pact') {
             // 立即获得 3 个随机稀有符文 + 设置永久伤害倍率


### PR DESCRIPTION
## Summary

- **镜像弹夹 (mirror_magazine)**: 优先操作 `ammoQueue`，为空时回退到 `_chargedAmmoQueue`，复制得分最高的子弹并追加到队列末尾
- **元素注入器 (element_injector)**: 同上双队列回退逻辑；删除最强 + 最弱子弹，剩余子弹所有属性层数翻倍；边界处理 2 颗 / 1 颗情形
- **开局义务选择过滤**: `run_start` 遗物选择时过滤掉 `mirror_magazine` / `element_injector`（开局无弹药序列，选了也无效）
- **末日时钟 (doomsday_timer)**: 每回合开始随机打击一名敌人，产生红→琥珀→紫三段冲击波 + 10 ember + 8 spark 粒子 + 骷髅浮字 ☠️ 末日 -N
- **猎人本能 (hunter_instinct)**: 战斗层 Layer 2 持续渲染旋转动态准心，锁定当前血量最低的存活敌人，带径向光晕 + 4 段弧线 + 中心十字
- **殒命爆裂 (mortal_burst)**: 击杀触发 FireWave + 双层冲击波（橙→深红）+ 14 ember + 10 spark + 骷髅浮字 💀 爆裂 N

## Test plan

- [ ] 拾取 `mirror_magazine`：战斗中弹药队列应多一颗最强子弹的克隆；战斗外应操作 `_chargedAmmoQueue`
- [ ] 拾取 `element_injector`：≥3 颗时删头尾、剩余翻倍；2 颗时保留最强并翻倍；1 颗直接翻倍
- [ ] 开局遗物选择界面不出现 `mirror_magazine` 和 `element_injector`
- [ ] 拥有 `doomsday_timer`，进入新一回合时可见冲击波 + 粒子 + 浮字特效
- [ ] 拥有 `hunter_instinct`，战斗中血量最低的敌人身上持续显示旋转准心光晕
- [ ] 拥有 `mortal_burst`，击杀敌人时触发火浪 + 双层冲击波 + 粒子爆发 + 浮字

https://claude.ai/code/session_01EBwEFwJFGfGjNzjpBLmFNp