### PR TITLE
fix(marble): 回响/剧毒弹珠钉盘颜色 + 回响概率分裂 + 战斗回响发射点改为反弹点

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -469,6 +469,7 @@ const CONFIG = {
             phantomChancePerLevel: 0.05, // 每层 echo 增加虚影概率
             phantomLifetimeMs: 1000,  // 虚影 Peg 存活时间 (ms)
             phantomChildChance: 0.25, // 虚影 Peg 被碰撞时再生成虚影的概率
+            marbleSplitChance: 0.18,  // 钉盘阶段：回响弹珠撞击属性钉子的概率分裂（每球至多 1 次）
         }
     },
     /** 游戏平衡性：敌人与数值 */

--- a/src/entities.js
+++ b/src/entities.js
@@ -2682,6 +2682,29 @@ class DropBall {
                             }
                         }
 
+                        // ==================== [新属性] 回响弹珠概率分裂 ====================
+                        // 回响弹珠（def.type === 'echo'）撞击属性钉子时，按概率原地分裂
+                        // 复用 SpecialSlot 'split' 同款分裂返回值，由 game_phase.js 创建两颗新球
+                        // 限制：每颗球至多分裂一次（_echoSplitUsed），且 canTriggerSplitSlot=true
+                        if (
+                            this.def && this.def.type === 'echo' &&
+                            !this._echoSplitUsed &&
+                            this.canTriggerSplitSlot &&
+                            peg.type !== 'normal' && peg.type !== 'pink'
+                        ) {
+                            const echoCfg2 = (CONFIG.mechanics && CONFIG.mechanics.echo) || {};
+                            const splitChance = echoCfg2.marbleSplitChance || 0.18;
+                            if (Math.random() < splitChance) {
+                                this._echoSplitUsed = true;
+                                this.active = false;
+                                this.stopSound();
+                                audio.playPowerup();
+                                game.spawn_createExplosion(peg.pos.x, peg.pos.y, '#60a5fa');
+                                game.spawn_createFloatingText(peg.pos.x, peg.pos.y - 24, '🔁回响分裂!', '#60a5fa');
+                                return { action: 'split', pos: this.pos, vel: this.vel, def: this.def };
+                            }
+                        }
+
                         // @section:layout_special_effects - 布局专属特殊效果（漏斗/菱形/稀疏通道）
                         // ==================== [布局补偿] 布局专属特殊效果 ====================
                         const boardLayout = game.boardLayout || 'default';
@@ -3176,6 +3199,8 @@ class DropBall {
                         'cryo': ['#e0f2fe', '#0369a1'],
                         'pyro': ['#ffedd5', '#ea580c'],
                         'resonance': ['#fef3c7', '#d97706'],
+                        'echo': ['#dbeafe', '#2563eb'],
+                        'venom': ['#dcfce7', '#16a34a'],
                     };
                      if (this.def.type && map[this.def.type]) {
                          baseLight = map[this.def.type][0];

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -732,8 +732,12 @@ class Projectile {
             _echoShotChance: 0,
         };
         if (game.burstQueue) {
+            // [echo-origin] 回响发射点 = 触发回响的反弹点（this.pos），而非发射器
+            // 由 game_phase.js 的 burstQueue 处理器读取 x/y 字段，缺省时回退到发射器位置
             game.burstQueue.push({
                 delay: 0,
+                x: this.pos.x,
+                y: this.pos.y,
                 vel: mirrorVel,
                 recipe: echoRecipe,
                 shotId: this.shotId,

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1627,7 +1627,10 @@ phase_gathering_getRandomPegType() {
             shot.delay -= timeScale;
             if (shot.delay <= 0) {
                 // [emitter-port] 子弹从发射器素材的上沿发射口生成（Y 轴上移 22px）
-                this.spawn_spawnBullet(this.width/2, this.height-102, shot.vel, shot.recipe, shot.shotId, shot.isLast);
+                // [echo-origin] 若 shot 携带 x/y（如回响弹），则从该坐标发射，否则回退到发射器
+                const spawnX = (typeof shot.x === 'number') ? shot.x : this.width/2;
+                const spawnY = (typeof shot.y === 'number') ? shot.y : this.height-102;
+                this.spawn_spawnBullet(spawnX, spawnY, shot.vel, shot.recipe, shot.shotId, shot.isLast);
                 audio.playShoot();
                 this.burstQueue.splice(i, 1);
             }


### PR DESCRIPTION
## Summary

- 钉盘颜色：DropBall 颜色 map 补全 echo（蓝）和 venom（绿）。
- 回响概率分裂：回响弹珠撞击属性钉子时按 18% 概率原地分裂（每球至多 1 次）。
- 战斗回响发射点：_tryTriggerEchoBullet 推入 burstQueue 时携带反弹点坐标 x/y，game_phase.js 处理器优先使用该坐标作为发射点。

## Files
- src/config.js
- src/entities.js
- src/entities/projectile.js
- src/game_phase.js