### PR TITLE
balance: 调整机制 + UI 优化（回响 / 剧毒 / 嗜血 / 抽奖 / 遗物 / 继承 / 符文页）

### DIFF
--- a/index.html
+++ b/index.html
@@ -2929,8 +2929,9 @@
 
             <!-- Tab 导航 -->
             <div class="flex gap-2 mb-5 border-b border-slate-700/50 pb-3">
-                <button id="rune-tab-launcher" onclick="game.ui_switchRuneTab('launcher')" class="flex-1 py-2 px-3 rounded-lg text-xs font-bold tracking-wider transition-all duration-200 bg-purple-700/60 text-purple-100 border border-purple-500/60">⚡ 發射器</button>
-                <button id="rune-tab-codex" onclick="game.ui_switchRuneTab('codex')" class="flex-1 py-2 px-3 rounded-lg text-xs font-bold tracking-wider transition-all duration-200 bg-slate-800/60 text-slate-400 border border-slate-700/40 hover:bg-slate-700/60 hover:text-slate-200">📖 詞條圖鑑</button>
+                <button id="rune-tab-launcher" onclick="game.ui_switchRuneTab('launcher')" class="flex-1 py-2 px-2 rounded-lg text-[11px] font-bold tracking-wider transition-all duration-200 bg-purple-700/60 text-purple-100 border border-purple-500/60">⚡ 配置</button>
+                <button id="rune-tab-management" onclick="game.ui_switchRuneTab('management')" class="flex-1 py-2 px-2 rounded-lg text-[11px] font-bold tracking-wider transition-all duration-200 bg-slate-800/60 text-slate-400 border border-slate-700/40 hover:bg-slate-700/60 hover:text-slate-200">⚗️ 管理</button>
+                <button id="rune-tab-codex" onclick="game.ui_switchRuneTab('codex')" class="flex-1 py-2 px-2 rounded-lg text-[11px] font-bold tracking-wider transition-all duration-200 bg-slate-800/60 text-slate-400 border border-slate-700/40 hover:bg-slate-700/60 hover:text-slate-200">📖 圖鑑</button>
             </div>
 
             <!-- 发射器内容区域 -->
@@ -2962,39 +2963,6 @@
                 </div>
             </div>
 
-            <!-- 合成区域 -->
-            <div class="mb-4 bg-amber-900/10 border border-amber-700/30 rounded-xl p-4">
-                <div class="flex items-center gap-2 mb-3">
-                    <span class="text-amber-400">⚗️</span>
-                    <div class="text-xs text-amber-300/80 tracking-widest uppercase font-bold">合成爐</div>
-                    <div class="text-[10px] text-slate-500 ml-auto">選中 3 個同 ID 同等級符文</div>
-                </div>
-                <button id="rune-merge-btn"
-                    onclick="game.ui_doRuneMerge()"
-                    disabled
-                    class="w-full py-2 px-3 rounded-xl text-sm font-bold bg-slate-800/60 text-slate-600 border border-slate-700/40 cursor-not-allowed transition-all duration-200">
-                    ⚗️ 合成（需選中 3 個同 ID 同等級）
-                </button>
-            </div>
-
-            <!-- 重铸炉区域 -->
-            <div class="mb-4 bg-purple-900/10 border border-purple-700/30 rounded-xl p-4">
-                <div class="flex items-center gap-2 mb-3">
-                    <span class="text-purple-400">🔮</span>
-                    <div class="text-xs text-purple-300/80 tracking-widest uppercase font-bold">重鑄爐</div>
-                    <div class="text-[10px] text-slate-500 ml-auto">選中任意 3 個符文</div>
-                </div>
-                <button id="rune-reforge-btn"
-                    onclick="game.ui_doRuneReforge()"
-                    disabled
-                    class="w-full py-2 px-3 rounded-xl text-sm font-bold bg-slate-800/60 text-slate-600 border border-slate-700/40 cursor-not-allowed transition-all duration-200">
-                    🔮 重鑄（消耗 3 個符文，獲得全新符文）
-                </button>
-            </div>
-
-            <!-- 操作结果提示 -->
-            <div id="rune-action-result" class="hidden mb-4 text-sm font-bold text-center py-2 px-3 rounded-xl"></div>
-
             <!-- 激活词条列表 -->
             <div class="mb-4">
                 <div class="text-xs text-amber-300/60 tracking-widest uppercase mb-3">已激活詞條</div>
@@ -3024,6 +2992,52 @@
             </div>
 
             </div><!-- end #rune-launcher-content -->
+
+            <!-- 符文管理面板（熔炼 / 重铸） -->
+            <div id="rune-management-panel" class="hidden">
+                <div class="text-xs text-slate-400/70 mb-3 leading-relaxed">
+                    在此頁面熔煉或重鑄符文。請先在「配置」頁面選中 3 個符文，再返回此頁執行操作。
+                </div>
+
+                <!-- 当前选中状态 -->
+                <div class="mb-4 px-3 py-2 bg-slate-900/40 border border-slate-700/40 rounded-lg flex items-center justify-between">
+                    <span class="text-[11px] text-slate-400">當前選中</span>
+                    <span id="rune-management-selected-count" class="text-xs text-purple-300 font-bold">0 / 3</span>
+                </div>
+
+                <!-- 合成区域 -->
+                <div class="mb-4 bg-amber-900/10 border border-amber-700/30 rounded-xl p-4">
+                    <div class="flex items-center gap-2 mb-3">
+                        <span class="text-amber-400">⚗️</span>
+                        <div class="text-xs text-amber-300/80 tracking-widest uppercase font-bold">合成爐</div>
+                        <div class="text-[10px] text-slate-500 ml-auto">選中 3 個同 ID 同等級符文</div>
+                    </div>
+                    <button id="rune-merge-btn"
+                        onclick="game.ui_doRuneMerge()"
+                        disabled
+                        class="w-full py-2 px-3 rounded-xl text-sm font-bold bg-slate-800/60 text-slate-600 border border-slate-700/40 cursor-not-allowed transition-all duration-200">
+                        ⚗️ 合成（需選中 3 個同 ID 同等級）
+                    </button>
+                </div>
+
+                <!-- 重铸炉区域 -->
+                <div class="mb-4 bg-purple-900/10 border border-purple-700/30 rounded-xl p-4">
+                    <div class="flex items-center gap-2 mb-3">
+                        <span class="text-purple-400">🔮</span>
+                        <div class="text-xs text-purple-300/80 tracking-widest uppercase font-bold">重鑄爐</div>
+                        <div class="text-[10px] text-slate-500 ml-auto">選中任意 3 個符文</div>
+                    </div>
+                    <button id="rune-reforge-btn"
+                        onclick="game.ui_doRuneReforge()"
+                        disabled
+                        class="w-full py-2 px-3 rounded-xl text-sm font-bold bg-slate-800/60 text-slate-600 border border-slate-700/40 cursor-not-allowed transition-all duration-200">
+                        🔮 重鑄（消耗 3 個符文，獲得全新符文）
+                    </button>
+                </div>
+
+                <!-- 操作结果提示 -->
+                <div id="rune-action-result" class="hidden mb-4 text-sm font-bold text-center py-2 px-3 rounded-xl"></div>
+            </div><!-- end #rune-management-panel -->
 
             <!-- 词条图鉴面板 -->
             <div id="rune-codex-panel" class="hidden">

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -2539,7 +2539,12 @@ export const combat_system = {
                 const { damagePerKill, elementPenalty } = bloodthirstFx.params;
                 const killCount = this.runewordKillCount || 0;
                 if (killCount > 0 && damagePerKill > 0) {
-                    finalRecipe.damage = (finalRecipe.damage || 0) + damagePerKill * killCount;
+                    // 三角阈值：每击杀 1, 2, 3, 4... 个敌人才 +damagePerKill 伤害
+                    // 累计阈值 1, 3, 6, 10, 15... bonus = floor((-1 + sqrt(1+8N))/2)
+                    const bonusTier = Math.floor((-1 + Math.sqrt(1 + 8 * killCount)) / 2);
+                    if (bonusTier > 0) {
+                        finalRecipe.damage = (finalRecipe.damage || 0) + damagePerKill * bonusTier;
+                    }
                 }
                 if (elementPenalty > 0) {
                     if (finalRecipe.cryo > 0) {

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -84,6 +84,8 @@ class Projectile {
         this.rotation = 0;
         this.windBladeAngle = 0; // 风属性环绕风刃的旋转角度
         this.lifeTime = 60 * 30; // [修改] 加倍子弹生命时间 (从15秒增加到30秒)
+        // 回响子弹寿命限制为 1 秒，避免镜像反方向子弹长时间留存
+        if (this._isEchoChild) this.lifeTime = 60;
         this.chainHistory = [];
         this.trail = [];
         // [拖尾调优] 根据子弹强度（属性层数）和类型决定拖尾长度。

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -901,7 +901,10 @@ phase_gathering_getRandomPegType() {
                     oneShotMult = 1; // 维持公式一致：×当前 stacks 一次
                     e._wasFrozenLastTurn = false;
                 }
-                let dotDmg = (e.venomStacks * dotPerStack * dotMultiplier) * ticks * oneShotMult;
+                // 三角阈值：每累计 1, 2, 3, 4… 层才 +1 点伤害
+                // stacks=1→1dmg, stacks=3→2dmg, stacks=6→3dmg, stacks=10→4dmg ...
+                const venomTier = Math.floor((-1 + Math.sqrt(1 + 8 * e.venomStacks)) / 2);
+                let dotDmg = (venomTier * dotPerStack * dotMultiplier) * ticks * oneShotMult;
                 // 对 shield 敌人 DoT 双倍（共鸣 Tier3）
                 if (ignoreShield && e.affixes && e.affixes.includes('shield')) {
                     dotDmg *= 2;

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -1002,7 +1002,7 @@ export const game_system = {
         const finalPicks = slotAttrs.map(arr => arr[Math.floor(Math.random() * arr.length)]);
 
         const allSame = finalPicks.length >= 3 && finalPicks.every(p => p === finalPicks[0]);
-        const incVal = allSame ? 5 : 2;
+        const incVal = allSame ? 5 : 1;
 
         const applyUpgrade = () => {
             if (allSame) {
@@ -1086,7 +1086,7 @@ export const game_system = {
         });
         const finalPicks = slotAttrs.map(arr => arr[Math.floor(Math.random() * arr.length)]);
         const allSame = finalPicks.length >= 3 && finalPicks.every(p => p === finalPicks[0]);
-        const baseInc = allSame ? 5 : 2;
+        const baseInc = allSame ? 5 : 1;
         const incVal = baseInc + Math.max(0, bonusCount | 0);
 
         const applyUpgrade = () => {

--- a/src/rune_config.js
+++ b/src/rune_config.js
@@ -408,7 +408,7 @@ const RUNEWORD_DB = [
         name: '嗜血初锋',
         effectId: 'bloodthirst_growth',
         pattern: ['rune_pierce_1', 'rune_pyro_1', 'rune_pierce_1'],
-        effect_desc: '每次击杀敌人，本局全局基础伤害永久 +1。但你的冰霜与火焰属性层数降低 30%。',
+        effect_desc: '每累计击杀 1, 2, 3, 4… 个敌人后，本局全局基础伤害永久再 +1（三角阈值）。但你的冰霜与火焰属性层数降低 30%。',
         baseParams: { damagePerKill: 1, elementPenalty: 0.3 },
         perLevelParams: { damagePerKill: 1, elementPenalty: -0.1 }
     },

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -17,7 +17,8 @@
 
 import { CONFIG } from '../config.js';
 import { eventBus, EVENT_TYPES } from '../event_bus.js';
-import { RUNE_DB, RARITY_DISPLAY } from '../rune_config.js';
+import { RUNE_DB, RARITY_DISPLAY, STAT_DISPLAY } from '../rune_config.js';
+import { calcRuneBaseStats } from '../rune_system.js';
 import { getAmmoIconSrc } from '../bitmap_icons.js';
 
 /**
@@ -449,9 +450,13 @@ export const hud_system = {
                     }
                     combatHud.appendChild(card);
                 });
+
+                // --- [继承加成] 显示符文基础属性、词条加成与全局额外伤害/击杀加成 ---
+                const inheritCard = this._buildInheritanceCard();
+                if (inheritCard) combatHud.appendChild(inheritCard);
             }
-        } 
-        else { 
+        }
+        else {
             // --- 收集阶段 ---
             
             // 1. 隐藏战斗 HUD
@@ -1023,6 +1028,67 @@ export const hud_system = {
         });
     },
 
+    /**
+     * 构建继承加成卡片：展示当前所有附加属性、伤害继承
+     * - 全局基础伤害加成（flatDamageBonus 来自 alchemist_powder_tube 等遗物）
+     * - 嗜血初锋累计击杀加成（runewordKillCount，三角阈值）
+     * - 符文网格基础属性加成（calcRuneBaseStats）
+     * - 词条共鸣属性加成（runewordStats）
+     * @returns {HTMLElement|null}
+     * @private
+     */
+    _buildInheritanceCard() {
+        const flatDmg = this.flatDamageBonus || 0;
+        const killCount = this.runewordKillCount || 0;
+        const bloodthirstFx = this.activeRunewordEffects && this.activeRunewordEffects['bloodthirst_growth'];
+        let bloodthirstBonus = 0;
+        if (bloodthirstFx && killCount > 0) {
+            const damagePerKill = (bloodthirstFx.params && bloodthirstFx.params.damagePerKill) || 0;
+            const bonusTier = Math.floor((-1 + Math.sqrt(1 + 8 * killCount)) / 2);
+            bloodthirstBonus = damagePerKill * bonusTier;
+        }
+
+        let baseStats = {};
+        let runewordStats = {};
+        try {
+            if (this.runeGrid) baseStats = calcRuneBaseStats(this.runeGrid, RUNE_DB) || {};
+        } catch (e) { baseStats = {}; }
+        if (this.runewordStats && typeof this.runewordStats === 'object') runewordStats = this.runewordStats;
+
+        const baseEntries = Object.entries(baseStats).filter(([, v]) => v > 0);
+        const runewordEntries = Object.entries(runewordStats).filter(([, v]) => v > 0);
+
+        if (flatDmg <= 0 && bloodthirstBonus <= 0 && baseEntries.length === 0 && runewordEntries.length === 0) {
+            return null;
+        }
+
+        const card = document.createElement('div');
+        card.className = 'recipe-card mb-1';
+        card.style.cssText = 'background:rgba(15,23,42,0.85);border:1px solid rgba(168,85,247,0.4);border-radius:6px;padding:4px 6px;';
+
+        const header = document.createElement('div');
+        header.className = 'border-b border-purple-500/20 pb-0.5 mb-1';
+        header.innerHTML = '<span class="font-bold text-purple-300 text-[10px] tracking-wider">✨ 继承加成</span>';
+        card.appendChild(header);
+
+        const lines = [];
+        if (flatDmg > 0) lines.push(`<span class="text-amber-300">⚔️ 基础伤害 +${flatDmg}</span>`);
+        if (bloodthirstBonus > 0) lines.push(`<span class="text-red-300">🩸 嗜血 +${bloodthirstBonus} (${killCount}杀)</span>`);
+        baseEntries.forEach(([k, v]) => {
+            const info = STAT_DISPLAY[k] || { name: k, icon: '' };
+            lines.push(`<span class="text-blue-300">${info.icon} ${info.name} +${v}</span>`);
+        });
+        runewordEntries.forEach(([k, v]) => {
+            const info = STAT_DISPLAY[k] || { name: k, icon: '' };
+            lines.push(`<span class="text-amber-300">${info.icon} ${info.name} +${v}</span>`);
+        });
+
+        const grid = document.createElement('div');
+        grid.className = 'flex flex-wrap gap-x-2 gap-y-0.5 text-[9px] leading-tight';
+        grid.innerHTML = lines.join('');
+        card.appendChild(grid);
+        return card;
+    },
 
 };
 

--- a/src/ui/rune_launcher.js
+++ b/src/ui/rune_launcher.js
@@ -667,7 +667,14 @@ export const rune_launcher_system = {
             card.className = [
                 'flex items-start gap-3 p-3',
                 'bg-purple-900/20 border border-purple-700/40 rounded-xl',
+                'cursor-pointer hover:bg-purple-900/40 hover:border-purple-500/60 transition-all duration-150',
             ].join(' ');
+            card.title = '點擊查看詞條詳細效果';
+            card.onclick = () => {
+                if (typeof this.ui_showRunewordDetail === 'function') {
+                    this.ui_showRunewordDetail(rw.id || rw.effectId, rw.level || 1);
+                }
+            };
             // [Agent D] 根据 level 动态计算效果数值描述
             const level = rw.level || 1;
             const bp = rw.baseParams || {};
@@ -853,6 +860,12 @@ export const rune_launcher_system = {
             countEl.className = selectedCount > 0
                 ? 'text-xs text-purple-300 font-bold'
                 : 'text-xs text-slate-500';
+        }
+        // 同步管理页选中计数
+        const mgCountEl = document.getElementById('rune-management-selected-count');
+        if (mgCountEl) {
+            mgCountEl.textContent = `${selectedCount} / 3`;
+            mgCountEl.style.color = selectedCount > 0 ? '#c4b5fd' : '#64748b';
         }
 
         // 获取选中符文对象
@@ -1104,26 +1117,115 @@ export const rune_launcher_system = {
      */
     ui_switchRuneTab(tab) {
         const launcherContent = document.getElementById('rune-launcher-content');
+        const managementPanel = document.getElementById('rune-management-panel');
         const codexPanel = document.getElementById('rune-codex-panel');
         const tabLauncher = document.getElementById('rune-tab-launcher');
+        const tabManagement = document.getElementById('rune-tab-management');
         const tabCodex = document.getElementById('rune-tab-codex');
         if (!launcherContent || !codexPanel) return;
 
         const activeClass = ['bg-purple-700/60', 'text-purple-100', 'border-purple-500/60'];
         const inactiveClass = ['bg-slate-800/60', 'text-slate-400', 'border-slate-700/40'];
 
+        const setActive = (btn, on) => {
+            if (!btn) return;
+            if (on) { btn.classList.add(...activeClass); btn.classList.remove(...inactiveClass); }
+            else    { btn.classList.remove(...activeClass); btn.classList.add(...inactiveClass); }
+        };
+
+        // 默认隐藏全部内容
+        launcherContent.classList.add('hidden');
+        if (managementPanel) managementPanel.classList.add('hidden');
+        codexPanel.classList.add('hidden');
+
         if (tab === 'launcher') {
             launcherContent.classList.remove('hidden');
-            codexPanel.classList.add('hidden');
-            if (tabLauncher) { tabLauncher.classList.add(...activeClass); tabLauncher.classList.remove(...inactiveClass); }
-            if (tabCodex) { tabCodex.classList.remove(...activeClass); tabCodex.classList.add(...inactiveClass); }
+            setActive(tabLauncher, true);
+            setActive(tabManagement, false);
+            setActive(tabCodex, false);
+        } else if (tab === 'management') {
+            if (managementPanel) managementPanel.classList.remove('hidden');
+            setActive(tabLauncher, false);
+            setActive(tabManagement, true);
+            setActive(tabCodex, false);
+            // 更新管理页选中计数
+            if (typeof this._ui_updateRuneActionButtons === 'function') this._ui_updateRuneActionButtons();
+            const sel = document.getElementById('rune-management-selected-count');
+            if (sel) {
+                const c = this._selectedRuneIndices ? this._selectedRuneIndices.size : 0;
+                sel.textContent = `${c} / 3`;
+            }
         } else {
-            launcherContent.classList.add('hidden');
             codexPanel.classList.remove('hidden');
-            if (tabCodex) { tabCodex.classList.add(...activeClass); tabCodex.classList.remove(...inactiveClass); }
-            if (tabLauncher) { tabLauncher.classList.remove(...activeClass); tabLauncher.classList.add(...inactiveClass); }
+            setActive(tabLauncher, false);
+            setActive(tabManagement, false);
+            setActive(tabCodex, true);
             this.ui_renderRuneCodex();
         }
+    },
+
+
+    /**
+     * ui_showRunewordDetail - 弹出词条详细效果浮层
+     * @param {string} runewordId
+     * @param {number} [level=1]
+     */
+    ui_showRunewordDetail(runewordId, level = 1) {
+        const rw = RUNEWORD_DB.find(r => r.id === runewordId);
+        if (!rw) return;
+        let overlay = document.getElementById('runeword-detail-overlay');
+        if (!overlay) {
+            overlay = document.createElement('div');
+            overlay.id = 'runeword-detail-overlay';
+            overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.75);z-index:600;display:flex;align-items:center;justify-content:center;padding:16px;';
+            overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
+            document.body.appendChild(overlay);
+        } else {
+            overlay.innerHTML = '';
+            overlay.style.display = 'flex';
+        }
+
+        const patternIcons = rw.pattern.map(rid => {
+            const rd = RUNE_DB.find(r => r.id === rid);
+            return rd ? `<span title="${rd.name}">${_ui_buildRuneIconHTML(rd, 1)}</span>` : '?';
+        }).join('<span style="color:#64748b;margin:0 2px;">→</span>');
+
+        const dynamicDesc = (typeof this._ui_calcRunewordDynamicDesc === 'function')
+            ? this._ui_calcRunewordDynamicDesc(rw, level) : '';
+
+        const tabs = [1, 2, 3].map(lv => {
+            const active = lv === level;
+            return `<button data-lv="${lv}" style="padding:4px 10px;border-radius:6px;font-size:11px;font-weight:bold;cursor:pointer;border:1px solid ${active ? '#fbbf24' : '#475569'};background:${active ? 'rgba(251,191,36,0.25)' : 'rgba(30,41,59,0.6)'};color:${active ? '#fde68a' : '#94a3b8'};">Lv.${lv}</button>`;
+        }).join('');
+
+        const card = document.createElement('div');
+        card.style.cssText = 'max-width:380px;width:100%;background:#0f172a;border:1px solid rgba(168,85,247,0.5);border-radius:14px;padding:18px;box-shadow:0 0 40px rgba(168,85,247,0.3);';
+        card.innerHTML = `
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
+                <div style="display:flex;align-items:center;gap:8px;">
+                    <span style="font-size:22px;">✨</span>
+                    <span style="font-size:16px;font-weight:bold;color:#e9d5ff;">${rw.name}</span>
+                    <span style="font-size:10px;color:#94a3b8;background:rgba(30,41,59,0.7);padding:2px 6px;border-radius:4px;">${rw.effect_desc.match(/【(.+?)】/)?.[1] || ''}</span>
+                </div>
+                <button id="runeword-detail-close" style="width:28px;height:28px;border-radius:50%;background:#1e293b;color:#cbd5e1;border:1px solid #334155;cursor:pointer;font-size:14px;">✕</button>
+            </div>
+            <div style="font-size:11px;color:#cbd5e1;margin-bottom:8px;">符文組合：<span style="font-size:16px;">${patternIcons}</span></div>
+            <div style="font-size:12px;color:#e2e8f0;line-height:1.6;margin-bottom:10px;">${rw.effect_desc}</div>
+            <div id="runeword-detail-dynamic" style="font-size:12px;color:#34d399;font-weight:bold;min-height:18px;margin-bottom:12px;">${dynamicDesc}</div>
+            <div style="display:flex;align-items:center;gap:6px;">
+                <span style="font-size:11px;color:#94a3b8;">等級：</span>
+                <div id="runeword-detail-tabs" style="display:flex;gap:6px;">${tabs}</div>
+            </div>
+        `;
+        overlay.appendChild(card);
+
+        card.querySelector('#runeword-detail-close').onclick = () => overlay.remove();
+        card.querySelectorAll('#runeword-detail-tabs button').forEach(btn => {
+            btn.onclick = () => {
+                const lv = parseInt(btn.dataset.lv, 10);
+                this.ui_showRunewordDetail(runewordId, lv);
+            };
+        });
     },
 
 

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -1,6 +1,6 @@
 import { eventBus, EVENT_TYPES } from './event_bus.js';
 import { RUNE_DB } from './rune_config.js';
-import { CONFIG } from './config.js';
+import { CONFIG, RELIC_DB } from './config.js';
 import { getAmmoIconSrcByKey } from './bitmap_icons.js';
 
 export const ui_system = {
@@ -1156,6 +1156,32 @@ export const ui_system = {
         pause.style.display = 'none';
     },
 
-    ui_syncPauseSettings() {},
-    ui_renderPauseRelics() {}
+    ui_syncPauseSettings() {
+        if (typeof this.ui_renderPauseRelics === 'function') this.ui_renderPauseRelics();
+    },
+    ui_renderPauseRelics() {
+        const list = document.getElementById('pause-relic-list');
+        if (!list) return;
+        const owned = (this.ownedRelics || []);
+        if (owned.length === 0) {
+            list.innerHTML = '<div class="pause-empty-relics">尚未获得任何遗物</div>';
+            return;
+        }
+        // 统计每件遗物的拥有数量
+        const counts = {};
+        owned.forEach(id => { counts[id] = (counts[id] || 0) + 1; });
+        const html = Object.entries(counts).map(([id, count]) => {
+            const def = RELIC_DB.find(r => r.id === id) || { name: id, icon: '❓', desc: '' };
+            const stack = count > 1 ? ` <span style="color:#fbbf24;font-weight:bold;">×${count}</span>` : '';
+            return `
+                <div style="display:flex;align-items:flex-start;gap:8px;padding:8px;margin-bottom:6px;background:rgba(30,41,59,0.6);border:1px solid rgba(100,116,139,0.3);border-radius:8px;">
+                    <span style="font-size:20px;line-height:1;">${def.icon || '🔮'}</span>
+                    <div style="flex:1;min-width:0;">
+                        <div style="font-size:12px;font-weight:bold;color:#e2e8f0;">${def.name}${stack}</div>
+                        <div style="font-size:10px;color:#94a3b8;margin-top:2px;line-height:1.4;">${def.desc || ''}</div>
+                    </div>
+                </div>`;
+        }).join('');
+        list.innerHTML = html;
+    }
 };


### PR DESCRIPTION
## Summary
- **回响子弹**：`_isEchoChild` 寿命 30s → 1s
- **设置面板·已获得遗物**：实现 `ui_renderPauseRelics`，按 RELIC_DB 名称/图标/描述渲染（含数量叠加）
- **子弹老虎机默认值**：non-allSame 升幅 +2 → +1（`sys_skipChaosEssenceUpgrade` & `sys_runInWallClearLottery` 同步）
- **嗜血初锋**：从「每杀 +1 伤害」改为三角阈值「累计 1/2/3/4… 杀才再 +1 伤害」，对应 `effect_desc` 同步
- **战斗 HUD·继承加成**：在配方卡片下方新增浮卡，展示 `flatDamageBonus`、嗜血累计加成、`calcRuneBaseStats(runeGrid)` 与词条共鸣属性
- **符文发射器拆分**：原「⚡ 發射器 / 📖 詞條圖鑑」两 Tab → 「⚡ 配置 / ⚗️ 管理 / 📖 圖鑑」三 Tab；熔炼与重铸移到管理页，避免上下长滚
- **激活词条卡片可点击**：弹出全局浮窗显示效果描述与 Lv.1/2/3 数值切换
- **剧毒 DoT**：从「每层 1 点」改为三角阈值「累计 1/3/6/10… 层才 +1 点每回合伤害」

## Test plan
- [ ] 回响触发后镜像子弹约 1s 后消失
- [ ] 暂停面板打开时显示当前所有遗物及叠加数
- [ ] 老虎机默认情况只 +1，全相同仍 +5；围墙清场加成 baseInc 同步
- [ ] 嗜血在 1/3/6/10 杀时基础伤害分别 +1/+2/+3/+4
- [ ] 战斗 HUD 在拥有任何继承属性时显示「✨ 继承加成」卡
- [ ] 符文发射器三 Tab 切换正常；管理页选中计数同步；熔炼/重铸按鈕正常
- [ ] 已激活词条点击弹出详情，Lv 切换正确
- [ ] 剧毒 1 层不再造成伤害，3/6/10 层时 DoT 分别为 1/2/3 × dotPerStack

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5f22Yw5Bicimgt2Yn4f4C)_