### PR TITLE
feat(enemy-art): integrate V2 enemy art assets with manifest-driven resolver

### DIFF
--- a/assets/sprites/enemies/composites/enemy_bastion_heavyarmor_3x1_idle.json
+++ b/assets/sprites/enemies/composites/enemy_bastion_heavyarmor_3x1_idle.json
@@ -1,9 +1,17 @@
 {
-  "frameSize": 128,
-  "placeholder": true,
+  "frameSize": 1680,
+  "frameWidth": 1680,
+  "frameHeight": 720,
+  "placeholder": false,
   "single": true,
   "animations": {
-    "idle": { "row": 0, "frames": 1, "fps": 1 }
+    "idle": {
+      "row": 0,
+      "frames": 1,
+      "fps": 1,
+      "frameWidth": 1680,
+      "frameHeight": 720
+    }
   },
-  "_note": "Single-frame composite placeholder. Real artwork should follow the standard sprite-sheet manifest: idle row + optional hit/move/cast rows."
+  "_note": "Single-frame externally-generated artwork. To upgrade to a multi-frame sprite sheet, partition the PNG into rows/columns and add hit/move/cast entries with their own frameWidth/frameHeight."
 }

--- a/assets/sprites/enemies/composites/enemy_maw_devour_2x2_idle.json
+++ b/assets/sprites/enemies/composites/enemy_maw_devour_2x2_idle.json
@@ -1,9 +1,17 @@
 {
-  "frameSize": 128,
-  "placeholder": true,
+  "frameSize": 1248,
+  "frameWidth": 1248,
+  "frameHeight": 1248,
+  "placeholder": false,
   "single": true,
   "animations": {
-    "idle": { "row": 0, "frames": 1, "fps": 1 }
+    "idle": {
+      "row": 0,
+      "frames": 1,
+      "fps": 1,
+      "frameWidth": 1248,
+      "frameHeight": 1248
+    }
   },
-  "_note": "Single-frame composite placeholder. Real artwork should follow the standard sprite-sheet manifest: idle row + optional hit/move/cast rows."
+  "_note": "Single-frame externally-generated artwork. To upgrade to a multi-frame sprite sheet, partition the PNG into rows/columns and add hit/move/cast entries with their own frameWidth/frameHeight."
 }

--- a/assets/sprites/enemies/composites/enemy_residue_1x1_idle.json
+++ b/assets/sprites/enemies/composites/enemy_residue_1x1_idle.json
@@ -1,9 +1,17 @@
 {
-  "frameSize": 128,
-  "placeholder": true,
+  "frameSize": 1248,
+  "frameWidth": 1248,
+  "frameHeight": 1248,
+  "placeholder": false,
   "single": true,
   "animations": {
-    "idle": { "row": 0, "frames": 1, "fps": 1 }
+    "idle": {
+      "row": 0,
+      "frames": 1,
+      "fps": 1,
+      "frameWidth": 1248,
+      "frameHeight": 1248
+    }
   },
-  "_note": "Single-frame composite placeholder. Real artwork should follow the standard sprite-sheet manifest: idle row + optional hit/move/cast rows."
+  "_note": "Single-frame externally-generated artwork. To upgrade to a multi-frame sprite sheet, partition the PNG into rows/columns and add hit/move/cast entries with their own frameWidth/frameHeight."
 }

--- a/assets/sprites/enemies/composites/enemy_siege_siege_3x2_idle.json
+++ b/assets/sprites/enemies/composites/enemy_siege_siege_3x2_idle.json
@@ -1,9 +1,17 @@
 {
-  "frameSize": 128,
-  "placeholder": true,
+  "frameSize": 1536,
+  "frameWidth": 1536,
+  "frameHeight": 1024,
+  "placeholder": false,
   "single": true,
   "animations": {
-    "idle": { "row": 0, "frames": 1, "fps": 1 }
+    "idle": {
+      "row": 0,
+      "frames": 1,
+      "fps": 1,
+      "frameWidth": 1536,
+      "frameHeight": 1024
+    }
   },
-  "_note": "Single-frame composite placeholder. Real artwork should follow the standard sprite-sheet manifest: idle row + optional hit/move/cast rows."
+  "_note": "Single-frame externally-generated artwork. To upgrade to a multi-frame sprite sheet, partition the PNG into rows/columns and add hit/move/cast entries with their own frameWidth/frameHeight."
 }

--- a/assets/sprites/enemies/composites/enemy_spire_echorelay_1x2_idle.json
+++ b/assets/sprites/enemies/composites/enemy_spire_echorelay_1x2_idle.json
@@ -1,9 +1,17 @@
 {
-  "frameSize": 128,
-  "placeholder": true,
+  "frameSize": 1536,
+  "frameWidth": 864,
+  "frameHeight": 1536,
+  "placeholder": false,
   "single": true,
   "animations": {
-    "idle": { "row": 0, "frames": 1, "fps": 1 }
+    "idle": {
+      "row": 0,
+      "frames": 1,
+      "fps": 1,
+      "frameWidth": 864,
+      "frameHeight": 1536
+    }
   },
-  "_note": "Single-frame composite placeholder. Real artwork should follow the standard sprite-sheet manifest: idle row + optional hit/move/cast rows."
+  "_note": "Single-frame externally-generated artwork. To upgrade to a multi-frame sprite sheet, partition the PNG into rows/columns and add hit/move/cast entries with their own frameWidth/frameHeight."
 }

--- a/assets/sprites/enemies/composites/enemy_ward_deflection_2x1_idle.json
+++ b/assets/sprites/enemies/composites/enemy_ward_deflection_2x1_idle.json
@@ -1,9 +1,17 @@
 {
-  "frameSize": 128,
-  "placeholder": true,
+  "frameSize": 2560,
+  "frameWidth": 2560,
+  "frameHeight": 1440,
+  "placeholder": false,
   "single": true,
   "animations": {
-    "idle": { "row": 0, "frames": 1, "fps": 1 }
+    "idle": {
+      "row": 0,
+      "frames": 1,
+      "fps": 1,
+      "frameWidth": 2560,
+      "frameHeight": 1440
+    }
   },
-  "_note": "Single-frame composite placeholder. Real artwork should follow the standard sprite-sheet manifest: idle row + optional hit/move/cast rows."
+  "_note": "Single-frame externally-generated artwork. To upgrade to a multi-frame sprite sheet, partition the PNG into rows/columns and add hit/move/cast entries with their own frameWidth/frameHeight."
 }

--- a/assets/sprites/enemies/enemy_sprite_manifest.json
+++ b/assets/sprites/enemies/enemy_sprite_manifest.json
@@ -91,7 +91,7 @@
       "baseArchetype": "residue",
       "footprint": "1x1",
       "affixes": [],
-      "placeholder": true
+      "placeholder": false
     },
     "bastion:3x1:heavyArmor": {
       "resourceId": "enemy_bastion_heavyarmor_3x1",
@@ -99,8 +99,10 @@
       "manifestPath": "assets/sprites/enemies/composites/enemy_bastion_heavyarmor_3x1_idle.json",
       "baseArchetype": "bastion",
       "footprint": "3x1",
-      "affixes": ["heavyArmor"],
-      "placeholder": true
+      "affixes": [
+        "heavyArmor"
+      ],
+      "placeholder": false
     },
     "maw:2x2:devour": {
       "resourceId": "enemy_maw_devour_2x2",
@@ -108,8 +110,10 @@
       "manifestPath": "assets/sprites/enemies/composites/enemy_maw_devour_2x2_idle.json",
       "baseArchetype": "maw",
       "footprint": "2x2",
-      "affixes": ["devour"],
-      "placeholder": true
+      "affixes": [
+        "devour"
+      ],
+      "placeholder": false
     },
     "siege:3x2:siege": {
       "resourceId": "enemy_siege_siege_3x2",
@@ -117,8 +121,10 @@
       "manifestPath": "assets/sprites/enemies/composites/enemy_siege_siege_3x2_idle.json",
       "baseArchetype": "siege",
       "footprint": "3x2",
-      "affixes": ["siege"],
-      "placeholder": true
+      "affixes": [
+        "siege"
+      ],
+      "placeholder": false
     },
     "echoSpire:1x2:echoRelay": {
       "resourceId": "enemy_spire_echorelay_1x2",
@@ -126,8 +132,10 @@
       "manifestPath": "assets/sprites/enemies/composites/enemy_spire_echorelay_1x2_idle.json",
       "baseArchetype": "echoSpire",
       "footprint": "1x2",
-      "affixes": ["echoRelay"],
-      "placeholder": true
+      "affixes": [
+        "echoRelay"
+      ],
+      "placeholder": false
     },
     "deflector:2x1:deflectionWard": {
       "resourceId": "enemy_ward_deflection_2x1",
@@ -135,8 +143,10 @@
       "manifestPath": "assets/sprites/enemies/composites/enemy_ward_deflection_2x1_idle.json",
       "baseArchetype": "deflector",
       "footprint": "2x1",
-      "affixes": ["deflectionWard"],
-      "placeholder": true
+      "affixes": [
+        "deflectionWard"
+      ],
+      "placeholder": false
     }
   }
 }

--- a/src/render/sprite_renderer.js
+++ b/src/render/sprite_renderer.js
@@ -190,9 +190,13 @@ export class SpriteRenderer {
         const anim = this._meta.animations[this._currentAnim];
         if (!anim) return false;
 
+        // 支持矩形帧：优先使用 manifest 顶层 frameWidth/frameHeight，
+        // 其次使用 anim.frameWidth/frameHeight，最后回退到正方形 frameSize（默认 128）。
         const fs = this._meta.frameSize || 128;
-        const srcX = this._frameIndex * fs;
-        const srcY = anim.row * fs;
+        const fw = anim.frameWidth  || this._meta.frameWidth  || fs;
+        const fh = anim.frameHeight || this._meta.frameHeight || fs;
+        const srcX = this._frameIndex * fw;
+        const srcY = anim.row * fh;
 
         const prevAlpha = ctx.globalAlpha;
         ctx.globalAlpha = prevAlpha * alpha;
@@ -200,7 +204,7 @@ export class SpriteRenderer {
         try {
             ctx.drawImage(
                 this._image,
-                srcX, srcY, fs, fs,   // 源矩形（Sprite Sheet 上的帧）
+                srcX, srcY, fw, fh,   // 源矩形（Sprite Sheet 上的帧）
                 x,    y,   w,  h      // 目标矩形（Canvas 上的绘制区域）
             );
         } catch (e) {
@@ -308,7 +312,9 @@ export function createSpriteRenderer(enemyTypeOrEnemy, bossType, baseArchetype) 
     }
 
     // 0) 资源协议解析（baseArchetype + footprint + affixSet → composite 资源）
-    if (enemyInfo.baseArchetype || (enemyInfo.gridCols > 1 || enemyInfo.gridRows > 1)) {
+    // 对所有非 Boss 敌人（含 1×1 residue）都走 manifest 解析，命中再使用，
+    // 未命中再回到下面的 V2 metadata / golem 兜底。
+    if (enemyInfo.type !== 'boss') {
         const resolved = resolveEnemyVisualAsset(enemyInfo);
         if (resolved && resolved.spritePath && (resolved.fallbackLevel === 'composite' || resolved.fallbackLevel === 'archetype')) {
             return new SpriteRenderer(resolved.spritePath, resolved.manifestPath || undefined);


### PR DESCRIPTION
## Summary

- Add canonical enemy art directories (`archetypes/`, `composites/`, `overlays/`, UI icon dirs) with V2 placeholder and real composite art assets
- Implement `resolveEnemyVisualAsset(enemy)` in `src/data/enemy_visual_assets.js` as single source of truth for runtime asset resolution keyed by `<baseArchetype>:<cols>x<rows>:<sortedAffixSet>`
- Wire `SpriteRenderer`, `Enemy.initSprite`, and training ground UI to share the same manifest keys — no duplicate hardcoded paths
- Fix composite PNG rendering: extend `SpriteRenderer.draw()` to read `frameWidth`/`frameHeight` from per-animation or top-level manifest fields, so full-resolution single-frame composites (e.g. 1680×720 bastion) render correctly instead of sampling only the top-left 128×128 corner
- Training ground `enemy_v2` tab displays colored hit-status badges: **Composite Sprite** (green) / **Sprite** (blue) / **Vector fallback** (yellow) / **Missing asset** (red)
- Fallback chain: composite → archetype → V2 metadata → golem_elite/golem_normal → vector draw; never throws, never blanks

## Composite assets covered

| Key | Dimensions |
|-----|-----------|
| `residue:1x1:` | 1248×1248 |
| `bastion:3x1:heavyArmor` | 1680×720 |
| `maw:2x2:devour` | 1248×1248 |
| `siege:3x2:siege` | 1536×1024 |
| `echoSpire:1x2:echoRelay` | 864×1536 |
| `deflector:2x1:deflectionWard` | 2560×1440 |

## Test plan

- [ ] Hard-refresh training ground → `enemy_v2` → 验收 tab; all 6 composite scenarios show green **Composite Sprite** badge
- [ ] Archetype-only scenarios show blue **Sprite** badge
- [ ] Enemies with unknown archetype fall back to vector without errors in console
- [ ] `node --check src/data/enemy_visual_assets.js src/render/sprite_renderer.js` passes
- [ ] No changes to combat balance, spawn probabilities, or save structure

https://claude.ai/code/session_018BJBfniLvSHEMqjCWgNgQf

---
_Generated by [Claude Code](https://claude.ai/code/session_018BJBfniLvSHEMqjCWgNgQf)_