### PR TITLE
fix: correct CONFIG guard in _tryTriggerEchoBullet to prevent TypeError

### DIFF
--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -681,8 +681,8 @@ class Projectile {
 
         const echoRes = game.activeElementResonances && game.activeElementResonances['echo'];
         const echoResParams = echoRes ? echoRes.params : null;
-        const baseChance = (CONFIG.mechanics && CONFIG.mechanics.echo && CONFIG.balance.echo.baseTriggerChance) || 0.25;
-        const chancePerLevel = (CONFIG.mechanics && CONFIG.mechanics.echo && CONFIG.balance.echo.chancePerLevel) || 0.05;
+        const baseChance = (CONFIG.balance && CONFIG.balance.echo && CONFIG.balance.echo.baseTriggerChance) || 0.25;
+        const chancePerLevel = (CONFIG.balance && CONFIG.balance.echo && CONFIG.balance.echo.chancePerLevel) || 0.05;
         const triggerBonus = echoResParams ? (echoResParams.triggerChanceBonus || 0) : 0;
         const inheritRatio = echoResParams ? (echoResParams.inheritRatio || 0.5) : 0.5;
         const triggerChance = Math.min(1.0, baseChance + echoLevel * chancePerLevel + triggerBonus);


### PR DESCRIPTION
## Summary

- Fixed `TypeError: Cannot read properties of undefined (reading 'baseTriggerChance')` crash in `_tryTriggerEchoBullet` (projectile.js:684)
- The guard on lines 684-685 checked `CONFIG.mechanics.echo` but then read from `CONFIG.balance.echo` without guarding `CONFIG.balance`
- Changed both lines to guard via `CONFIG.balance && CONFIG.balance.echo` consistently

## Root Cause

```js
// Before — wrong namespace in guard
(CONFIG.mechanics && CONFIG.mechanics.echo && CONFIG.balance.echo.baseTriggerChance)

// After — consistent guard on the namespace being read
(CONFIG.balance && CONFIG.balance.echo && CONFIG.balance.echo.baseTriggerChance)
```

## Test plan

- [ ] Fire projectiles with `echo > 0` and trigger wall bounces — no TypeError in console
- [ ] Verify echo bullet spawns in mirror direction on bounce
- [ ] Confirm fallback values (0.25 base chance, 0.05 per level) apply when `CONFIG.balance.echo` is absent

https://claude.ai/code/session_01EXPBRQujxfoSmmju6vG9W3