### PR TITLE
feat(enemies): PoC DOM/CSS 可爱风敌人渲染层（普通敌人）

### DIFF
--- a/index.html
+++ b/index.html
@@ -2738,6 +2738,7 @@
     </style>
     <!-- Phase 5A: 位图化 UI 样式覆盖层 -->
     <link rel="stylesheet" href="src/styles/bitmap_ui.css">
+    <link rel="stylesheet" href="src/styles/enemy_dom.css">
 </head>
 <body>
 <div id="app-wrapper">
@@ -2760,6 +2761,8 @@
 
 <div id="game-container">
     <canvas id="gameCanvas"></canvas>
+    <!-- PoC: DOM/CSS 敌人图层（叠在 canvas 之上，覆盖 enemy 本体 + HP + 表情） -->
+    <div id="enemy-dom-layer" aria-hidden="true"></div>
     <div id="crt-overlay"></div>
 
     <!-- Boss 入场全屏遗罩（深红色暗化） -->

--- a/src/config.js
+++ b/src/config.js
@@ -851,6 +851,14 @@ const CONFIG = {
 
     // ==================== 敌人渲染管线增强参数 (Task A) ====================
     enemyRender: {
+        // ─── DOM/CSS 渲染器（PoC: 可爱风纯 CSS 敌人）───────────────────────
+        // 为 true 时，符合 domRendererTypes 的敌人会用 DOM 元素 + CSS 渲染本体，
+        // 跳过 canvas 上对应的 Layer 1（裁剪/材质/affix 色调/HP 槽/状态层）。
+        // 子弹、粒子、词缀光环等仍然由 canvas 绘制；HP 与状态由 DOM 层呈现。
+        domRendererEnabled: true,
+        // 哪些敌人类型走 DOM 渲染（PoC 阶段仅普通敌人）
+        domRendererTypes: ['normal'],
+
         // A1: Layer 1.5 材质光泽渐变
         // 顶部白色叠加 alpha（模拟凸起高光）
         glossTopAlpha: 0.08,

--- a/src/core.js
+++ b/src/core.js
@@ -45,6 +45,7 @@ import { calc_utils } from './calc_utils.js';
 import { tutorial_system } from './tutorial_system.js';
 import { game_over_mixin } from './ui/game_over.js';
 import { preloadAllSprites } from './render/sprite_renderer.js'; // [Phase 5B] 预加载所有 Sprite Sheet
+import { DomEnemyLayer } from './render/dom_enemy_layer.js'; // [PoC] DOM/CSS 敌人图层
 
 // ==================== 延迟音频初始化 ====================
 let _audioInitialized = false;
@@ -334,6 +335,8 @@ class Game {
         this._perfUpTimer = 0;
         // [Phase 5B] 预加载所有 Sprite Sheet（在游戏循环开始前触发异步加载）
         preloadAllSprites();
+        // [PoC] DOM/CSS 敌人图层（普通敌人本体由 DOM 渲染，神态由 CSS 驱动）
+        this.domEnemyLayer = new DomEnemyLayer();
         // 启动游戏主循环
         this.sys_loop();
     }

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -1317,7 +1317,17 @@ class Enemy {
     // @section:draw_entry_and_perf_check - 绘制入口与性能等级检查
     draw(ctx) {
         if (!this.active) return;
-        ctx.save(); 
+
+        // [PoC] DOM/CSS 敌人图层接管：普通敌人的本体（容器/纹理/HP/状态层）由 DOM 渲染，
+        // 跳过 canvas 上的本体绘制。子弹、词缀光环、boss 等仍走原 canvas 路径。
+        const _domCfg = CONFIG.enemyRender;
+        if (_domCfg && _domCfg.domRendererEnabled
+            && Array.isArray(_domCfg.domRendererTypes)
+            && _domCfg.domRendererTypes.includes(this.type)) {
+            return;
+        }
+
+        ctx.save();
         ctx.translate(this.pos.x, this.pos.y + this.bumpOffsetY);
 
         // === D1 & D2: 待机生动感（呼吸缩放 + 微浮动）===

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1862,6 +1862,9 @@ phase_gathering_getRandomPegType() {
                 }
             });
 
+            // [PoC] DOM/CSS 敌人图层每帧同步（普通敌人本体由 DOM 渲染）
+            if (this.domEnemyLayer) this.domEnemyLayer.sync(this.enemies, this.width, this.height);
+
             // [猎人本能] 绘制持续标记特效：找到血量最低的活跃敌人并渲染动态瞄准十字准星
             if (this.ownedRelics && this.ownedRelics.includes('hunter_instinct')) {
                 let hunterTarget = null;

--- a/src/render/dom_enemy_layer.js
+++ b/src/render/dom_enemy_layer.js
@@ -1,0 +1,233 @@
+/**
+ * dom_enemy_layer.js — DOM/CSS 敌人图层（可爱风 PoC）
+ *
+ * 职责：
+ *   - 维护 #enemy-dom-layer 下的 .enemy DOM 节点池，与 game.enemies 数组同步
+ *   - 每帧把敌人状态（位置/HP/受击/冻结/预警/注视）写到 CSS 变量与 data 属性
+ *   - 配合 enemy_dom.css，通过 CSS 实现所有动画与神态切换
+ *
+ * 与 canvas 的边界：
+ *   - 当 CONFIG.enemyRender.domRendererEnabled 且 enemy.type ∈ domRendererTypes 时，
+ *     enemy.draw() 内部会跳过 Layer 1（本体/材质/HP 槽/状态层）的 canvas 绘制；
+ *   - 子弹、粒子、词缀光环、boss 入场等仍由 canvas 绘制。
+ *
+ * 使用：
+ *   import { DomEnemyLayer } from './render/dom_enemy_layer.js';
+ *   const layer = new DomEnemyLayer();        // 在 game-container 渲染初始化后构造
+ *   layer.sync(this.enemies, this.width, this.height); // 每帧（在 enemy.update/draw 之后）调用
+ *
+ * 性能：
+ *   - 节点池：敌人离场时 DOM 不立刻删除，只是 hidden + 标记 free，等下次 spawn 复用。
+ *   - 每帧只更新 CSS 变量 / data-attribute；transform 通过 translate3d，GPU 合成层。
+ */
+
+import { CONFIG } from '../config.js';
+
+const ENEMY_LAYER_ID = 'enemy-dom-layer';
+const NODE_KEY = '__domEnemyNode';
+
+export class DomEnemyLayer {
+    constructor() {
+        this.container = document.getElementById(ENEMY_LAYER_ID);
+        this.enabled = !!(CONFIG.enemyRender && CONFIG.enemyRender.domRendererEnabled);
+        this.allowedTypes = new Set(
+            (CONFIG.enemyRender && CONFIG.enemyRender.domRendererTypes) || []
+        );
+
+        if (!this.container) {
+            console.warn('[DomEnemyLayer] #enemy-dom-layer not found in DOM. Disabled.');
+            this.enabled = false;
+            return;
+        }
+        if (!this.enabled) this.container.classList.add('is-disabled');
+
+        /** @type {WeakMap<object, HTMLElement>} enemy → DOM 节点 */
+        this._nodes = new WeakMap();
+        /** @type {Set<HTMLElement>} 已分配（活跃）的节点集合，用于离场清理 */
+        this._activeNodes = new Set();
+        /** @type {HTMLElement[]} 空闲节点池 */
+        this._freePool = [];
+    }
+
+    /**
+     * 当前敌人是否应该被 DOM 层接管？
+     * @param {object} enemy
+     * @returns {boolean}
+     */
+    shouldRender(enemy) {
+        if (!this.enabled) return false;
+        if (!enemy || enemy.active === false) return false;
+        return this.allowedTypes.has(enemy.type);
+    }
+
+    /**
+     * 每帧同步：根据 game.enemies 数组创建/更新/隐藏 DOM 节点
+     * @param {Array<object>} enemies
+     * @param {number} _width  未使用，保留接口
+     * @param {number} _height 未使用，保留接口
+     */
+    sync(enemies, _width, _height) {
+        if (!this.enabled) return;
+
+        const stillActive = new Set();
+
+        for (const e of enemies) {
+            if (!this.shouldRender(e)) continue;
+            if (e.pos.y < -e.height) continue; // 屏幕外（boss 入场之类）跳过
+
+            let node = this._nodes.get(e);
+            if (!node) {
+                node = this._acquireNode();
+                this._nodes.set(e, node);
+                this._initNodeForEnemy(node, e);
+            }
+            this._updateNode(node, e);
+            stillActive.add(node);
+        }
+
+        // 回收离场节点
+        for (const node of this._activeNodes) {
+            if (!stillActive.has(node)) this._releaseNode(node);
+        }
+        this._activeNodes = stillActive;
+    }
+
+    /** 关闭整个图层（例如调试时切回纯 canvas 模式） */
+    setEnabled(flag) {
+        this.enabled = !!flag;
+        if (!this.container) return;
+        this.container.classList.toggle('is-disabled', !this.enabled);
+        if (!this.enabled) {
+            for (const node of this._activeNodes) this._releaseNode(node);
+            this._activeNodes.clear();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 节点池
+    // ──────────────────────────────────────────────────────────────
+
+    _acquireNode() {
+        const node = this._freePool.pop() || this._createNode();
+        node.style.display = '';
+        node[NODE_KEY] = true;
+        this.container.appendChild(node);
+        this._activeNodes.add(node);
+        return node;
+    }
+
+    _releaseNode(node) {
+        node.style.display = 'none';
+        node.dataset.state = 'idle';
+        this._freePool.push(node);
+    }
+
+    _createNode() {
+        const root = document.createElement('div');
+        root.className = 'enemy';
+        root.dataset.state = 'idle';
+        root.dataset.tier = 'normal';
+        root.innerHTML = `
+            <div class="enemy__shadow"></div>
+            <div class="enemy__body"></div>
+            <div class="enemy__cheeks"></div>
+            <div class="enemy__eyes">
+                <div class="enemy__eye enemy__eye--l"></div>
+                <div class="enemy__eye enemy__eye--r"></div>
+            </div>
+            <div class="enemy__mouth"></div>
+            <div class="enemy__hp"></div>
+        `.trim();
+        return root;
+    }
+
+    _initNodeForEnemy(node, enemy) {
+        // 给眨眼/呼吸不同延迟，避免群体同步
+        const seed = (enemy.visualSeed != null) ? enemy.visualSeed : Math.random();
+        node.style.setProperty('--blink-delay', `${(seed * 4.8).toFixed(2)}s`);
+        node.style.setProperty('--breathe-delay', `${(seed * 2.6).toFixed(2)}s`);
+        // 静态倾斜：敌人构造时已有 _staticTilt（弧度），转为 deg
+        const tiltDeg = (enemy._staticTilt || 0) * (180 / Math.PI);
+        node.style.setProperty('--tilt', `${tiltDeg.toFixed(2)}deg`);
+        node.dataset.tier = enemy.type || 'normal';
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 每帧更新
+    // ──────────────────────────────────────────────────────────────
+
+    _updateNode(node, enemy) {
+        const w = enemy.width;
+        const h = enemy.height;
+
+        // 位置：canvas 1:1 映射到 game-container 像素
+        // bumpOffsetY 是受击 / 入场偏移
+        const x = enemy.pos.x;
+        const y = enemy.pos.y + (enemy.bumpOffsetY || 0);
+
+        const style = node.style;
+        style.setProperty('--x', `${x.toFixed(1)}px`);
+        style.setProperty('--y', `${y.toFixed(1)}px`);
+        style.setProperty('--w', `${w}px`);
+        style.setProperty('--h', `${h}px`);
+
+        // HP 比例
+        const hp = enemy.displayHp != null ? enemy.displayHp : enemy.hp;
+        const hpRatio = Math.max(0, Math.min(1, hp / enemy.maxHp));
+        style.setProperty('--hp', hpRatio.toFixed(3));
+
+        // 注视方向：让瞳孔朝着最近的子弹（如果有）；否则随机微动
+        const look = this._computeLookDirection(enemy);
+        style.setProperty('--look-x', look.x.toFixed(2));
+        style.setProperty('--look-y', look.y.toFixed(2));
+
+        // 状态机：优先级 dying > telegraph > frozen > hit > low > idle
+        let state = 'idle';
+        if (!enemy.active || enemy.hp <= 0) {
+            state = 'dying';
+        } else if (enemy.actionPhase === 'telegraphing') {
+            state = 'telegraph';
+        } else if (enemy.isFrozenCurrentTurn || (typeof enemy.temp === 'number' && enemy.temp <= -34)) {
+            state = 'frozen';
+        } else if (enemy.hitTimer > 0 || (enemy._hitImpact && enemy._hitImpact > 0.02)) {
+            state = 'hit';
+        } else if (hpRatio < 0.3) {
+            state = 'low';
+        }
+        if (node.dataset.state !== state) node.dataset.state = state;
+
+        // Affix 装饰（PoC 仅做几个最显眼的）
+        const affixes = enemy.affixes || [];
+        this._setAffixFlag(node, 'shield', affixes.includes('shield') || (enemy.shieldCharges > 0));
+        this._setAffixFlag(node, 'regen',  affixes.includes('regen'));
+        this._setAffixFlag(node, 'haste',  affixes.includes('haste'));
+    }
+
+    _setAffixFlag(node, name, on) {
+        const key = `affix${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+        const expected = on ? '1' : '0';
+        if (node.dataset[key] !== expected) node.dataset[key] = expected;
+    }
+
+    /**
+     * 计算瞳孔注视方向 ∈ [-1, 1]^2
+     * 优先注视 actionPhase===telegraphing 时的红色目标，
+     * 否则锁定最近的子弹（_lookTarget 由外部注入），
+     * 否则用一个低频 wobble。
+     */
+    _computeLookDirection(enemy) {
+        const t = enemy._lookTarget;
+        if (t && typeof t.x === 'number' && typeof t.y === 'number') {
+            const dx = t.x - enemy.pos.x;
+            const dy = t.y - enemy.pos.y;
+            const m = Math.hypot(dx, dy) || 1;
+            return { x: Math.max(-1, Math.min(1, dx / m)), y: Math.max(-1, Math.min(1, dy / m)) };
+        }
+        const now = performance.now() / 1000;
+        const seed = enemy.visualSeed || 0.5;
+        return {
+            x: Math.sin(now * 0.7 + seed * 6.28) * 0.4,
+            y: Math.cos(now * 0.5 + seed * 4.0) * 0.25 - 0.15, // 略向下，更萌
+        };
+    }
+}

--- a/src/styles/enemy_dom.css
+++ b/src/styles/enemy_dom.css
@@ -1,0 +1,455 @@
+/*
+ * enemy_dom.css — DOM/CSS 敌人图层（可爱风 PoC）
+ *
+ * 设计契约：
+ *   .enemy 节点：
+ *     - 由 dom_enemy_layer.js 创建并每帧通过 CSS 变量同步
+ *     - 父容器 #enemy-dom-layer 是 #game-container 的兄弟元素，绝对定位铺满
+ *     - position 通过 transform: translate3d(var(--x), var(--y), 0) 驱动
+ *     - 尺寸通过 --w / --h 变量
+ *     - 状态通过 data-state 切换：idle / hit / low / frozen / telegraph / dying
+ *     - HP 比 0~1 通过 --hp 驱动
+ *     - 注视方向 --look-x / --look-y ∈ [-1, 1]
+ *     - data-tier="normal | elite | boss" 微调配色
+ *     - data-affix-shield / data-affix-regen / ... 控制 affix 装饰
+ *
+ * 美术语言：圆头团子（slime）。深底 + 高光 + 大眼睛，
+ *   贴合现有 dark-cyberpunk-alchemy 调子，加入"可读神态"。
+ */
+
+#enemy-dom-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;     /* 让 canvas 继续接收 click/touch */
+    overflow: hidden;
+    z-index: 2;               /* canvas z-index:1 → DOM 敌人在其上 */
+}
+
+/* 当 feature flag 关闭时由 JS 隐藏 */
+#enemy-dom-layer.is-disabled { display: none; }
+
+/* ============================================================
+ * .enemy 容器
+ * ============================================================ */
+.enemy {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: var(--w, 60px);
+    height: var(--h, 60px);
+    /* 中心对齐到 (--x, --y) */
+    transform: translate3d(calc(var(--x, 0px) - 50%), calc(var(--y, 0px) - 50%), 0)
+               scale(var(--scale, 1));
+    transform-origin: 50% 50%;
+    will-change: transform;
+    contain: layout style paint;
+    --hp: 1;
+    --look-x: 0;
+    --look-y: 0;
+    --tilt: 0deg;
+    /* 总开关：dying 时整体淡出 */
+    opacity: var(--opacity, 1);
+    transition: opacity 0.25s ease-out;
+}
+
+/* ============================================================
+ * 身体（圆团子 + 渐变 + 内阴影）
+ * ============================================================ */
+.enemy__body {
+    position: absolute;
+    inset: 6%;                /* 留一点 padding 给阴影/装饰 */
+    border-radius: 48% 52% 47% 53% / 55% 50% 50% 45%;
+    background:
+        radial-gradient(circle at 35% 28%,
+            rgba(255, 255, 255, 0.35) 0%,
+            rgba(255, 255, 255, 0.08) 18%,
+            transparent 38%),
+        radial-gradient(circle at 50% 60%,
+            #475569 0%,
+            #1e293b 60%,
+            #0f172a 100%);
+    box-shadow:
+        inset 0 -6px 14px rgba(0, 0, 0, 0.55),
+        inset 0 5px 8px rgba(255, 255, 255, 0.15),
+        0 4px 10px rgba(0, 0, 0, 0.45);
+    transform: rotate(var(--tilt, 0deg));
+    transition: filter 0.25s ease, background 0.4s ease;
+}
+
+/* 接触阴影（敌人脚下软椭圆） */
+.enemy__shadow {
+    position: absolute;
+    left: 12%;
+    right: 12%;
+    bottom: -8%;
+    height: 12%;
+    background: radial-gradient(ellipse at center,
+        rgba(0, 0, 0, 0.55) 0%,
+        rgba(0, 0, 0, 0) 70%);
+    filter: blur(2px);
+    pointer-events: none;
+    z-index: -1;
+}
+
+/* ============================================================
+ * 眼睛 + 瞳孔（可注视）
+ * ============================================================ */
+.enemy__eyes {
+    position: absolute;
+    inset: 28% 18% 38% 18%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    pointer-events: none;
+}
+.enemy__eye {
+    position: relative;
+    width: 30%;
+    aspect-ratio: 1 / 1.05;
+    background: #f8fafc;
+    border-radius: 50%;
+    box-shadow:
+        inset 0 -2px 3px rgba(15, 23, 42, 0.3),
+        0 1px 2px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+    transition: transform 0.2s ease, height 0.15s ease;
+}
+.enemy__eye::before {
+    /* 瞳孔 */
+    content: "";
+    position: absolute;
+    width: 55%;
+    height: 55%;
+    left: 50%;
+    top: 50%;
+    background: radial-gradient(circle at 35% 30%, #334155 0%, #020617 70%);
+    border-radius: 50%;
+    transform: translate(
+        calc(-50% + var(--look-x) * 22%),
+        calc(-50% + var(--look-y) * 22%)
+    );
+    transition: transform 0.12s ease-out, background 0.3s ease, width 0.2s ease, height 0.2s ease;
+}
+.enemy__eye::after {
+    /* 高光点 */
+    content: "";
+    position: absolute;
+    width: 22%;
+    height: 22%;
+    left: 28%;
+    top: 22%;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 50%;
+    transform: translate(calc(var(--look-x) * 10%), calc(var(--look-y) * 10%));
+}
+
+/* 眨眼：周期性把眼睛压扁 */
+@keyframes enemy-blink {
+    0%, 92%, 100% { transform: scaleY(1); }
+    95%, 97%      { transform: scaleY(0.05); }
+}
+.enemy__eye {
+    animation: enemy-blink 4.8s var(--blink-delay, 0s) infinite ease-in-out;
+}
+/* 冰冻 / 死亡时停止眨眼，神态保持 */
+.enemy[data-state="frozen"] .enemy__eye,
+.enemy[data-state="dying"] .enemy__eye {
+    animation: none;
+}
+
+/* ============================================================
+ * 嘴巴（用 clip-path 切表情）
+ * ============================================================ */
+.enemy__mouth {
+    position: absolute;
+    left: 50%;
+    top: 70%;
+    width: 22%;
+    height: 9%;
+    transform: translate(-50%, -50%);
+    background: #1e1b29;
+    border-radius: 0 0 50% 50% / 0 0 100% 100%;
+    box-shadow: inset 0 -2px 1px rgba(255, 255, 255, 0.12);
+    transition: clip-path 0.18s ease, background 0.3s ease, transform 0.18s ease;
+    /* 默认: 微笑（半圆） */
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+}
+
+/* ============================================================
+ * 腮红
+ * ============================================================ */
+.enemy__cheeks {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+.enemy__cheeks::before,
+.enemy__cheeks::after {
+    content: "";
+    position: absolute;
+    width: 14%;
+    height: 9%;
+    top: 62%;
+    background: radial-gradient(ellipse at center,
+        rgba(244, 114, 182, 0.55) 0%,
+        rgba(244, 114, 182, 0) 70%);
+    border-radius: 50%;
+    filter: blur(0.5px);
+    opacity: 0.85;
+    transition: opacity 0.3s ease;
+}
+.enemy__cheeks::before { left: 14%; }
+.enemy__cheeks::after  { right: 14%; }
+
+/* ============================================================
+ * idle 呼吸（基础态：缓慢上下 + 轻微缩放）
+ * ============================================================ */
+@keyframes enemy-breathe {
+    0%, 100% { transform: translateY(0)    scaleY(1)    scaleX(1); }
+    50%      { transform: translateY(-2%) scaleY(1.025) scaleX(0.985); }
+}
+.enemy[data-state="idle"] .enemy__body {
+    animation: enemy-breathe 2.6s ease-in-out infinite;
+    animation-delay: var(--breathe-delay, 0s);
+}
+
+/* ============================================================
+ * 状态: hit（受击）
+ * ============================================================ */
+@keyframes enemy-hit-flash {
+    0%   { filter: brightness(2.6) saturate(0.6); transform: scale(1.18, 0.78) rotate(var(--tilt, 0deg)); }
+    40%  { filter: brightness(1.3); transform: scale(0.92, 1.08) rotate(var(--tilt, 0deg)); }
+    100% { filter: none;             transform: scale(1) rotate(var(--tilt, 0deg)); }
+}
+.enemy[data-state="hit"] .enemy__body {
+    animation: enemy-hit-flash 0.32s ease-out;
+}
+.enemy[data-state="hit"] .enemy__mouth {
+    /* >o< */
+    width: 18%;
+    height: 12%;
+    background: #0b0a13;
+    border-radius: 50%;
+    clip-path: none;
+}
+
+/* ============================================================
+ * 状态: low（低血量，HP < 30%）
+ * ============================================================ */
+.enemy[data-state="low"] .enemy__body {
+    animation: enemy-breathe 1.4s ease-in-out infinite,
+               enemy-tremble 0.18s ease-in-out infinite alternate;
+    background:
+        radial-gradient(circle at 35% 28%,
+            rgba(255, 255, 255, 0.25) 0%,
+            transparent 35%),
+        radial-gradient(circle at 50% 60%,
+            #475569 0%,
+            #1f2937 60%,
+            #0f172a 100%);
+}
+@keyframes enemy-tremble {
+    from { transform: translateX(-1.2%); }
+    to   { transform: translateX(1.2%); }
+}
+.enemy[data-state="low"] .enemy__mouth {
+    /* >﹏< 用一个被压扁的椭圆 + 深色波浪 */
+    width: 30%;
+    height: 5%;
+    background: #0b0a13;
+    border-radius: 50%;
+    clip-path: polygon(0 0, 12% 100%, 25% 0, 50% 100%, 75% 0, 88% 100%, 100% 0, 100% 100%, 0 100%);
+}
+.enemy[data-state="low"] .enemy__eye::before {
+    /* 瞳孔变小 + 抖动 */
+    width: 38%;
+    height: 38%;
+}
+.enemy[data-state="low"] .enemy__cheeks::before,
+.enemy[data-state="low"] .enemy__cheeks::after {
+    opacity: 0.4;
+}
+
+/* ============================================================
+ * 状态: frozen（冰冻）
+ * ============================================================ */
+.enemy[data-state="frozen"] .enemy__body {
+    animation: none;
+    filter: hue-rotate(165deg) brightness(1.15) saturate(0.7);
+    background:
+        radial-gradient(circle at 35% 28%,
+            rgba(186, 230, 253, 0.55) 0%,
+            rgba(125, 211, 252, 0.15) 30%,
+            transparent 60%),
+        radial-gradient(circle at 50% 60%,
+            #67e8f9 0%,
+            #0e7490 60%,
+            #155e75 100%);
+}
+.enemy[data-state="frozen"] .enemy__eye::before {
+    /* 眼神呆滞，瞳孔变成竖纹 */
+    background: #0c4a6e;
+    width: 25%;
+    height: 65%;
+    border-radius: 30%;
+}
+.enemy[data-state="frozen"] .enemy__mouth {
+    width: 18%;
+    height: 4%;
+    background: #0c4a6e;
+    border-radius: 4px;
+    clip-path: none;
+}
+/* 冰晶碎片（伪元素） */
+.enemy[data-state="frozen"] .enemy__body::before {
+    content: "";
+    position: absolute;
+    inset: -4%;
+    border-radius: inherit;
+    background:
+        linear-gradient(38deg, transparent 45%, rgba(255, 255, 255, 0.45) 47%, transparent 50%),
+        linear-gradient(-22deg, transparent 60%, rgba(186, 230, 253, 0.35) 62%, transparent 65%);
+    pointer-events: none;
+    mix-blend-mode: screen;
+}
+
+/* ============================================================
+ * 状态: telegraph（攻击预警）
+ * ============================================================ */
+@keyframes enemy-telegraph-shake {
+    0%, 100% { transform: translate(0, 0); }
+    20% { transform: translate(-2px, 1px); }
+    40% { transform: translate(2px, -1px); }
+    60% { transform: translate(-1px, -2px); }
+    80% { transform: translate(1px, 2px); }
+}
+@keyframes enemy-telegraph-glow {
+    0%, 100% {
+        box-shadow:
+            inset 0 -6px 14px rgba(0, 0, 0, 0.55),
+            inset 0 5px 8px rgba(255, 255, 255, 0.15),
+            0 0 12px rgba(239, 68, 68, 0.55);
+    }
+    50% {
+        box-shadow:
+            inset 0 -6px 14px rgba(0, 0, 0, 0.55),
+            inset 0 5px 8px rgba(255, 255, 255, 0.15),
+            0 0 28px rgba(239, 68, 68, 0.95);
+    }
+}
+.enemy[data-state="telegraph"] .enemy__body {
+    animation: enemy-telegraph-shake 0.18s linear infinite,
+               enemy-telegraph-glow 0.6s ease-in-out infinite;
+    background:
+        radial-gradient(circle at 35% 28%,
+            rgba(255, 200, 200, 0.35) 0%,
+            transparent 35%),
+        radial-gradient(circle at 50% 60%,
+            #7f1d1d 0%,
+            #450a0a 60%,
+            #1c0606 100%);
+}
+.enemy[data-state="telegraph"] .enemy__mouth {
+    /* 张大嘴 oOo */
+    width: 32%;
+    height: 26%;
+    background: #1a0202;
+    border-radius: 50%;
+    clip-path: none;
+    box-shadow: inset 0 4px 6px rgba(0, 0, 0, 0.8);
+}
+.enemy[data-state="telegraph"] .enemy__eye::before {
+    background: radial-gradient(circle, #ef4444 0%, #7f1d1d 70%);
+    width: 70%;
+    height: 70%;
+}
+
+/* ============================================================
+ * 状态: dying
+ * ============================================================ */
+@keyframes enemy-die {
+    0%   { transform: scale(1) rotate(0); opacity: 1; }
+    60%  { transform: scale(1.18) rotate(8deg); opacity: 0.6; }
+    100% { transform: scale(0.4) rotate(-12deg); opacity: 0; }
+}
+.enemy[data-state="dying"] .enemy__body {
+    animation: enemy-die 0.5s ease-in forwards;
+}
+
+/* ============================================================
+ * HP 微条（在头顶上方）
+ * ============================================================ */
+.enemy__hp {
+    position: absolute;
+    left: 12%;
+    right: 12%;
+    top: -10%;
+    height: 5%;
+    min-height: 3px;
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 999px;
+    overflow: hidden;
+    backdrop-filter: blur(2px);
+}
+.enemy__hp::before {
+    content: "";
+    display: block;
+    width: calc(var(--hp, 1) * 100%);
+    height: 100%;
+    background: linear-gradient(
+        to right,
+        #f87171 0%,
+        #facc15 50%,
+        #4ade80 100%);
+    /* 反向渐变：HP 满偏绿，越低越偏红 —— 通过 hue-rotate */
+    filter: hue-rotate(calc((1 - var(--hp, 1)) * -90deg));
+    transition: width 0.25s ease-out;
+}
+
+/* ============================================================
+ * Tier 配色微调（精英/Boss 占位 - PoC 默认仅 normal）
+ * ============================================================ */
+.enemy[data-tier="elite"] .enemy__body {
+    background:
+        radial-gradient(circle at 35% 28%, rgba(196,181,253,0.4) 0%, transparent 40%),
+        radial-gradient(circle at 50% 60%, #7c3aed 0%, #4c1d95 60%, #2e1065 100%);
+}
+.enemy[data-tier="boss"] .enemy__body {
+    background:
+        radial-gradient(circle at 35% 28%, rgba(252,165,165,0.4) 0%, transparent 40%),
+        radial-gradient(circle at 50% 60%, #dc2626 0%, #7f1d1d 60%, #450a0a 100%);
+}
+
+/* ============================================================
+ * Affix 装饰（PoC 简化版：用 outline + 颜色暗示）
+ * ============================================================ */
+.enemy[data-affix-shield="1"] .enemy__body {
+    outline: 2px dashed rgba(147, 197, 253, 0.85);
+    outline-offset: 4px;
+}
+.enemy[data-affix-regen="1"] .enemy__body {
+    box-shadow:
+        inset 0 -6px 14px rgba(0, 0, 0, 0.55),
+        inset 0 5px 8px rgba(255, 255, 255, 0.15),
+        0 0 12px rgba(74, 222, 128, 0.6),
+        0 4px 10px rgba(0, 0, 0, 0.45);
+}
+.enemy[data-affix-haste="1"]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+        90deg,
+        transparent 0,
+        transparent 10px,
+        rgba(250, 204, 21, 0.18) 10px,
+        rgba(250, 204, 21, 0.18) 12px);
+    border-radius: inherit;
+    pointer-events: none;
+    animation: enemy-haste-streak 0.5s linear infinite;
+}
+@keyframes enemy-haste-streak {
+    from { background-position: 0 0; }
+    to   { background-position: 22px 0; }
+}


### PR DESCRIPTION
## 目的

把普通敌人的"静态位图本体"换成 DOM + CSS 驱动的可爱团子，让神态/表情可以靠 CSS class + 变量灵活迭代——绕开贴图素材在表情维度的天花板。这是一个 PoC，方向跑通后再扩展到精英 / Boss。

## 架构

- 新增 `#enemy-dom-layer`，叠在 canvas 之上，由 `DomEnemyLayer.sync()` 每帧从 `game.enemies` 同步。
- 通过 `CONFIG.enemyRender.domRendererEnabled` / `domRendererTypes` 开关。
- `enemy.draw()` 命中 DOM 类型时早返回，跳过 canvas Layer 1（本体/纹理/HP 槽/状态层）。
- DomEnemyLayer 用节点池 + WeakMap 管理生命周期；每帧只写 CSS 变量与 `data-state`。

## 可爱风 5 个状态

| state | 触发 | 表现 |
|-------|------|------|
| `idle` | 默认 | 缓慢呼吸 + 周期眨眼 + 瞳孔追踪 |
| `hit` | `hitTimer > 0` 或 `_hitImpact > 0.02` | 0.32s squash & stretch + 嘴巴 `>o<` + 高亮闪烁 |
| `low` | `displayHp / maxHp < 0.3` | 加快呼吸 + 抖动 + 嘴巴 `>﹏<` + 瞳孔缩小 |
| `frozen` | `isFrozenCurrentTurn` 或 `temp <= -34` | 冰晶高光 + 青色调 + 瞳孔变竖纹 + 停止眨眼 |
| `telegraph` | `actionPhase === 'telegraphing'` | 红色脉冲发光 + 高频抖动 + 张大嘴 + 瞳孔变红 |

外加 `dying`（hp ≤ 0 时缩放淡出）。

## 文件

- `index.html` — 新增 `#enemy-dom-layer` 容器与 `enemy_dom.css` 引用
- `src/config.js` — 增加 `enemyRender.domRendererEnabled` / `domRendererTypes`
- `src/core.js` — 实例化 `DomEnemyLayer`
- `src/game_phase.js` — 每帧调用 `domEnemyLayer.sync()`
- `src/entities/enemy.js` — DOM 类型早返回，跳过 canvas 本体绘制
- `src/render/dom_enemy_layer.js` — DOM 节点池 + 状态机（NEW）
- `src/styles/enemy_dom.css` — 可爱史莱姆 + 5 状态 CSS（NEW）

## PoC 范围限制（后续 PR 处理）

- 仅 `type === 'normal'` 敌人。精英 / Boss 仍走 canvas（保持现状）。
- normal 敌人的 affix 视觉简化为 outline / glow / streak（hex 护盾、regen 波纹、devour 触手等 canvas 程序化特效在 DOM 模式下不绘制）。
- HP 条从 canvas 液体条改为 DOM 头顶细条。
- 状态特效仅 frozen，overheated / venom 等暂未迁移。
- DOM 敌人浮在弹幕之前（z-index 高于 canvas）。

## 测试 plan

- [ ] 浏览器实际跑一波：进战斗，观察普通敌人造型 / 神态是否对路
- [ ] 受击 → squash + 嘴巴变形
- [ ] 血量低于 30% → 抖动 + `>﹏<` 嘴
- [ ] 冰冻 → 青色冰晶 + 瞳孔竖纹
- [ ] Telegraph → 红色脉冲 + 张嘴
- [ ] 敌人死亡 → DOM 节点回收
- [ ] 多敌人同屏（5+）帧率不掉
- [ ] 关闭 `domRendererEnabled` → 退回原 canvas 渲染（A/B 对比）

## 回滚

`CONFIG.enemyRender.domRendererEnabled = false` 即可一键回退到纯 canvas 渲染。

https://claude.ai/code/session_01K6DPhRUGFxSSQtqnyr9rfM
