### PR TITLE
feat(enemies): V2 视觉重设计——尺寸基底 + 专属词条体系

### DIFF
--- a/.cursor/rules/enemy_index.md
+++ b/.cursor/rules/enemy_index.md
@@ -1,8 +1,46 @@
 # 敌人词缀与 Boss 索引 (Enemy Affix & Boss Index)
 
-> **数据来源**：`src/config.js` → `balance.affixes`, `balance.bossConfigs`, `BOSS_DB`, `ENEMY_CURVE_CONFIG`；`src/spawn_system.js` → `spawn_generateAffixes()`, `spawn_scheduleNextBoss()`；`src/systems.js` → `TRUTH_BOOK_DATA.enemies`
-> **用途**：Agent 快速查询 8 种敌人词缀和 8 个 Boss 的行为机制、出现回合、克制属性及关键代码位置。
-> **最后更新**：调整敌人与 Boss 血量算法，优化数值平衡（2026-04-23）
+> **数据来源**：`src/config.js` → `balance.affixes`, `balance.bossConfigs`, `BOSS_DB`, `ENEMY_CURVE_CONFIG`；`src/spawn_system.js` → `spawn_generateAffixes()`, `spawn_trySpawnArchetypes()`, `spawn_scheduleNextBoss()`；`src/systems.js` → `TRUTH_BOOK_DATA.enemies`
+> **用途**：Agent 快速查询 8 种通用词缀、7 种 V2 基底专属词缀和 8 个 Boss 的行为机制、出现回合、克制属性及关键代码位置。
+> **最后更新**：V2 敌人视觉重设计——尺寸基底 + 专属词条体系（2026-05-02）
+
+## 0. V2 基底专属词条总览（7 种，仅通过基底敌人附带，不进入随机词条池）
+
+> 详见敌人视觉设计 V2 文档。所有基底专属词条均由 `spawn_trySpawnArchetypes()` 在生成大型基底敌人时一次性注入，**不会**通过 `spawn_generateAffixes()` 随机分配。
+
+| 词条 ID | 中文名 | 绑定基底 | 默认尺寸 (cols×rows) | 最早出现回合 | 同屏上限 |
+|---|---|---|---|---|---|
+| `heavyArmor` | 装甲横梁 | bastion | 3×1 | R5 | 不限（每行最多 1 个大型基底） |
+| `deflectionWard` | 棱盾兽 | deflector | 2×1 | R9 | 不限 |
+| `echoRelay` | 共振尖塔 | echoSpire | 1×2 | R10 | 不限 |
+| `devour` | 深渊胃囊 | maw | 2×2 | R12 | ≤ 2 |
+| `prism` | 折光棱柱 | prism | 1×3 | R16 | 不限 |
+| `hive` | 孵化巢 | hive | 2×3 | R18 | ≤ 1 |
+| `siege` | 攻城履带 | siege | 3×2 | R22 | ≤ 1 |
+| `gravityWell` | 引力炉心 | gravityWell | 3×3 | R30 | ≤ 1（出现时跳过其他大型基底） |
+
+### V2 词条行为速查
+
+| 词条 | 行为概要 | 关键代码 |
+|---|---|---|
+| `deflectionWard` | 屏障 = `maxHp × deflectionWardBarrierPct (=10%)`；只吸收 pierce/bounce 类伤害；普通直击、火焰 DoT、毒素 DoT 绕过；未被打破则每回合开始回满 | `enemy.js#takeDamage` 顶部分支；`game_phase.js#phase_enemy_startLogic` 重置块 |
+| `echoRelay` | 每回合额外触发一次周围（半径 ≈ 1.5×width + 0.5×height）敌人的 regen/healer/clone/haste；自身 HP 倍率为 0.5；同回合每个目标只被 echo 一次（`_echoedThisTurn`） | `Enemy._echoRelayRetrigger` 静态方法；`executeTurnAction` 末尾分支 |
+| `prism` | 与 shield 共用激光偏折面入口；命中伤害按 `prismLaserDeflect (=0.5)` 衰减；产生七色折射粒子 | `combat/collision.js` 激光检测；`combat_system.js` `hitType === 'prism'` 分支 |
+| `hive` | 每 `hiveSpawnInterval (=2)` 回合在巢周围生成血量为自身 `hiveSpawnHpPct (=15%)` 的低血量幼体（无词条，标记 `_isHiveLarva`） | `Enemy._hiveSpawnLarva` 静态方法 |
+| `siege` | 每 `siegePushInterval (=3)` 回合执行一次 `+siegePushRows (=2)` 行的额外推进 | `executeTurnAction` siege 分支 |
+| `gravityWell` | 在 `gravityWellPullRadius (=220px)` 半径内对所有带速度的子弹按 `gravityWellPullStrength (=0.18)` 施加回拉力 | `projectile.js#update` 顶部块 |
+
+### V2 基底生成流程
+
+| 步骤 | 描述 |
+|---|---|
+| 1. 入口 | `spawn_spawnEnemyRowAt` 在普通敌人填充前调用 `spawn_trySpawnArchetypes` |
+| 2. 总体概率 | `Math.min(0.40, 0.10 + round × 0.012)` |
+| 3. 候选筛选 | 排除回合数不足、同屏数量超限、`gravityWell` 在场时跳过其他大型 |
+| 4. 加权抽签 | 按 `weight` 字段（`gravityWell=0.025` … `bastion=0.18`）随机一个基底 |
+| 5. 位置寻找 | 洗牌列起点，逐个尝试连续 cols 列的空闲位置；失败则放弃本行 |
+| 6. 实例化 | 设置 `width = cols × enemyWidth`、`height = rows × enemyHeight`、`baseArchetype`、`gridCols`、`gridRows`、专属词条、移动间隔、特效 |
+| 7. 形状 | 调用 `spawn_applyArchetypeShape(e, archetypeId)` 注入语义轮廓（胃囊缺口、棱镜菱形、引力圆等） |
 
 ## 1. 敌人词缀总览（8 种）
 

--- a/src/combat/collision.js
+++ b/src/combat/collision.js
@@ -92,8 +92,10 @@ export const CollisionSystem = {
             if (d > 0 && d < closest.dist) closest = { dist: d, hitType: 'wall', normal: 'y' };
         }
         // 2. 检测带盾敌人 (视为反射面)
+        //    [V2 prism] 折光棱柱（prism 词条）也作为激光偏折面参与处理。
         this.enemies.forEach(e => {
-            if (!e.active || !e.affixes.includes('shield')) return;
+            if (!e.active) return;
+            if (!(e.affixes.includes('shield') || e.affixes.includes('prism'))) return;
 
             // 使用线段与矩形相交检测（Slab method 简化版）
             const halfW = e.width / 2 + 5;
@@ -113,7 +115,7 @@ export const CollisionSystem = {
 
                 closest = {
                     dist: t,
-                    hitType: 'shield',
+                    hitType: e.affixes.includes('prism') ? 'prism' : 'shield',
                     normal: nx > ny ? 'x' : 'y',
                     enemy: e
                 };

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -2921,6 +2921,17 @@ export const combat_system = {
                         this.combat_damageEnemy(hitResult.enemy, { config: taskRecipe, pos: nextPos, isCopy: false });
                         audio.playHit('bounce');
                         this.spawn_createParticle(nextPos.x, nextPos.y, '#3b82f6', 'spark');
+                    } else if (hitResult.hitType === 'prism') {
+                        // [V2 prism] 折光棱柱：分束折射，命中伤害按 prismLaserDeflect 衰减
+                        const deflect = (CONFIG.balance.affixes && CONFIG.balance.affixes.prismLaserDeflect) || 0.5;
+                        const reducedRecipe = Object.assign({}, taskRecipe, { damage: (taskRecipe.damage || 0) * deflect });
+                        this.combat_damageEnemy(hitResult.enemy, { config: reducedRecipe, pos: nextPos, isCopy: false });
+                        audio.playHit('bounce');
+                        // 折光七色粒子
+                        const prismCols = ['#ef4444', '#22c55e', '#3b82f6', '#a855f7', '#facc15'];
+                        for (let i = 0; i < 4; i++) {
+                            this.spawn_createParticle(nextPos.x, nextPos.y, prismCols[Math.floor(Math.random() * prismCols.length)], 'spark');
+                        }
                     }
 
                     // 镜面反射方向

--- a/src/config.js
+++ b/src/config.js
@@ -526,6 +526,42 @@ const CONFIG = {
             heavyArmorHpMult: 2.0,      // 重装：血量倍率
             heavyArmorMoveInterval: 2,  // 重装：移动间隔（回合数）
             heavyArmorWideGridCols: 3,  // 重装变种：占3列宽
+
+            // ============================================
+            // [V2 基底专属词条] 详见 design_spec_bitmap.md / 敌人视觉重设计 V2 文档
+            // 这些词条只通过 spawn_trySpawnArchetype 生成的大型基底敌人附带，
+            // 不进入 ENEMY_CURVE_CONFIG.AFFIX_WEIGHT_CURVES 的随机词条池。
+            // ============================================
+
+            // [deflectionWard] 棱盾兽 2x1 偏折屏障
+            deflectionWardBarrierPct: 0.10,   // 屏障值 = maxHp × 10%
+            deflectionWardHpMult: 1.0,        // 棱盾兽血量倍率（基底 hp 系数）
+
+            // [echoRelay] 共振尖塔 1x2 回响中继
+            echoRelayHpPct: 0.5,              // 自身最大生命值为同回合标准精英的 50%
+            echoRelayRange: 1.5,              // 触发周围敌人词条的范围（自身宽度倍数）
+            echoRelayHpMult: 0.5,             // 与基底 hp 联动的最终倍率（与 echoRelayHpPct 等效）
+
+            // [prism] 折光棱柱 1x3 折光（基础减伤 + 激光分束）
+            prismLaserDeflect: 0.5,           // 激光命中时分束伤害衰减比
+            prismHpMult: 1.4,                 // 折光棱柱血量倍率（高于普通敌人）
+
+            // [hive] 孵化巢 2x3 周期生成弱小单位
+            hiveSpawnInterval: 2,             // 每隔几回合孵化一次
+            hiveSpawnHpPct: 0.15,             // 幼体血量为基底 baseHP 的比例
+            hiveHpMult: 2.5,                  // 孵化巢自身血量倍率
+
+            // [siege] 攻城履带 3x2 低频重压
+            siegePushInterval: 3,             // 每隔几回合执行一次重压推进
+            siegePushRows: 2,                 // 重压推进的行数
+            siegeHpMult: 3.5,                 // 攻城履带血量倍率
+            siegeMoveInterval: 2,             // 普通回合移动间隔（迟缓）
+
+            // [gravityWell] 引力炉心 3x3 大型场控
+            gravityWellPullStrength: 0.18,    // 弹道回拉强度（0~1，乘以方向矢量）
+            gravityWellPullRadius: 220,       // 引力影响半径（像素）
+            gravityWellHpMult: 6.0,           // 引力炉心血量倍率
+            gravityWellMoveInterval: 3,       // 移动间隔（极慢）
         },
 
         // =========================================

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -1068,6 +1068,36 @@ class Enemy {
             if(this.affixes.includes('clone') && Math.random() < afx.cloneChanceTurn) {
                 game.spawn_triggerCloneSpawn(this);
             }
+
+            // --- 5. [V2 hive] 孵化巢：周期性孵化弱小幼体 ---
+            if (this.affixes.includes('hive')) {
+                if (this._hiveCooldown === undefined) this._hiveCooldown = afx.hiveSpawnInterval || 2;
+                this._hiveCooldown--;
+                if (this._hiveCooldown <= 0) {
+                    this._hiveCooldown = afx.hiveSpawnInterval || 2;
+                    Enemy._hiveSpawnLarva(this, game, afx);
+                }
+            }
+
+            // --- 6. [V2 siege] 攻城履带：周期性重压推进（额外推进数行） ---
+            if (this.affixes.includes('siege')) {
+                if (this._siegeCooldown === undefined) this._siegeCooldown = afx.siegePushInterval || 3;
+                this._siegeCooldown--;
+                if (this._siegeCooldown <= 0) {
+                    this._siegeCooldown = afx.siegePushInterval || 3;
+                    const pushRows = afx.siegePushRows || 2;
+                    const pushAmount = game.enemyHeight * pushRows;
+                    this.advance(pushAmount);
+                    this.bumpOffsetY = -8;
+                    game.spawn_createFloatingText(this.pos.x, this.pos.y - 40, `🚜SIEGE +${pushRows}`, '#facc15');
+                    game.spawn_createShockwave(this.pos.x, this.pos.y, '#facc15');
+                }
+            }
+
+            // --- 7. [V2 echoRelay] 回响中继：额外触发一次周围敌人的词条效果 ---
+            if (this.affixes.includes('echoRelay')) {
+                Enemy._echoRelayRetrigger(this, game, afx);
+            }
         }
 
         // --- [改动] 移动与跳跃：移出循环，始终只执行一次 ---
@@ -4130,7 +4160,36 @@ class Enemy {
     // @section:damage_shield_check - 护盾吸收与穿透判断
     takeDamage(amount, source = null, bypassShield = false) {
         let actualDamage = amount;
-        
+
+        // 0. [V2 deflectionWard] 偏折屏障：仅吸收"反弹"和"穿透"类伤害
+        //    - 直击伤害（无 pierce/bounce）、火焰持续伤害（bypassShield=true）、毒素 DoT 不受屏障影响
+        //    - 屏障值 = maxHp × deflectionWardBarrierPct，每回合开始若未破则回满
+        if (this.affixes && this.affixes.includes('deflectionWard') && (this.wardBarrier || 0) > 0 && !bypassShield) {
+            const cfg = source && source.config;
+            const isPierce = !!(cfg && cfg.pierce > 0);
+            const isBounceHit = !!(cfg && cfg.bounce > 0
+                && source.bouncesLeft !== undefined && source.bouncesLeft < cfg.bounce);
+            // 即使是首次命中（未弹跳），bounce 配置仍代表"反弹流派"，按规范也应被屏障吸收
+            const isBounceConfig = !!(cfg && cfg.bounce > 0);
+            if (isPierce || isBounceHit || isBounceConfig) {
+                const before = this.wardBarrier;
+                const absorbed = Math.min(this.wardBarrier, actualDamage);
+                this.wardBarrier -= absorbed;
+                actualDamage -= absorbed;
+                if (typeof game !== 'undefined') {
+                    game.spawn_createFloatingText(this.pos.x, this.pos.y - 18, `🔷-${Math.ceil(absorbed)}`, '#67e8f9');
+                }
+                if (this.wardBarrier <= 0) {
+                    this.wardBrokenThisTurn = true;
+                    if (typeof game !== 'undefined') {
+                        game.spawn_createParticle(this.pos.x, this.pos.y, '#67e8f9', 'shard');
+                        game.spawn_createFloatingText(this.pos.x, this.pos.y - 36, '🔷BREAK', '#22d3ee');
+                    }
+                }
+                if (actualDamage <= 0) return { actualDamage: Math.ceil(absorbed), killed: false, deflected: true };
+            }
+        }
+
         // 1. 计算护盾逻辑 (优化版)
         if (this.affixes.includes('shield') && !bypassShield) {
             // A. 方向判定：检查是否从后方 (上方) 攻击
@@ -5272,6 +5331,116 @@ class Enemy {
             // 我们约定新逻辑下 vertices 存储的是相对中心点的偏移
             return new Vec2(this.pos.x + v.x, this.pos.y + v.y);
         });
+    }
+
+    // ==================== [V2 基底专属词条] 静态辅助 ====================
+
+    /**
+     * @static
+     * @method _hiveSpawnLarva
+     * @description [hive] 在孵化巢下方/侧方寻找空位生成一个低血量幼体（无词条）。
+     *              幼体血量为 baseHP（按巢血量近似）的 hiveSpawnHpPct 比例。
+     */
+    static _hiveSpawnLarva(host, game, afx) {
+        if (!game || !host || !host.active) return;
+        const w = game.enemyWidth, h = game.enemyHeight;
+        const candidatePositions = [
+            new Vec2(host.pos.x,           host.pos.y + host.height / 2 + h / 2),
+            new Vec2(host.pos.x - w,       host.pos.y + host.height / 2 + h / 2),
+            new Vec2(host.pos.x + w,       host.pos.y + host.height / 2 + h / 2),
+            new Vec2(host.pos.x - host.width / 2 - w / 2, host.pos.y),
+            new Vec2(host.pos.x + host.width / 2 + w / 2, host.pos.y),
+        ];
+        for (const p of candidatePositions) {
+            if (p.x < w / 2 || p.x > game.width - w / 2) continue;
+            if (game.calc_isAreaOccupied(p.x, p.y, w * 0.8, h * 0.8)) continue;
+            const pct = (afx && afx.hiveSpawnHpPct) || 0.15;
+            const larvaHp = Math.max(1, Math.floor(host.maxHp * pct));
+            const larva = new Enemy(p.x, p.y, w, h, larvaHp);
+            larva.affixes = [];
+            larva.type = 'normal';
+            larva._isHiveLarva = true;
+            larva.dropTargetY = p.y;
+            larva.hasActedThisTurn = true;
+            if (typeof game.sys_determineEnemyReward === 'function') {
+                game.sys_determineEnemyReward(larva, false);
+            }
+            if (typeof larva.initSprite === 'function') larva.initSprite();
+            game.enemies.push(larva);
+            game.spawn_createParticle(p.x, p.y, '#a3e635', 'mist');
+            game.spawn_createFloatingText(host.pos.x, host.pos.y - 50, '🥚HATCH', '#a3e635');
+            return;
+        }
+    }
+
+    /**
+     * @static
+     * @method _echoRelayRetrigger
+     * @description [echoRelay] 额外触发一次周围敌人的词条效果。
+     *              "周围"按尖塔占格外缘一圈计算（用 1.5 倍尖塔宽度作为半径）。
+     *              触发的词条限制为 regen / healer / clone / devour / haste（位置相关词条不重复触发）。
+     *              每个被触发的目标本回合最多被 echo 一次（_echoedThisTurn 标记），避免多塔叠加失控。
+     */
+    static _echoRelayRetrigger(spire, game, afx) {
+        if (!game || !spire || !spire.active) return;
+        const range = spire.width * (afx && afx.echoRelayRange ? afx.echoRelayRange : 1.5)
+            + (spire.height * 0.5);
+        let triggered = 0;
+        for (const other of game.enemies) {
+            if (!other || !other.active || other === spire) continue;
+            if (other._echoedThisTurn) continue;
+            if (spire.pos.dist(other.pos) > range) continue;
+            const list = other.affixes || [];
+            let didEcho = false;
+
+            // regen：再生一次
+            if (list.includes('regen') && other.hp < other.maxHp) {
+                const heal = Math.floor(other.maxHp * (afx.regenPercent || 0.2)) || 1;
+                other.hp = Math.min(other.maxHp, other.hp + heal);
+                game.spawn_createFloatingText(other.pos.x, other.pos.y - 30, `+${heal}`, '#4ade80');
+                didEcho = true;
+            }
+            // healer：对邻居再治疗一次（治疗本人不结算，仅周围）
+            if (list.includes('healer')) {
+                const range2 = other.width * (afx.healerRange || 2);
+                game.enemies.forEach(t => {
+                    if (t !== other && t.active && t.hp < t.maxHp && other.pos.dist(t.pos) < range2) {
+                        const healAmt = Math.ceil(t.maxHp * (afx.healerPercent || 0.12));
+                        if (t.hp > t.greenHp) t.greenHp = t.hp;
+                        t.hp = Math.min(t.maxHp, t.hp + healAmt);
+                        didEcho = true;
+                    }
+                });
+            }
+            // clone：额外触发一次分身（按 cloneChanceTurn 概率）
+            if (list.includes('clone') && Math.random() < (afx.cloneChanceTurn || 0.5)) {
+                if (typeof game.spawn_triggerCloneSpawn === 'function') {
+                    game.spawn_triggerCloneSpawn(other);
+                    didEcho = true;
+                }
+            }
+            // haste：额外触发一次冲刺移动
+            if (list.includes('haste')) {
+                const moveAmount = game.enemyHeight;
+                const targetY = other.dropTargetY + moveAmount;
+                const isBlocked = game.calc_isAreaOccupied(other.pos.x, targetY, other.width * 0.8, other.height * 0.8, other);
+                if (!isBlocked) {
+                    other.advance(moveAmount);
+                    game.spawn_createFloatingText(other.pos.x, other.pos.y - 50, '⚡ECHO!', '#f0abfc');
+                    didEcho = true;
+                }
+            }
+
+            if (didEcho) {
+                other._echoedThisTurn = true;
+                triggered++;
+            }
+        }
+
+        if (triggered > 0) {
+            game.spawn_createShockwave(spire.pos.x, spire.pos.y, '#f0abfc');
+            game.spawn_createFloatingText(spire.pos.x, spire.pos.y - 30, `🔮ECHO ×${triggered}`, '#f0abfc');
+        }
     }
 }
 

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -157,6 +157,28 @@ class Projectile {
         // [优化 1] 增加空气阻力，防止无限加速导致的隧穿 (可选，这里设为 1.0 表示无阻力)
         this.vel = this.vel.mult(1.0);
 
+        // [V2 gravityWell] 引力炉心：对附近的子弹施加微弱回拉，造成可预测的弹道偏折
+        // 仅对带速度的常规子弹生效；激光/风刀等无 vel 主体不在此处理。
+        if (this.vel && this.vel.mag() > 0.1) {
+            const cfgAfx = (typeof CONFIG !== 'undefined' && CONFIG.balance) ? CONFIG.balance.affixes : null;
+            if (cfgAfx) {
+                const pullR = cfgAfx.gravityWellPullRadius || 220;
+                const pullS = cfgAfx.gravityWellPullStrength || 0.18;
+                for (const e of enemies) {
+                    if (!e || !e.active || !e.affixes || !e.affixes.includes('gravityWell')) continue;
+                    const dx = e.pos.x - this.pos.x;
+                    const dy = e.pos.y - this.pos.y;
+                    const dist = Math.hypot(dx, dy);
+                    if (dist > 1 && dist < pullR) {
+                        const falloff = 1 - dist / pullR;
+                        const accel = pullS * falloff * timeScale;
+                        this.vel.x += (dx / dist) * accel;
+                        this.vel.y += (dy / dist) * accel;
+                    }
+                }
+            }
+        }
+
         // [优化 2] 动态子步进计算
         // 确保每一步移动距离不超过半径的 50%，大幅提升高速碰撞的稳定性
         const speed = this.vel.mag();

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1158,6 +1158,21 @@ phase_gathering_getRandomPegType() {
             // [照射词条] 回合结束时清零照射叠加层数，防止残留到下一回合
             if (e._irradiationStacks) e._irradiationStacks = 0;
 
+            // [V2 echoRelay] 重置回合内的 echo 触发标记
+            e._echoedThisTurn = false;
+
+            // [V2 deflectionWard] 偏折屏障：若上一回合未被击破，则本回合开始恢复至满屏障值
+            if (e.affixes && e.affixes.includes('deflectionWard')) {
+                if (e.wardBarrierMax === undefined) {
+                    const pct = (CONFIG.balance.affixes && CONFIG.balance.affixes.deflectionWardBarrierPct) || 0.10;
+                    e.wardBarrierMax = Math.max(1, Math.floor(e.maxHp * pct));
+                }
+                if (!e.wardBrokenThisTurn) {
+                    e.wardBarrier = e.wardBarrierMax;
+                }
+                e.wardBrokenThisTurn = false;
+            }
+
             // [Boss 移动提示预计算]
             // 在回合开始时预计算 Boss 本回合是否会移动，以便 UI 标签能在回合开始时就显示正确提示
             if (e.type === 'boss' && e.bossType && typeof e._moveCooldown !== 'undefined') {

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -459,58 +459,12 @@ export const spawn_system = {
         }
 
         // =========================================
-        // 2.5 重装变种（3x1 宽型敌人）预生成
+        // 2.5 V2 基底敌人（尺寸+专属词条）预生成
         // =========================================
-        // 从第5回合起，有一定概率在当前行生成一个占3列宽的重装变种。
-        // 重装变种具有 heavyArmor 词条：血量翻倍，每2回合才能移动一次。
-        const _haAfxCfg = CONFIG.balance.affixes;
-        const _haMinRound = 5;
-        const _haSpawnChance = Math.min(0.22, 0.06 + this.round * 0.008); // 随回合数增加，最高22%
-        const _haCols = (_haAfxCfg && _haAfxCfg.heavyArmorWideGridCols) || 3;
-        if (this.round >= _haMinRound && Math.random() < _haSpawnChance) {
-            // 查找连续空闲的 _haCols 列
-            const _totalCols = CONFIG.gameplay.enemyCols;
-            for (let _sc = 0; _sc <= _totalCols - _haCols; _sc++) {
-                let _colsFree = true;
-                for (let _dc = 0; _dc < _haCols; _dc++) {
-                    if (occupiedCols[_sc + _dc]) { _colsFree = false; break; }
-                }
-                if (!_colsFree) continue;
-                // 宽敌人中心 X = 起始列 + (cols/2) 个单元格宽度的中心
-                const _wideCenterX = (_sc + (_haCols - 1) / 2) * w + w / 2;
-                const _wideW = w * _haCols;
-                if (this.calc_isAreaOccupied(_wideCenterX, yPos, _wideW * 0.85, this.enemyHeight * 0.85)) continue;
-                // 血量：应用重装词条翻倍系数
-                const _haMult = (_haAfxCfg && _haAfxCfg.heavyArmorHpMult) || 2.0;
-                const _haHp = Math.floor(baseHP * _haMult * (0.9 + Math.random() * 0.2));
-                const _haEnemy = new Enemy(_wideCenterX, yPos, _wideW, this.enemyHeight, _haHp);
-                _haEnemy.affixes = ['heavyArmor'];
-                _haEnemy.type = 'elite';
-                _haEnemy.isWideEnemy = true;
-                _haEnemy.gridCols = _haCols;
-                // 初始化重装移动冷却
-                _haEnemy._moveInterval = (_haAfxCfg && _haAfxCfg.heavyArmorMoveInterval) || 2;
-                _haEnemy._moveCooldown = 0;
-                if (options.offScreenEntrance) {
-                    _haEnemy.pos.y = yPos - 2 * this.enemyHeight;
-                    _haEnemy.hasActedThisTurn = true;
-                    _haEnemy._spawnedThisTurn = true;
-                }
-                _haEnemy._spawnColIndex = _sc + Math.floor(_haCols / 2);
-                // 标记占用的所有列
-                for (let _dc = 0; _dc < _haCols; _dc++) occupiedCols[_sc + _dc] = true;
-                // 掉落判定
-                if (typeof this.sys_determineEnemyReward === 'function') {
-                    this.sys_determineEnemyReward(_haEnemy, false);
-                }
-                // Sprite 初始化
-                if (typeof _haEnemy.initSprite === 'function') _haEnemy.initSprite();
-                this.enemies.push(_haEnemy);
-                // 入场特效：蓝灰色冲击波突出重型单位
-                this.spawn_createShockwave(_haEnemy.pos.x, _haEnemy.pos.y, '#94a3b8');
-                break; // 每行最多一个重装变种
-            }
-        }
+        // 详见 design_spec_bitmap.md / "敌人视觉设计 V2" 文档：
+        // 不同尺寸（1x1、2x1、1x2、2x2、3x1、1x3、2x3、3x2、3x3）对应不同基底，
+        // 每个基底绑定一个专属词条；专属词条不进入随机词条池。
+        this.spawn_trySpawnArchetypes(yPos, baseHP, occupiedCols, w, options);
 
         // =========================================
         // 3. 填充剩余空位 (Fill Loop)
@@ -2236,6 +2190,250 @@ export const spawn_system = {
 
             default:
                 // 无 Boss 历史或未知 Boss：默认 AABB
+                e.collisionShape = 'aabb';
+                e.collisionData = null;
+                break;
+        }
+    },
+
+    /**
+     * @method spawn_trySpawnArchetypes
+     * @description [V2 敌人视觉] 尝试在指定行生成大型基底敌人（尺寸 + 专属词条）。
+     *
+     * 基底列表（cols × rows，专属词条）：
+     *   - 2x1 棱盾兽    deflectionWard  (R9+)
+     *   - 1x2 共振尖塔  echoRelay       (R10+)
+     *   - 2x2 深渊胃囊  devour          (R12+)
+     *   - 3x1 装甲横梁  heavyArmor      (R5+)
+     *   - 1x3 折光棱柱  prism           (R16+)
+     *   - 2x3 孵化巢    hive            (R18+)
+     *   - 3x2 攻城履带  siege           (R22+)
+     *   - 3x3 引力炉心  gravityWell     (R30+)
+     *
+     * 同屏限流（避免大型机制单位扎堆）：
+     *   - 2x2 同屏 ≤ 2，2x3/3x2 ≤ 1，3x3 ≤ 1，3x3 出现时跳过其他大型基底
+     *   - 1x1 标准敌人在主填充循环中生成，不在此处理
+     */
+    spawn_trySpawnArchetypes(yPos, baseHP, occupiedCols, w, options) {
+        const r = this.round || 0;
+        const totalCols = CONFIG.gameplay.enemyCols;
+        const afx = CONFIG.balance.affixes;
+
+        // 当前同屏大型基底统计（用于限流）
+        let countMaw = 0, countHive = 0, countSiege = 0, countWell = 0;
+        for (const e of this.enemies) {
+            if (!e || !e.active) continue;
+            const a = e.baseArchetype;
+            if (a === 'maw') countMaw++;
+            else if (a === 'hive') countHive++;
+            else if (a === 'siege') countSiege++;
+            else if (a === 'gravityWell') countWell++;
+        }
+
+        // 候选基底列表（按从大到小尝试，3x3 出现时跳过其他大型）
+        const candidates = [
+            { id: 'gravityWell',   cols: 3, rows: 3, affix: 'gravityWell',   minRound: 30, weight: 0.025, hpMult: afx.gravityWellHpMult || 6.0,  color: '#7c3aed', skip: countWell >= 1 },
+            { id: 'siege',         cols: 3, rows: 2, affix: 'siege',         minRound: 22, weight: 0.05,  hpMult: afx.siegeHpMult || 3.5,        color: '#facc15', skip: countSiege >= 1 || countWell >= 1 },
+            { id: 'hive',          cols: 2, rows: 3, affix: 'hive',          minRound: 18, weight: 0.06,  hpMult: afx.hiveHpMult || 2.5,         color: '#a3e635', skip: countHive >= 1 || countWell >= 1 },
+            { id: 'prism',         cols: 1, rows: 3, affix: 'prism',         minRound: 16, weight: 0.08,  hpMult: afx.prismHpMult || 1.4,        color: '#67e8f9', skip: countWell >= 1 },
+            { id: 'maw',           cols: 2, rows: 2, affix: 'devour',        minRound: 12, weight: 0.10,  hpMult: 2.0,                            color: '#7f1d1d', skip: countMaw >= 2 || countWell >= 1 },
+            { id: 'echoSpire',     cols: 1, rows: 2, affix: 'echoRelay',     minRound: 10, weight: 0.10,  hpMult: afx.echoRelayHpMult || 0.5,    color: '#f0abfc', skip: countWell >= 1 },
+            { id: 'deflector',     cols: 2, rows: 1, affix: 'deflectionWard',minRound: 9,  weight: 0.12,  hpMult: afx.deflectionWardHpMult || 1.0,color: '#38bdf8', skip: false },
+            { id: 'bastion',       cols: 3, rows: 1, affix: 'heavyArmor',    minRound: 5,  weight: 0.18,  hpMult: afx.heavyArmorHpMult || 2.0,   color: '#94a3b8', skip: false },
+        ];
+
+        // 构建权重池
+        const pool = [];
+        let totalW = 0;
+        for (const c of candidates) {
+            if (r < c.minRound || c.skip) continue;
+            // 大型基底的总体出现概率随回合数缓慢增加，但单种概率仍由 weight 决定
+            pool.push(c);
+            totalW += c.weight;
+        }
+        if (pool.length === 0) return;
+
+        // 总体生成概率：保留与原 heavyArmor 相近的曲线（最高 40%）
+        const overallChance = Math.min(0.40, 0.10 + r * 0.012);
+        if (Math.random() >= overallChance) return;
+
+        // 加权抽签
+        let roll = Math.random() * totalW;
+        let chosen = pool[0];
+        for (const c of pool) {
+            if (roll < c.weight) { chosen = c; break; }
+            roll -= c.weight;
+        }
+
+        // 寻找连续 chosen.cols 列的空闲位置
+        const startCols = [];
+        for (let sc = 0; sc <= totalCols - chosen.cols; sc++) startCols.push(sc);
+        // 洗牌起始列，避免总出现在最左
+        for (let i = startCols.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [startCols[i], startCols[j]] = [startCols[j], startCols[i]];
+        }
+
+        for (const sc of startCols) {
+            let free = true;
+            for (let dc = 0; dc < chosen.cols; dc++) {
+                if (occupiedCols[sc + dc]) { free = false; break; }
+            }
+            if (!free) continue;
+
+            const wPx = w * chosen.cols;
+            const hPx = this.enemyHeight * chosen.rows;
+            // 中心 X
+            const centerX = (sc + (chosen.cols - 1) / 2) * w + w / 2;
+            // 中心 Y：多行基底向下扩展，中心 = yPos + (rows-1)*enemyHeight/2
+            const centerY = yPos + (chosen.rows - 1) * this.enemyHeight / 2;
+
+            // 区域占用检查（适当缩小以避免边角误判）
+            if (this.calc_isAreaOccupied(centerX, centerY, wPx * 0.85, hPx * 0.85)) continue;
+
+            // 血量计算
+            const hp = Math.floor(baseHP * chosen.hpMult * (0.9 + Math.random() * 0.2));
+
+            const e = new Enemy(centerX, centerY, wPx, hPx, hp);
+            e.affixes = [chosen.affix];
+            e.type = 'elite';
+            e.baseArchetype = chosen.id;
+            e.gridCols = chosen.cols;
+            e.gridRows = chosen.rows;
+            if (chosen.cols >= 2) e.isWideEnemy = true;
+
+            // 移动间隔：依据基底类型分配，体现"越大越慢"
+            if (chosen.affix === 'heavyArmor') {
+                e._moveInterval = afx.heavyArmorMoveInterval || 2;
+            } else if (chosen.affix === 'siege') {
+                e._moveInterval = afx.siegeMoveInterval || 2;
+            } else if (chosen.affix === 'gravityWell') {
+                e._moveInterval = afx.gravityWellMoveInterval || 3;
+            } else if (chosen.rows >= 2 || chosen.cols >= 3) {
+                e._moveInterval = 2;
+            } else {
+                e._moveInterval = 1;
+            }
+            e._moveCooldown = 0;
+
+            // [deflectionWard] 屏障初始化：满屏障值
+            if (chosen.affix === 'deflectionWard') {
+                const pct = afx.deflectionWardBarrierPct || 0.10;
+                e.wardBarrierMax = Math.max(1, Math.floor(hp * pct));
+                e.wardBarrier = e.wardBarrierMax;
+                e.wardBrokenThisTurn = false;
+            }
+            // [echoRelay] 自身血量减半（覆盖 hp 计算的 echoRelayHpMult，再保险）
+            // 这里不再二次乘以 0.5，保持 hpMult 已经设为 0.5
+            // [hive] 孵化倒计时
+            if (chosen.affix === 'hive') {
+                e._hiveCooldown = afx.hiveSpawnInterval || 2;
+            }
+            // [siege] 重压倒计时
+            if (chosen.affix === 'siege') {
+                e._siegeCooldown = afx.siegePushInterval || 3;
+            }
+
+            // 入场动画与状态
+            if (options.offScreenEntrance) {
+                e.pos.y = centerY - 2 * this.enemyHeight;
+                e.dropTargetY = centerY;
+                e.hasActedThisTurn = true;
+                e._spawnedThisTurn = true;
+            }
+            e._spawnColIndex = sc + Math.floor(chosen.cols / 2);
+
+            // 标记占用列
+            for (let dc = 0; dc < chosen.cols; dc++) occupiedCols[sc + dc] = true;
+
+            // 异型形状（部分基底有专属轮廓）
+            this.spawn_applyArchetypeShape(e, chosen.id);
+
+            // 掉落判定与 sprite 初始化
+            if (typeof this.sys_determineEnemyReward === 'function') {
+                this.sys_determineEnemyReward(e, false);
+            }
+            if (typeof e.initSprite === 'function') e.initSprite();
+            this.enemies.push(e);
+
+            // 入场冲击波（按基底主色）
+            this.spawn_createShockwave(e.pos.x, e.pos.y, chosen.color);
+            return; // 每行只生成一个大型基底
+        }
+    },
+
+    /**
+     * @method spawn_applyArchetypeShape
+     * @description [V2] 为基底敌人分配轮廓形状。覆盖 spawn_applyMinionShape 的 Boss 形状映射，
+     *              因为基底敌人有自己的语义形体（胃囊、棱柱、卵囊等）。
+     */
+    spawn_applyArchetypeShape(e, archetypeId) {
+        const w = e.width, h = e.height;
+        switch (archetypeId) {
+            case 'maw': // 2x2 缺口圆角矩形（深渊胃囊）
+                e.collisionShape = 'polygon';
+                e.collisionData = { vertices: [
+                    new Vec2(-w * 0.45, -h * 0.45),
+                    new Vec2( w * 0.45, -h * 0.45),
+                    new Vec2( w * 0.50,  h * 0.10),
+                    new Vec2( w * 0.20,  h * 0.50),
+                    new Vec2(-w * 0.20,  h * 0.50),
+                    new Vec2(-w * 0.50,  h * 0.10),
+                ]};
+                break;
+            case 'deflector': // 2x1 倾斜棱面盾壳
+                e.collisionShape = 'polygon';
+                e.collisionData = { vertices: [
+                    new Vec2(-w * 0.50,  h * 0.30),
+                    new Vec2(-w * 0.30, -h * 0.45),
+                    new Vec2( w * 0.30, -h * 0.45),
+                    new Vec2( w * 0.50,  h * 0.30),
+                    new Vec2( w * 0.30,  h * 0.50),
+                    new Vec2(-w * 0.30,  h * 0.50),
+                ]};
+                break;
+            case 'echoSpire': // 1x2 细长尖塔
+                e.collisionShape = 'polygon';
+                e.collisionData = { vertices: [
+                    new Vec2(0,         -h * 0.50),
+                    new Vec2( w * 0.30, -h * 0.30),
+                    new Vec2( w * 0.40,  h * 0.45),
+                    new Vec2(-w * 0.40,  h * 0.45),
+                    new Vec2(-w * 0.30, -h * 0.30),
+                ]};
+                break;
+            case 'prism': // 1x3 棱镜（菱形拉长）
+                e.collisionShape = 'polygon';
+                e.collisionData = { vertices: [
+                    new Vec2(0,         -h * 0.50),
+                    new Vec2( w * 0.45,  0),
+                    new Vec2(0,          h * 0.50),
+                    new Vec2(-w * 0.45,  0),
+                ]};
+                break;
+            case 'hive': // 2x3 孵化巢（圆角胶囊）
+                e.collisionShape = 'aabb';
+                e.collisionData = null;
+                break;
+            case 'siege': // 3x2 履带（六边形横向）
+                e.collisionShape = 'polygon';
+                e.collisionData = { vertices: [
+                    new Vec2(-w * 0.50, -h * 0.20),
+                    new Vec2(-w * 0.30, -h * 0.50),
+                    new Vec2( w * 0.30, -h * 0.50),
+                    new Vec2( w * 0.50, -h * 0.20),
+                    new Vec2( w * 0.50,  h * 0.20),
+                    new Vec2( w * 0.30,  h * 0.50),
+                    new Vec2(-w * 0.30,  h * 0.50),
+                    new Vec2(-w * 0.50,  h * 0.20),
+                ]};
+                break;
+            case 'gravityWell': // 3x3 引力炉心：圆形
+                e.collisionShape = 'arc';
+                e.collisionData = { radius: Math.min(w, h) * 0.45 };
+                break;
+            case 'bastion': // 3x1 重装：保持矩形
+            default:
                 e.collisionShape = 'aabb';
                 e.collisionData = null;
                 break;

--- a/src/systems.js
+++ b/src/systems.js
@@ -484,9 +484,38 @@ class UIManager {
                 name: '👅 吞噬', 
                 desc: `有概率吞噬相鄰友軍，繼承其全部生命與詞條。` 
             },
-            'jump': { 
-                name: '🦘 跳躍', 
-                desc: `前方被阻擋時，可直接跳過最多 ${afx.jumpRows} 行障礙。` 
+            'jump': {
+                name: '🦘 跳躍',
+                desc: `前方被阻擋時，可直接跳過最多 ${afx.jumpRows} 行障礙。`
+            },
+            // [V2 基底专属词条]
+            'heavyArmor': {
+                name: '🛡️ 重裝',
+                desc: `占 3 列橫向裝甲：血量 ×${afx.heavyArmorHpMult || 2.0}，每 ${afx.heavyArmorMoveInterval || 2} 回合才能移動一次。`
+            },
+            'deflectionWard': {
+                name: '🔷 偏折屏障',
+                desc: `2×1 棱盾獸：擁有相當於最大生命值 ${(afx.deflectionWardBarrierPct || 0.10) * 100}% 的屏障，僅吸收反彈/穿透類傷害，未被打破則每回合恢復至滿值。`
+            },
+            'echoRelay': {
+                name: '🔮 回響中繼',
+                desc: `1×2 共振尖塔：每回合額外觸發一次周圍敵人的詞條效果（再生/治療/分身/極速）；自身最大生命值僅為標準精英的 ${(afx.echoRelayHpPct || 0.5) * 100}%。`
+            },
+            'prism': {
+                name: '🌈 折光',
+                desc: `1×3 折光棱柱：作為激光偏折面參與反射，命中後傷害衰減為原伤害的 ${(afx.prismLaserDeflect || 0.5) * 100}%，產生七色折射粒子。`
+            },
+            'hive': {
+                name: '🥚 孵化',
+                desc: `2×3 孵化巢：每 ${afx.hiveSpawnInterval || 2} 回合在周圍生成一隻血量為自身 ${(afx.hiveSpawnHpPct || 0.15) * 100}% 的低血量幼體。`
+            },
+            'siege': {
+                name: '🚜 攻城',
+                desc: `3×2 攻城履帶：每 ${afx.siegePushInterval || 3} 回合執行一次 +${afx.siegePushRows || 2} 行的重壓推進，壓縮戰場空間。`
+            },
+            'gravityWell': {
+                name: '🌀 引力井',
+                desc: `3×3 引力炉心：在 ${afx.gravityWellPullRadius || 220}px 半徑內對所有子彈施加微弱回拉，造成可預測的彈道偏折。`
             }
         };
     }


### PR DESCRIPTION
## Summary

按 "敌人视觉设计 V2" 规范，把敌人从单格方块 + 任意词条重构为**尺寸基底 + 专属词条 + 通用词条叠加**的三层体系。

### 语义四层
- **等级层** type: normal / elite / boss
- **尺寸层** gridCols × gridRows: 1×1 ~ 3×3
- **基底层** baseArchetype: bastion / deflector / echoSpire / maw / prism / hive / siege / gravityWell
- **词条层** affixes: 通用词条 + 基底专属词条（专属词条**不进入随机池**）

### 新增 / 升级的基底

| 尺寸 | 基底 | 专属词条 | 最早回合 | 同屏上限 |
|---|---|---|---|---|
| 3×1 | bastion | heavyArmor (既有) | R5 | – |
| 2×1 | deflector | deflectionWard (新) | R9 | – |
| 1×2 | echoSpire | echoRelay (新) | R10 | – |
| 2×2 | maw | devour (升级) | R12 | ≤2 |
| 1×3 | prism | prism (新) | R16 | – |
| 2×3 | hive | hive (新) | R18 | ≤1 |
| 3×2 | siege | siege (新) | R22 | ≤1 |
| 3×3 | gravityWell | gravityWell (新) | R30 | ≤1 |

### 词条机制要点
- **deflectionWard**: maxHp × 10% 屏障，**只吸收 pierce/bounce 类伤害**；普通直击、火焰 DoT、毒素 DoT 全部绕过；未击破则每回合开始回满。
- **echoRelay**: 每回合额外触发一次邻近敌人的 regen / healer / clone / haste；自身 HP 减半。
- **prism**: 与 shield 共用激光偏折面入口，命中伤害衰减为 50% + 七色折射粒子。
- **hive**: 每 2 回合在巢周围生成血量为自身 15% 的低血量幼体。
- **siege**: 每 3 回合执行一次 +2 行的额外推进。
- **gravityWell**: 220 px 半径内对所有带速度的子弹按距离衰减施加微弱回拉。

### 实现入口
- spawn_system.js#spawn_trySpawnArchetypes — 统一基底分发
- spawn_system.js#spawn_applyArchetypeShape — 各基底语义轮廓
- entities/enemy.js — takeDamage 屏障分支、executeTurnAction 新增 hive/siege/echoRelay 分支
- combat/collision.js + combat_system.js — prism 偏折
- entities/projectile.js — gravityWell 子弹回拉
- game_phase.js — 屏障回满 / _echoedThisTurn 重置

## Test plan
- [ ] R5+ 出现 3×1 重装、R9+ 出现 2×1 棱盾兽、R12+ 出现 2×2 深渊胃囊
- [ ] 棱盾兽屏障只被 pierce/bounce 子弹消耗；普通直击与火焰 DoT 直接打 HP
- [ ] 共振尖塔旁的 regen/healer/clone/haste 敌人每回合多结算一次
- [ ] 折光棱柱被激光命中后产生衰减弹射 + 七色粒子
- [ ] 孵化巢每 2 回合在周围生成一个低血量小怪
- [ ] 攻城履带每 3 回合多推进 2 行
- [ ] 引力炉心 220 px 内的子弹弹道明显回拉
- [ ] 同屏限流：maw≤2、hive/siege≤1、gravityWell 出现时其他大型不再生成

https://claude.ai/code/session_01MiDdPxeJ4ywpZHeA4RKyea