### PR TITLE
fix: 清场检测排除顶部墙外的敌人

### DIFF
--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1185,8 +1185,8 @@ phase_gathering_getRandomPegType() {
     phase_finalizeRound() {
         // 1. 统计当前存活敌人数据
         const activeEnemies = this.enemies.filter(e => e.active);
-        // [清屏检测] 记录本回合是否完成了清屏，供下一回合生成逻辑使用
-        const clearedThisRound = activeEnemies.length === 0;
+        // [清屏检测] 仅统计围墙内（pos.y > 0）的敌人：墙外敌人无法被子弹击中，不应计入清场判定
+        const clearedThisRound = !activeEnemies.some(e => e.pos.y > 0);
         // 使用 Set 统计有多少个不同的 Y 坐标（即有多少行）
         // Math.round 处理浮点误差，/50 是行高，确保归类准确
         const uniqueRows = new Set(activeEnemies.map(e => Math.round(e.pos.y / this.enemyHeight)));


### PR DESCRIPTION
## Summary

- `phase_finalizeRound()` 的清场判定（`clearedThisRound`）改为只统计围墙内（`pos.y > 0`）的敌人，与战斗循环中 `activeEnemies` 计数器的逻辑保持一致
- 墙外敌人无法被子弹击中，不应阻断清场奖励（`_prevRoundCleared`）和围墙清空抽奖的触发

## 变更

`src/game_phase.js:1189`

```js
// Before
const clearedThisRound = activeEnemies.length === 0;

// After
const clearedThisRound = !activeEnemies.some(e => e.pos.y > 0);
```

## Test plan

- [ ] 战斗阶段打光所有可见敌人（围墙内），确认清场奖励正常触发，即使仍有敌人在顶部墙外等待入场
- [ ] 确认正常情况（围墙内有存活敌人）下清场奖励不会误触发

https://claude.ai/code/session_01NUNfT8msgZ1hEG46F6Se8w