### PR TITLE
ui: real-time damage stats panel with live DPS

### DIFF
--- a/src/combat/damage_calc.js
+++ b/src/combat/damage_calc.js
@@ -122,7 +122,25 @@ export const DamageCalc = {
             }
             shotStats.byAttr[attrType][sourceType] += amount;
         }
+        // --- 3. 滑窗 DPS 采样：记录命中时间戳，剔除过期样本，重算 DPS ---
+        const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+        const windowMs = this._dpsWindowMs || 3000;
+        if (!this._damageRecentSamples) this._damageRecentSamples = [];
+        this._damageRecentSamples.push({ t: now, amount });
+        const cutoff = now - windowMs;
+        // 由于 push 是单调递增 t，可以用 shift 高效剔除
+        while (this._damageRecentSamples.length > 0 && this._damageRecentSamples[0].t < cutoff) {
+            this._damageRecentSamples.shift();
+        }
+        let windowSum = 0;
+        for (let i = 0; i < this._damageRecentSamples.length; i++) windowSum += this._damageRecentSamples[i].amount;
+        this._dps = windowSum / (windowMs / 1000);
+
         this.ui_updateRoundDamage();
+        // 实时刷新伤害统计面板（rAF 节流，仅在面板可见且查看当前回合时实际重建 DOM）
+        if (typeof this.ui_scheduleDamageStatsRefresh === 'function') {
+            this.ui_scheduleDamageStatsRefresh();
+        }
     },
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/core.js
+++ b/src/core.js
@@ -230,8 +230,13 @@ class Game {
         this.shotDamageHistory = []; 
         this.shotIdCounter = 0; 
         this.shotDamageMap = new Map(); 
-        this.roundDamageHistory = []; 
-        this.currentViewingRound = 0; 
+        this.roundDamageHistory = [];
+        this.currentViewingRound = 0;
+        // 实时伤害统计：滑窗 DPS + rAF 节流刷新
+        this._damageRecentSamples = []; // [{t, amount}] 用于计算最近窗口 DPS
+        this._dps = 0;                  // 当前瞬时 DPS（基于 _dpsWindowMs 滑窗）
+        this._dpsWindowMs = 3000;       // DPS 滑窗大小（毫秒）
+        this._damageStatsRafScheduled = false; // rAF 节流标志，避免每帧多次重建
         this.isEnemyTurn = false;      
         this.enemyTurnTimer = 0;       
         this.enemyWaveY = 0;       

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -43,6 +43,9 @@ export const game_phase = {
         // 回合计数的唯一执行位置保留在 phase_finalizeRound 中
         this.prevRoundDamage = this.roundDamage; // 记录上一回合伤害
         this.roundDamage = 0; // 重置本回合伤害
+        // 重置实时 DPS 滑窗
+        this._damageRecentSamples = [];
+        this._dps = 0;
         // 事件总线广播波次推进（[BUGFIX #5b] 保留：不在此处更新 DOM，由 UI 监听 wave:advance 事件处理）
         eventBus.emit(EVENT_TYPES.WAVE_ADVANCED, { round: this.round });
     },

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -83,6 +83,10 @@ export const hud_system = {
             }
             // 更新显示
             this.ui_updateRoundDamage();
+            // 子弹完成 → 主动刷新一次实时面板（rAF 节流）
+            if (typeof this.ui_scheduleDamageStatsRefresh === 'function') {
+                this.ui_scheduleDamageStatsRefresh();
+            }
         }
     },
 
@@ -95,15 +99,26 @@ export const hud_system = {
         const el = document.getElementById('round-damage-val');
         const container = document.getElementById('round-damage-display');
         if (!el || !container) return;
-        
+
         // 使用本回合实时累计伤害 (roundDamage)
         const targetValue = Math.floor(this.roundDamage);  // [Mixin 正常用法：读取 Game 实例状态]
-        const currentValue = parseInt(el.innerText.replace(/,/g, '')) || 0;
-        
+        const currentValue = parseInt((el.innerText || '0').replace(/,/g, '')) || 0;
+
+        // 实时 DPS 副标签：单独的 #round-damage-dps 元素，在主数字旁显示
+        let dpsEl = document.getElementById('round-damage-dps');
+        if (!dpsEl) {
+            dpsEl = document.createElement('span');
+            dpsEl.id = 'round-damage-dps';
+            dpsEl.className = 'ml-2 text-xs font-bold text-amber-300';
+            el.parentNode && el.parentNode.appendChild(dpsEl);
+        }
+        const dps = Math.floor(this._dps || 0);
+        dpsEl.innerText = dps > 0 ? `(${dps.toLocaleString()} DPS)` : '';
+
         if (targetValue > 0) {
             container.classList.remove('opacity-0');
             container.classList.add('opacity-100');
-            
+
             // 如果差值较小，直接更新，避免频繁启动定时器
             if (Math.abs(targetValue - currentValue) < 5) {
                 el.innerText = targetValue.toLocaleString();
@@ -112,17 +127,17 @@ export const hud_system = {
 
             // 滚动数字效果
             if (this._damageScrollInterval) clearInterval(this._damageScrollInterval);
-            
-            const duration = 300; 
+
+            const duration = 300;
             const steps = 10;
             const stepValue = (targetValue - currentValue) / steps;
             let currentStep = 0;
-            
+
             this._damageScrollInterval = setInterval(() => {
                 currentStep++;
                 const newValue = Math.floor(currentValue + stepValue * currentStep);
                 el.innerText = newValue.toLocaleString();
-                
+
                 if (currentStep >= steps) {
                     el.innerText = targetValue.toLocaleString();
                     clearInterval(this._damageScrollInterval);
@@ -132,6 +147,36 @@ export const hud_system = {
             container.classList.add('opacity-0');
             container.classList.remove('opacity-100');
             el.innerText = '0';
+        }
+    },
+
+    /**
+     * @method ui_scheduleDamageStatsRefresh
+     * @description 实时伤害统计面板刷新 —— rAF 节流。
+     *   每次 combat_recordDamage 调用都会请求刷新，但实际重建 DOM 的频率最高 60fps，
+     *   且仅在「伤害面板可见 + 正在查看当前回合」时执行，避免无意义工作。
+     */
+    ui_scheduleDamageStatsRefresh() {
+        if (this._damageStatsRafScheduled) return;
+        // 仅当查看当前回合（实时数据）时才需要刷新
+        if (this.currentViewingRound !== 0) return;
+        // 仅当伤害 tab 实际可见时才刷新
+        const tabEl = document.getElementById('tab-damage');
+        if (!tabEl || tabEl.classList.contains('hidden')) return;
+
+        this._damageStatsRafScheduled = true;
+        const run = () => {
+            this._damageStatsRafScheduled = false;
+            // 再次确认仍处于实时查看模式，且面板仍可见（rAF 异步期间状态可能已变）
+            if (this.currentViewingRound !== 0) return;
+            const t = document.getElementById('tab-damage');
+            if (!t || t.classList.contains('hidden')) return;
+            this.ui_updateDamageStats();
+        };
+        if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(run);
+        } else {
+            setTimeout(run, 16);
         }
     },
 
@@ -174,8 +219,23 @@ export const hud_system = {
         prevBtn.addEventListener('click', () => this.ui_switchDamageRound(1));
 
         const roundLabel = document.createElement('span');
-        roundLabel.className = 'text-xs font-bold text-amber-400 font-[Cinzel]';
-        roundLabel.textContent = `Round ${roundNumber}`;
+        roundLabel.className = 'text-xs font-bold text-amber-400 font-[Cinzel] flex items-center gap-2';
+        const isLive = this.currentViewingRound === 0;
+        if (isLive) {
+            const dot = document.createElement('span');
+            dot.className = 'inline-block w-2 h-2 rounded-full bg-red-500 animate-pulse';
+            dot.title = '实时';
+            roundLabel.appendChild(dot);
+            const liveText = document.createElement('span');
+            liveText.textContent = `Round ${roundNumber} · LIVE`;
+            roundLabel.appendChild(liveText);
+            const dpsBadge = document.createElement('span');
+            dpsBadge.className = 'text-[10px] font-normal text-amber-200 bg-slate-900/60 px-1.5 py-0.5 rounded';
+            dpsBadge.textContent = `${Math.floor(this._dps || 0).toLocaleString()} DPS`;
+            roundLabel.appendChild(dpsBadge);
+        } else {
+            roundLabel.textContent = `Round ${roundNumber}`;
+        }
 
         const nextBtn = document.createElement('button');
         nextBtn.className = 'text-slate-400 hover:text-white px-3 py-1';


### PR DESCRIPTION
## Summary
- 伤害统计面板从「回合结束/手动打开」改为**战斗中实时刷新**:`combat_recordDamage` 调用经 rAF 节流去重,最多每帧重建一次 DOM,并且仅当面板可见且查看当前回合时才执行,不浪费空转。
- 新增**滑窗 DPS**(默认 3s 窗口),在主伤害数字旁显示 `(N DPS)`,并在面板顶部加一个红色脉冲点 + `LIVE` + DPS 徽章,与历史回合视图区分。
- 切换到历史回合(`currentViewingRound !== 0`)时**自动停止**实时刷新,避免覆盖用户正在查看的快照。
- 回合推进时重置 DPS 采样,防止跨回合数据污染。

### 改动文件
- `src/core.js` — 新增 `_damageRecentSamples` / `_dps` / `_dpsWindowMs` / `_damageStatsRafScheduled`
- `src/combat/damage_calc.js` — `combat_recordDamage` 内采样并触发节流刷新
- `src/ui/hud.js` — 新增 `ui_scheduleDamageStatsRefresh()`;`ui_updateRoundDamage` 显示 DPS;`ui_updateDamageStats` 头部增加 LIVE 指示
- `src/game_phase.js` — `phase_advanceWave` 重置 DPS 滑窗

## Test plan
- [ ] 战斗中打开「伤害统计」tab,确认柱状图随每次命中实时增长(无明显卡顿)
- [ ] 主屏幕的 `Round Damage` 数字旁出现 `(N DPS)`,数值随战斗强度起伏,空闲 3s 后归零
- [ ] 面板头部出现红色脉冲点 + `LIVE` + DPS 徽章
- [ ] 切到历史回合(◀/▶)后实时刷新停止,数据不被覆盖;切回当前回合后恢复实时刷新
- [ ] 关闭/未打开伤害 tab 时,战斗高频命中(连锁闪电、散射)无额外性能开销
- [ ] 新回合开始 DPS 归零,旧采样不残留

https://claude.ai/code/session_01Dk1eTdBKKR4sXLEYaPyrkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk1eTdBKKR4sXLEYaPyrkU)_