### PR TITLE
feat: 新增敌人 V2 / 美术验收试炼场分类（enemy_v2）

### DIFF
--- a/docs/enemy_art_implementation_impact.md
+++ b/docs/enemy_art_implementation_impact.md
@@ -106,6 +106,36 @@ V2 专属词条已经具备基础绘制识别，但还需要补齐“常驻、�
 | P3 | 预设波次系统。 | 至少 5 类 preset 可按回合权重出现，并能安全回退随机生成。 |
 | P4 | 组合资产扩展。 | 通过脚本生成资产清单，逐步填充高频组合。 |
 
+## 8. 试炼场验收说明（enemy_v2 分类）
+
+在 `src/systems.js` 的 `TRAINING_SCENARIOS` 中新增了 `enemy_v2`（显示名「敌人 V2 / 美术验收」）分类，入口为右侧边栏「驗收」Tab。该分类提供 7 个可点击场景，专门用于对每种 V2 基底进行独立的视觉验收，与 V2 矩陣（一次展示全部 9 种）互为补充。
+
+### 8.1 场景列表
+
+| 场景 ID | 名称 | 尺寸 | baseArchetype | affixes | 验收重点 |
+|---|---|---|---|---|---|
+| `ev2_ref_1x1` | 1×1 基准对照 | 1×1 | 无 | 无 / shield | 单格基线尺寸与精英变体对比 |
+| `ev2_maw_2x2` | 2×2 深渊胃囊 | 2×2 | maw | devour | maw 胃囊形体 + devour 吞噬行为；旁边有 1×1 供吞噬测试 |
+| `ev2_bastion_3x1` | 3×1 装甲横梁 | 3×1 | bastion | heavyArmor | 横向 3 格轮廓 + 迟缓移动节奏（2 回合/次） |
+| `ev2_siege_3x2` | 3×2 攻城履带 | 3×2 | siege | siege | 冰冻免疫 + 静态展示履带形体 |
+| `ev2_siege_push` | Siege 阻挡推挤 | 3×2 + 1×1×3 | siege | siege | 前排 3 个阻挡兵 + 后排 siege 推挤链；触发演示验证链推挤逻辑 |
+| `ev2_large_generic_affix` | 大型 + 通用词条 | 2×2 + 1×1 | maw | devour+shield / regen | 通用词条（shield/regen）在大型基底上的视觉覆盖范围验收 |
+| `ev2_fallback_large` | 资源 Fallback（3×3） | 3×3 | gravityWell | gravityWell | 验证未接入正式资源时程序化矢量回退是否正常渲染 |
+
+### 8.2 实现约定
+
+- 每个场景 `setup(game)` 显式创建 `Enemy` 实例并赋值：`baseArchetype`、`gridCols`、`gridRows`、`isWideEnemy`（cols≥2）、`affixes`、`width`、`height`、`maxHp/hp`，与 `spawn_trySpawnArchetypes` 字段命名一致。
+- 调用 `game.spawn_applyArchetypeShape(e, archetypeId)` 为大型基底设置碰撞轮廓（polygon / arc / aabb）。
+- 场景 `desc` 固定显示：`📐 footprint` / `基底` / `词条` / `⚙️ 行为摘要` / `📦 资源状态`。资源状态从 `ENEMY_V2_BY_ID[id].placeholder` 读取：`🟡 占位资源` 或 `✅ 已接入正式美术资源`。
+- 不改变正式战斗默认刷怪概率、战斗平衡或存档逻辑；场景中敌人 `_moveInterval` 设置均为试炼场内部控制，不影响 `spawn_trySpawnArchetypes` 的生成逻辑。
+
+### 8.3 后续验收流程
+
+1. 打开试炼场 → 右侧边栏切换到「驗收」Tab。
+2. 逐一点击 7 个场景，观察敌人形体与词条特效是否符合 `docs/enemy_visual_design_v2.md` 规范。
+3. 对 `placeholder=true` 的基底，确认回退矢量绘制正常显示；有正式资源后，替换 `assets/sprites/enemies/v2/<resourceId>.png` 并将 `ENEMY_V2_METADATA` 中对应条目的 `placeholder` 改为 `false`，无需修改试炼场代码。
+4. 点击「触发演示」按钮，验证各基底的行为（吞噬、迟缓移动、推挤链、冰冻免疫）在试炼场环境中正常触发。
+
 ## References
 
 [1]: ../src/entities/enemy.js "敌人实体绘制、行动与词条视觉实现"

--- a/src/systems.js
+++ b/src/systems.js
@@ -808,7 +808,8 @@ const TRAINING_SCENARIOS = {
         { id: 'boss', name: 'Boss 機制' },
         { id: 'runeword', name: '符文詞條' },
         { id: 'relic', name: '遺物/精華' },
-        { id: 'v2matrix', name: '敵人 V2 矩陣' }
+        { id: 'v2matrix', name: '敵人 V2 矩陣' },
+        { id: 'enemy_v2', name: '敵人 V2 / 美術驗收' }
     ],
     scenarios: [
         // ── 敵人詞條 ──────────────────────────────────────────────────
@@ -1947,6 +1948,11 @@ const TRAINING_SCENARIOS = {
             }
         },
 
+        // ── 敵人 V2 美術驗收（逐場景单独验证基底 + 词条视觉）─────────────
+        // 对应 docs/enemy_art_implementation_impact.md §试炼场验收说明。
+        // 每个场景显式创建 Enemy 实例，字段与 spawn_trySpawnArchetypes 保持一致。
+        ...buildEnemyV2Scenarios(),
+
         // ── 敵人 V2 矩陣（尺寸基底 + 專屬詞條可見性驗收）─────────────
         // 對應文檔 docs/enemy_visual_design_v2.md：
         // 9 種 V2 基底（1×1 / 2×1 / 1×2 / 2×2 / 3×1 / 1×3 / 2×3 / 3×2 / 3×3）
@@ -2107,6 +2113,285 @@ function buildV2MatrixScenarios() {
     }));
 
     return [all, ...singles];
+}
+
+/**
+ * [敌人 V2 美术验收] 构建 enemy_v2 分类下的验收场景列表。
+ * 共 7 个场景（6 必选 + 1 可选 fallback），覆盖：
+ *   1. 1×1 基准对照
+ *   2. 2×2 maw/devour
+ *   3. 3×1 bastion/heavyArmor
+ *   4. 3×2 siege（静态展示）
+ *   5. siege 前排阻挡链推挤
+ *   6. 大型敌人 + 通用词条适配（maw + shield）
+ *   7. 资源 fallback 展示（3×3 gravityWell）
+ *
+ * 每个场景的 setup(game) 显式创建 Enemy 实例并赋值：
+ *   baseArchetype, gridCols, gridRows, affixes, width, height, maxHp/hp
+ * 这些字段与 spawn_trySpawnArchetypes 的命名保持一致。
+ *
+ * desc 字符串包含：尺寸 footprint / 基底 / 词条 / 行为摘要 / 资源状态。
+ */
+function buildEnemyV2Scenarios() {
+    // 资源状态：读取 ENEMY_V2_BY_ID 的 placeholder 字段
+    const resStatus = (id) => {
+        const meta = ENEMY_V2_BY_ID[id];
+        if (!meta) return '⚙️ 程序化矢量绘制（无 V2 资源键）';
+        return meta.placeholder
+            ? '🟡 占位资源 — sprite/icon 待正式美术替换（placeholder=true）'
+            : '✅ 已接入正式美术资源';
+    };
+
+    // 构造场景说明区域的标准文本
+    const mkDesc = (footprint, archetype, affixList, behavior, resourceNote) => {
+        const afxStr = affixList.length > 0 ? affixList.join(' + ') : '无';
+        const archStr = archetype || '无';
+        return [
+            `📐 footprint：${footprint}　基底：${archStr}　词条：${afxStr}`,
+            `⚙️ 行为：${behavior}`,
+            `📦 资源：${resourceNote}`
+        ].join('\n');
+    };
+
+    return [
+        // ── 场景 1：普通 1×1 对照 ─────────────────────────────────────
+        {
+            id: 'ev2_ref_1x1',
+            categoryId: 'enemy_v2',
+            name: '1×1 基准对照',
+            icon: '⬜',
+            desc: mkDesc('1×1', '无', [],
+                '标准单格炼金残渣，无专属基底、无词条。用作视觉对比基线，验证 1×1 占格单位的尺寸与渲染。',
+                '⚙️ 程序化矢量绘制（基线单位，不属于 V2 专属资源）'),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const e = new Enemy(2 * w + w / 2, top + h / 2, w, h, 200, 200, 'normal', []);
+                e.baseArchetype = null;
+                e.gridCols = 1;
+                e.gridRows = 1;
+                e._moveInterval = 9999;
+                e._moveCooldown = 9999;
+                e.hasActedThisTurn = true;
+                if (typeof e.initSprite === 'function') e.initSprite();
+                game.enemies.push(e);
+                // 精英变体对比
+                const elite = new Enemy(3 * w + w / 2, top + h / 2, w, h, 200, 200, 'elite', ['shield']);
+                elite.baseArchetype = null;
+                elite.gridCols = 1;
+                elite.gridRows = 1;
+                elite._moveInterval = 9999;
+                elite._moveCooldown = 9999;
+                elite.hasActedThisTurn = true;
+                if (typeof elite.initSprite === 'function') elite.initSprite();
+                game.enemies.push(elite);
+            },
+            bulletConfig: { damage: 20, bounce: 2, pierce: 0, scatter: 0, multicast: 0, pyro: 0, cryo: 0, lightning: 0, wind: 0, isLaser: false, isMatryoshka: false, type: 'normal' },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+
+        // ── 场景 2：2×2 深渊胃囊 / devour ────────────────────────────
+        {
+            id: 'ev2_maw_2x2',
+            categoryId: 'enemy_v2',
+            name: '2×2 深渊胃囊',
+            icon: '👁️',
+            desc: mkDesc('2×2', 'maw', ['devour'],
+                'devour：每回合有概率吞噬相邻友军并继承其血量与词条。旁边放有 1×1 目标供吞噬触发测试。点「触发演示」执行一回合行动。',
+                resStatus('maw')),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const afx = (CONFIG && CONFIG.balance && CONFIG.balance.affixes) || {};
+                const hp = Math.floor(200 * 2.0);
+                const maw = new Enemy(w * 1 + w, top + h, w * 2, h * 2, hp, hp, 'elite', ['devour']);
+                maw.baseArchetype = 'maw';
+                maw.gridCols = 2;
+                maw.gridRows = 2;
+                maw.isWideEnemy = true;
+                maw._moveInterval = 9999;
+                maw._moveCooldown = 9999;
+                maw.hasActedThisTurn = true;
+                if (typeof game.spawn_applyArchetypeShape === 'function') game.spawn_applyArchetypeShape(maw, 'maw');
+                if (typeof maw.initSprite === 'function') maw.initSprite();
+                game.enemies.push(maw);
+                // 1×1 相邻目标供吞噬
+                const food = new Enemy(w * 3 + w / 2, top + h / 2, w, h, 100, 100, 'normal', []);
+                food._moveInterval = 9999;
+                food.hasActedThisTurn = true;
+                if (typeof food.initSprite === 'function') food.initSprite();
+                game.enemies.push(food);
+            },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+
+        // ── 场景 3：3×1 装甲横梁 / heavyArmor ────────────────────────
+        {
+            id: 'ev2_bastion_3x1',
+            categoryId: 'enemy_v2',
+            name: '3×1 装甲横梁',
+            icon: '🧱',
+            desc: mkDesc('3×1', 'bastion', ['heavyArmor'],
+                'heavyArmor：血量 ×2.0，每 2 回合才移动一次，横向占满 3 列封锁通道。点「触发演示」观察迟缓移动节奏。',
+                resStatus('bastion')),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const afx = (CONFIG && CONFIG.balance && CONFIG.balance.affixes) || {};
+                const hpMult = afx.heavyArmorHpMult || 2.0;
+                const hp = Math.floor(200 * hpMult);
+                const e = new Enemy(w * 1.5 + w / 2, top + h / 2, w * 3, h, hp, hp, 'elite', ['heavyArmor']);
+                e.baseArchetype = 'bastion';
+                e.gridCols = 3;
+                e.gridRows = 1;
+                e.isWideEnemy = true;
+                e._moveInterval = afx.heavyArmorMoveInterval || 2;
+                e._moveCooldown = 0;
+                e.hasActedThisTurn = true;
+                if (typeof game.spawn_applyArchetypeShape === 'function') game.spawn_applyArchetypeShape(e, 'bastion');
+                if (typeof e.initSprite === 'function') e.initSprite();
+                game.enemies.push(e);
+            },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+
+        // ── 场景 4：3×2 攻城履带 / siege（静态展示）─────────────────
+        {
+            id: 'ev2_siege_3x2',
+            categoryId: 'enemy_v2',
+            name: '3×2 攻城履带',
+            icon: '🚛',
+            desc: mkDesc('3×2', 'siege', ['siege'],
+                'siege：免疫冰冻（热管闪烁反馈），血量 ×3.5，每 2 回合移动一次，前排无阻挡时正常推进。冻结词条对其无效。',
+                resStatus('siege')),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const afx = (CONFIG && CONFIG.balance && CONFIG.balance.affixes) || {};
+                const hp = Math.floor(200 * (afx.siegeHpMult || 3.5));
+                const e = new Enemy(w * 1.5 + w / 2, top + h, w * 3, h * 2, hp, hp, 'elite', ['siege']);
+                e.baseArchetype = 'siege';
+                e.gridCols = 3;
+                e.gridRows = 2;
+                e.isWideEnemy = true;
+                e._moveInterval = afx.siegeMoveInterval || 2;
+                e._moveCooldown = 9999;
+                e.hasActedThisTurn = true;
+                if (typeof game.spawn_applyArchetypeShape === 'function') game.spawn_applyArchetypeShape(e, 'siege');
+                if (typeof e.initSprite === 'function') e.initSprite();
+                game.enemies.push(e);
+            },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+
+        // ── 场景 5：siege 前排阻挡链推挤 ─────────────────────────────
+        {
+            id: 'ev2_siege_push',
+            categoryId: 'enemy_v2',
+            name: 'Siege 阻挡推挤',
+            icon: '🏗️',
+            desc: mkDesc('3×2 + 1×1×3 阻挡链', 'siege', ['siege'],
+                '前排 3 个 1×1 阻挡兵（col 1-3）+ 后排 3×2 siege（row 1-2）。点「触发演示」触发敌人行动：siege 移动被前排阻挡时会尝试将整条阻挡链向前推 1 行，验证链推挤逻辑与失败线判定。',
+                resStatus('siege')),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const afx = (CONFIG && CONFIG.balance && CONFIG.balance.affixes) || {};
+                const hp = Math.floor(200 * (afx.siegeHpMult || 3.5));
+                // 3×2 siege 放置在 row 1-2（center at row=1, rows=2）
+                const siege = new Enemy(w * 1.5 + w / 2, top + h + h, w * 3, h * 2, hp, hp, 'elite', ['siege']);
+                siege.baseArchetype = 'siege';
+                siege.gridCols = 3;
+                siege.gridRows = 2;
+                siege.isWideEnemy = true;
+                siege._moveInterval = afx.siegeMoveInterval || 2;
+                siege._moveCooldown = 0;
+                siege.hasActedThisTurn = false;
+                if (typeof game.spawn_applyArchetypeShape === 'function') game.spawn_applyArchetypeShape(siege, 'siege');
+                if (typeof siege.initSprite === 'function') siege.initSprite();
+                game.enemies.push(siege);
+                // 前排 3 个 1×1 阻挡兵 col 1, 2, 3（row 0）
+                for (let c = 1; c <= 3; c++) {
+                    const bx = c * w + w / 2;
+                    const by = top + h / 2;
+                    const blocker = new Enemy(bx, by, w, h, 150, 150, 'normal', []);
+                    blocker.gridCols = 1;
+                    blocker.gridRows = 1;
+                    blocker._moveInterval = 9999;
+                    blocker.hasActedThisTurn = false;
+                    if (typeof blocker.initSprite === 'function') blocker.initSprite();
+                    game.enemies.push(blocker);
+                }
+            },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+
+        // ── 场景 6：大型敌人 + 通用词条适配（maw + shield / regen）──
+        {
+            id: 'ev2_large_generic_affix',
+            categoryId: 'enemy_v2',
+            name: '大型 + 通用词条',
+            icon: '🧬',
+            desc: mkDesc('2×2', 'maw', ['devour', 'shield'],
+                '2×2 深渊胃囊叠加通用词条 shield：验证护盾特效能否覆盖完整 2×2 轮廓（而非只包住中心）。右侧 1×1 regen 精英用于对比同一通用词条在不同尺寸下的视觉缩放。',
+                resStatus('maw')),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const hp = Math.floor(200 * 2.0);
+                // 2×2 maw + devour + shield（左侧）
+                const maw = new Enemy(w * 0 + w, top + h, w * 2, h * 2, hp, hp, 'elite', ['devour', 'shield']);
+                maw.baseArchetype = 'maw';
+                maw.gridCols = 2;
+                maw.gridRows = 2;
+                maw.isWideEnemy = true;
+                maw._moveInterval = 9999;
+                maw._moveCooldown = 9999;
+                maw.hasActedThisTurn = true;
+                if (typeof game.spawn_applyArchetypeShape === 'function') game.spawn_applyArchetypeShape(maw, 'maw');
+                if (typeof maw.initSprite === 'function') maw.initSprite();
+                game.enemies.push(maw);
+                // 1×1 regen 精英（右侧对比）
+                const ref = new Enemy(w * 3 + w / 2, top + h / 2, w, h, 200, 200, 'elite', ['regen']);
+                ref.gridCols = 1;
+                ref.gridRows = 1;
+                ref._moveInterval = 9999;
+                ref.hasActedThisTurn = true;
+                if (typeof ref.initSprite === 'function') ref.initSprite();
+                game.enemies.push(ref);
+            },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+
+        // ── 场景 7（可选 fallback）：3×3 引力炉心资源降级渲染 ────────
+        {
+            id: 'ev2_fallback_large',
+            categoryId: 'enemy_v2',
+            name: '资源 Fallback（3×3）',
+            icon: '🔧',
+            desc: mkDesc('3×3', 'gravityWell', ['gravityWell'],
+                '引力炉心 —— 验证当正式美术资源未接入时，是否正确回退到程序化矢量绘制（黑核 + 环形炉壁 + 向心网格）。同时验证 3×3 大体型的碰撞轮廓（arc 圆形）。',
+                resStatus('gravityCore')),
+            setup: (game) => {
+                const w = game.enemyWidth, h = game.enemyHeight;
+                const top = game.combatGridTopY;
+                const afx = (CONFIG && CONFIG.balance && CONFIG.balance.affixes) || {};
+                const hp = Math.floor(200 * (afx.gravityWellHpMult || 6.0));
+                const e = new Enemy(w * 1.5 + w / 2, top + h * 1.5, w * 3, h * 3, hp, hp, 'elite', ['gravityWell']);
+                e.baseArchetype = 'gravityWell';
+                e.gridCols = 3;
+                e.gridRows = 3;
+                e.isWideEnemy = true;
+                e._moveInterval = afx.gravityWellMoveInterval || 3;
+                e._moveCooldown = 9999;
+                e.hasActedThisTurn = true;
+                if (typeof game.spawn_applyArchetypeShape === 'function') game.spawn_applyArchetypeShape(e, 'gravityWell');
+                if (typeof e.initSprite === 'function') e.initSprite();
+                game.enemies.push(e);
+            },
+            demoAction: (game) => { game.phase_enemy_startLogic(); }
+        },
+    ];
 }
 
 class TrainingGround {
@@ -2576,6 +2861,7 @@ class TrainingGround {
                 <button onclick="game.trainingGround.switchCategory('boss')" id="scat-btn-boss" class="train-scat-btn">Boss</button>
                 <button onclick="game.trainingGround.switchCategory('runeword')" id="scat-btn-runeword" class="train-scat-btn">符文</button>
                 <button onclick="game.trainingGround.switchCategory('v2matrix')" id="scat-btn-v2matrix" class="train-scat-btn" title="敵人視覺 V2 基底矩陣">V2</button>
+                <button onclick="game.trainingGround.switchCategory('enemy_v2')" id="scat-btn-enemy_v2" class="train-scat-btn" title="敵人 V2 美術驗收場景">驗收</button>
             </div>
             <!-- 场景列表 -->
             <div id="train-scenario-list" class="train-scenario-list"></div>


### PR DESCRIPTION
## Summary

- 在 `TRAINING_SCENARIOS` 中新增 `enemy_v2`（显示名「敌人 V2 / 美术验收」）分类，试炼场右侧边栏新增「驗收」Tab。
- 新增 `buildEnemyV2Scenarios()` 函数，提供 7 个可点击验收场景（6 必选 + 1 可选 fallback），覆盖全部核心 V2 基底类型。
- 更新 `docs/enemy_art_implementation_impact.md` 新增 §8「试炼场验收说明」，含场景列表、实现约定和后续验收流程。

## 场景列表

| 场景 ID | 名称 | 尺寸 | 验收重点 |
|---|---|---|---|
| `ev2_ref_1x1` | 1×1 基准对照 | 1×1 | 单格基线 + 精英 shield 变体 |
| `ev2_maw_2x2` | 2×2 深渊胃囊 | 2×2 | maw 胃囊形体 + devour 吞噬行为 |
| `ev2_bastion_3x1` | 3×1 装甲横梁 | 3×1 | 横向 3 格 + heavyArmor 迟缓移动 |
| `ev2_siege_3x2` | 3×2 攻城履带 | 3×2 | siege 静态展示 + 冰冻免疫标注 |
| `ev2_siege_push` | Siege 阻挡推挤 | 3×2 + 1×1×3 | 前排阻挡链 + 链推挤逻辑验证 |
| `ev2_large_generic_affix` | 大型 + 通用词条 | 2×2 + 1×1 | shield/regen 在大型基底上的视觉覆盖 |
| `ev2_fallback_large` | 资源 Fallback（3×3） | 3×3 | gravityWell 矢量回退渲染验证 |

## 实现要点

- 每个场景 `setup(game)` 显式赋值 `baseArchetype / gridCols / gridRows / isWideEnemy / affixes / width / height / maxHp`，与 `spawn_trySpawnArchetypes` 字段对齐。
- 调用 `spawn_applyArchetypeShape()` 设置正确碰撞轮廓（polygon / arc / aabb）。
- `desc` 统一展示 footprint / 基底 / 词条 / 行为摘要 / 资源状态（从 `ENEMY_V2_BY_ID[id].placeholder` 读取 🟡/✅ 标记）。
- **不改变**正式战斗刷怪概率、战斗平衡或存档逻辑。

## Test plan

- [ ] 打开试炼场，右侧边栏出现「驗收」Tab，可切换到 enemy_v2 分类。
- [ ] 7 个场景均可点击，战场正确生成对应敌人（尺寸、颜色、形体符合 V2 规范）。
- [ ] 每个场景的说明区域显示完整的 footprint / 基底 / 词条 / 行为 / 资源状态（🟡 占位或 ✅ 已接入）。
- [ ] 点击「触发演示」：maw 触发吞噬、bastion 观察迟缓移动、siege_push 验证链推挤。
- [ ] `node --check src/systems.js src/entities/enemy.js src/spawn_system.js src/config.js` 全部通过。
- [ ] `git diff --check` 无空白问题。

https://claude.ai/code/session_01VpfgGgKoz4GGrYeAQx1LgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpfgGgKoz4GGrYeAQx1LgX)_