### PR TITLE
feat: 钉板模块化 + 符文融合 + 局内商店三大养成系统

### DIFF
--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -2475,53 +2475,16 @@ export const combat_system = {
         const finalRecipe = pullNext();
         if (!finalRecipe) return;
 
-        // --- [符文词条系统] 将 activeRunewordStats 加成叠加到当前弹药配方 ---
-        if (this.activeRunewordStats && typeof this.activeRunewordStats === 'object') {
-            for (const [key, val] of Object.entries(this.activeRunewordStats)) {
-                if (typeof val === 'number' && val !== 0) {
-                    if (key === 'damage') {
-                        // damage 直接加到基础伤害
-                        finalRecipe.damage = (finalRecipe.damage || 0) + val;
-                    } else if (key === 'bounce') {
-                        finalRecipe.bounce = (finalRecipe.bounce || 0) + val;
-                    } else if (key === 'pierce') {
-                        finalRecipe.pierce = (finalRecipe.pierce || 0) + val;
-                    } else if (key === 'scatter') {
-                        finalRecipe.scatter = (finalRecipe.scatter || 0) + val;
-                    } else if (key === 'pyro') {
-                        finalRecipe.pyro = (finalRecipe.pyro || 0) + val;
-                    } else if (key === 'cryo') {
-                        finalRecipe.cryo = (finalRecipe.cryo || 0) + val;
-                    } else if (key === 'lightning') {
-                        finalRecipe.lightning = (finalRecipe.lightning || 0) + val;
-                    } else if (key === 'laser') {
-                        finalRecipe.laser = (finalRecipe.laser || 0) + val;
-                        if (finalRecipe.laser > 0) finalRecipe.isLaser = true;
-                    } else {
-                        // 其他数値属性通用叠加
-                        if (typeof finalRecipe[key] === 'number' || finalRecipe[key] === undefined) {
-                            finalRecipe[key] = (finalRecipe[key] || 0) + val;
-                        }
-                    }
-                }
-            }
-        }
-        
-        // --- [符文基础属性] 将 calcRuneBaseStats() 的基础属性层数叠加到当前弹药配方 ---
-        if (this.runeGrid && Array.isArray(this.runeGrid)) {
-            const baseStats = calcRuneBaseStats(this.runeGrid, RUNE_DB);
-            for (const [key, val] of Object.entries(baseStats)) {
-                if (typeof val === 'number' && val > 0) {
-                    if (key === 'laser') {
-                        finalRecipe.laser = (finalRecipe.laser || 0) + val;
-                        if (finalRecipe.laser > 0) finalRecipe.isLaser = true;
-                    } else {
-                        finalRecipe[key] = (finalRecipe[key] || 0) + val;
-                    }
-                // @section:fire_trajectory_calc - 弹道计算与散射角度
-                }
-            }
-        }
+        // ==================== [v2 重构] 符文属性附加路径已移除 ====================
+        // 旧版本：activeRunewordStats 和 calcRuneBaseStats 会把 pyro/cryo/bounce/...
+        // 直接叠加到 finalRecipe，使得"装备符文 = 子弹被动加属性"。
+        // v2 改为"符文融合钉板"机制：玩家在模块编辑器消耗符文，把对应元素
+        // 注入到钉板上的随机普通钉子，弹珠在采集阶段碰到该钉子才获得元素。
+        // 入口：rune_system.fuseRuneIntoBoard / phase_gathering_initPachinko 末尾。
+        //
+        // 保留 runeword 的非属性效果（mutation unlock / skill unlock）：这些走
+        // activeRunewordEffects，不在此处理。
+        // @section:fire_trajectory_calc - 弹道计算与散射角度
 
         // --- [炼金火药管] 平坦伤害加成 ---
         if (this.flatDamageBonus && this.flatDamageBonus > 0) {

--- a/src/config.js
+++ b/src/config.js
@@ -747,6 +747,24 @@ const CONFIG = {
         relicChance: 0.1,
         initTriggerThreshold: 15,
         nextTriggerThresholdIncrease: 8,
+        // ==================== [v2 钉板模块化] 模块网格 ====================
+        moduleCols: 4,                 // 模块网格列数
+        moduleRows: 3,                 // 模块网格行数（共 12 槽）
+        moduleDefaultSlots: 3,         // 默认开放的模块槽位数（顶部第 1 行）
+        moduleAreaTopY: 60,            // 模块区域起始 Y 坐标（画布顶部留白）
+        moduleAreaBottomMargin: 80,    // 模块区域底部留白
+        moduleSpacingX: 4,             // 模块横向间距 px
+        moduleSpacingY: 4,             // 模块纵向间距 px
+        // ==================== [v2 局内商店 + 符文碎片经济] ====================
+        runShopInterval: 2,            // 每 N 场战斗弹出一次局内商店
+        runShopRefreshCost: 10,        // 刷新一次商店消耗碎片
+        runShopItemsPerOffer: 5,       // 每次刷新提供的商品数
+        runShopRunesRatio: 0.6,        // 商品中符文占比
+        runShopEndOfRunFragmentSettle: 0.3, // 局结束时未消费碎片转换为 saveData 的比例
+        enemyDropFragmentChance: 0.45, // 敌人击杀后掉落碎片基础概率
+        enemyDropFragmentBaseAmount: 1,
+        enemyDropFragmentRoundBonus: 0.1,
+        bossFragmentDrop: 8,
         maxSkillPoints: 3,  // 技能点上限
         spSlotsStartRow:3,
         spSlotsEndRow:8,
@@ -1253,6 +1271,8 @@ const CONFIG = {
 
 // ==================== 钉盘结构遗物互斥集合 ====================
 // 所有影响钉盘结构（行数、布局形态）的遗物 ID，单局内只能选择其中一个
+// [v2 模块化] 行数/布局遗物保留作为 boardLayout 兼容入口（映射为预设模块组合），
+// 不影响新增的 module_slot_up / unlock_module_type 系列遗物（这些可叠加）。
 const BOARD_STRUCTURE_RELICS = new Set([
     'dimension_shard',       // 行数遗物：增加钉盘行数（1行）
     'dimension_crystal',     // 行数遗物：增加钉盘行数（2行）
@@ -1576,6 +1596,69 @@ const RELIC_DB = [
         desc: '【诅咒】子弹发射时，所有连射 (multicast) 层数清零并按每层 +(基础伤害 × 0.5) 折算为固定伤害。【收益】每次发射后有 75% 概率自动再发射一次（再发射不会再触发本效果）。',
         rarity: 'cursed',
         effect: 'greedy_wheel',
+        maxStacks: 1
+    },
+    // ==================== [v2 钉板模块化] 新增遗物 ====================
+    // 模块槽位扩张
+    {
+        id: 'module_slot_expander',
+        name: '模塊擴張器',
+        icon: '⊞',
+        desc: '釘板模塊槽位 +1。槽位按 row-major 順序解鎖（從第 1 行向下展開）。',
+        rarity: 'rare',
+        effect: 'module_slot_up',
+        amount: 1,
+        maxStacks: 9
+    },
+    {
+        id: 'module_row_unlock',
+        name: '模塊整行解鎖',
+        icon: '═',
+        desc: '釘板模塊槽位一次性 +4（解鎖一整行）。',
+        rarity: 'legendary',
+        effect: 'module_slot_up',
+        amount: 4,
+        maxStacks: 2
+    },
+    // 模块类型解锁
+    {
+        id: 'unlock_module_wheel',
+        name: '機械轉盤',
+        icon: '🎰',
+        desc: '解鎖 [轉盤模塊]：可放置在釘板上，弹珠落入後觸發屬性翻倍輪盤。',
+        rarity: 'rare',
+        effect: 'unlock_module_type',
+        moduleId: 'wheel_module',
+        maxStacks: 1
+    },
+    {
+        id: 'unlock_module_baffle',
+        name: '能量擋板',
+        icon: '⫽',
+        desc: '解鎖 [擋板模塊]：傾斜的高彈性平面，將弹珠導向特定方向。',
+        rarity: 'rare',
+        effect: 'unlock_module_type',
+        moduleId: 'baffle',
+        maxStacks: 1
+    },
+    {
+        id: 'unlock_module_fixed_slot',
+        name: '固定機關槽',
+        icon: '◈',
+        desc: '解鎖 [固定特殊槽模塊]：在固定位置生成回溯/連射/分裂槽。',
+        rarity: 'epic',
+        effect: 'unlock_module_type',
+        moduleId: 'fixed_slot',
+        maxStacks: 1
+    },
+    {
+        id: 'unlock_module_element_pair',
+        name: '冰火元素對',
+        icon: '❄🔥',
+        desc: '解鎖 [元素對模塊]：固定生成 1 顆冰霜釘 + 1 顆火焰釘，無需融合。',
+        rarity: 'rare',
+        effect: 'unlock_module_type',
+        moduleId: 'cryo_pyro_pair',
         maxStacks: 1
     },
 ];

--- a/src/core.js
+++ b/src/core.js
@@ -40,6 +40,7 @@ import { ui_system } from './ui_system.js';
 // [Task 2.4] 导入拆分后的 UI 子模块
 import { hud_system } from './ui/hud.js';
 import { shop_system } from './ui/shop.js';
+import { run_shop } from './ui/run_shop.js';
 import { rune_launcher_system } from './ui/rune_launcher.js';
 import { calc_utils } from './calc_utils.js';
 import { tutorial_system } from './tutorial_system.js';
@@ -99,7 +100,8 @@ class Game {
         const _subsystems = [
             game_system, game_phase, combat_system, render_system, spawn_system,
             ui_system, hud_system, shop_system, rune_launcher_system,
-            calc_utils, tutorial_system, game_over_mixin
+            calc_utils, tutorial_system, game_over_mixin,
+            run_shop
         ];
         for (const subsystem of _subsystems) {
             for (const [key, val] of Object.entries(subsystem)) {
@@ -249,12 +251,25 @@ class Game {
         this.slowMotionTimer = 0;        
         this.slowMotionThreshold = 100;  
         this.saveData = { currency: 0, runeFragments: 0, upgrades: {}, temporaryUpgrades: {}, unlockedItems: [], highScore: 0 };
-        this.runCurrency = 0;   
+        this.runCurrency = 0;
         // ==================== 本局统计字段 ====================
         this.runKillCount = 0;          // 本局击杀数
         this.runRuneFragmentsGained = 0; // 本局获得的符文碎片数
         this.bossDefeatedLog = [];       // 本局击败的 Boss 记录 [{bossId, bossName, round, isBigBoss}]
         this.runewordKillCount = 0;      // [词条 Hook] 嗜血初锋: 本局击杀累计数，跨回合持久
+
+        // ==================== [v2 钉板模块化] 模块系统状态 ====================
+        this.unlockedModuleTypes = ['std_stagger', 'dense_stagger', 'bouncer', 'funnel'];
+        this.unlockedModuleSlots = 3;
+        this.currentModuleLayout = ['std_stagger', 'std_stagger', 'std_stagger',
+            null, null, null, null, null, null, null, null, null];
+        this.pendingFusions = [];
+
+        // ==================== [v2 局内商店 + 符文碎片经济] ====================
+        this.runFragments = 0;
+        this.runShopInventory = [];
+        this.runShopRefreshes = 0;
+        this._runShopOpenedRound = -1;
 
         // ==================== 符文词条系统状态变量 ====================
         // Task 1: 数据结构升级 - runeInventory 和 runeGrid 存储对象格式 { id: string, level: number }

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -19,6 +19,7 @@ import {
     getLayoutParams,
     getAllLayoutHints,
 } from './plinko_physics.js';
+import { buildModuleEntities, calcModuleSlotRect, MODULE_DEFS } from './pinboard_modules.js';
 
 export const game_phase = {
 /**
@@ -95,6 +96,22 @@ export const game_phase = {
             });
         }
 
+        // ==================== [v2 钉板模块化] 进入采集前先打开模块编辑器 ====================
+        // 玩家可以在每场遗物结束后/采集开始前重新摆放模块、融合符文。
+        // 编辑器关闭后才真正进入采集阶段。混沌契约和教程局跳过编辑器。
+        const skipEditor = (this.ownedRelics && this.ownedRelics.includes('chaos_pact'))
+            || this._isTutorialRun
+            || this._moduleEditorShownThisRound;
+        if (!skipEditor && typeof this.ui_showModuleEditor === 'function') {
+            this._moduleEditorShownThisRound = true;
+            this.ui_showModuleEditor(() => {
+                this._moduleEditorShownThisRound = false;
+                this.phase_startGatheringPhase();
+            });
+            return;
+        }
+        this._moduleEditorShownThisRound = false;
+
         // --- [遗物 Hook] 混沌契约 (chaos_pact)：跳过研磨阶段，直接进入战斗 ---
         // 规则：契约持有者无法进行研磨；ammoQueue 复用上一回合的子弹快照，没有则用默认基础子弹兜底。
         if (this.ownedRelics && this.ownedRelics.includes('chaos_pact')) {
@@ -142,7 +159,192 @@ export const game_phase = {
 /**
      */
     // @section:pachinko_board_layout - 弹珠台布局计算与钉子生成
+    // [v2 模块化重写] 钉板由 4×3 = 12 个模块槽组成（CONFIG.gameplay.moduleCols/Rows）。
+    // 每个模块独立生成自己区域内的钉子/特殊槽。元素属性由"符文融合"在最末尾叠加。
+    phase_gathering_initPachinko_v2(shouldInherit = false) {
+        const cfg = CONFIG.gameplay;
+        const canvasWidth = (this.width && this.width > 0) ? this.width : 400;
+        const canvasHeight = (this.height && this.height > 0) ? this.height : 600;
+        const ctx = this.ctx || null;
+        const totalSlots = (cfg.moduleCols || 4) * (cfg.moduleRows || 3);
+
+        // 确保 currentModuleLayout 存在且正确长度
+        if (!Array.isArray(this.currentModuleLayout) || this.currentModuleLayout.length !== totalSlots) {
+            this.currentModuleLayout = new Array(totalSlots).fill(null);
+            const defaultSlots = cfg.moduleDefaultSlots || 3;
+            for (let i = 0; i < defaultSlots; i++) {
+                this.currentModuleLayout[i] = 'std_stagger';
+            }
+        }
+
+        const previousPegs = [...(this.pegs || [])];
+        this.pegs = [];
+        this.specialSlots = [];
+
+        let maxPegY = 0;
+        const slotsToBuild = Math.min(this.unlockedModuleSlots || cfg.moduleDefaultSlots || 3, totalSlots);
+
+        for (let i = 0; i < slotsToBuild; i++) {
+            const moduleId = this.currentModuleLayout[i];
+            if (!moduleId) continue;
+            const rect = calcModuleSlotRect(i, canvasWidth, canvasHeight, cfg);
+            const result = buildModuleEntities(moduleId, rect.x, rect.y, rect.w, rect.h, ctx, i);
+            if (result.pegs && result.pegs.length > 0) {
+                for (const p of result.pegs) {
+                    p.moduleSlotIdx = i;
+                    this.pegs.push(p);
+                    if (p.pos.y > maxPegY) maxPegY = p.pos.y;
+                }
+            }
+            if (result.specialSlots && result.specialSlots.length > 0) {
+                for (const s of result.specialSlots) {
+                    s.moduleSlotIdx = i;
+                    this.specialSlots.push(s);
+                }
+            }
+        }
+
+        this.boardBottomY = maxPegY;
+
+        // [继承] 上一回合钉子按索引保留 type/level（仅当数量一致且非粉色）
+        if (shouldInherit && previousPegs.length > 0) {
+            for (let i = 0; i < this.pegs.length && i < previousPegs.length; i++) {
+                const cur = this.pegs[i];
+                const prev = previousPegs[i];
+                if (prev && prev.type !== 'pink' && cur.type === 'normal') {
+                    cur.type = prev.type;
+                    cur.level = prev.level || 1;
+                    if (prev.cooldownTimer !== undefined) cur.cooldownTimer = prev.cooldownTimer;
+                }
+            }
+        }
+
+        // [pink_slime 遗物] 额外随机粉色钉子
+        const pinkCount = this.pinkPegCount || 0;
+        for (let i = 0; i < pinkCount; i++) {
+            if (this.pegs.length > 0) {
+                const idx = Math.floor(Math.random() * this.pegs.length);
+                this.pegs[idx].type = 'pink';
+            }
+        }
+
+        // [unlock_slot 遗物 + slot_count_up] 在模块外额外创建特殊槽
+        let effectiveSlots = [...(this.unlockedSlots || [])];
+        if (!this.activeSkills || this.activeSkills.length === 0) {
+            effectiveSlots = effectiveSlots.filter(t => t !== 'skill_point');
+        }
+        const effectiveSlotCount = Math.min(this.slotCount || 0, effectiveSlots.length > 0 ? this.slotCount : 0);
+        if (effectiveSlots.length > 0 && effectiveSlotCount > 0) {
+            const validIdx = this.pegs.map((p, i) => i).filter(i => this.pegs[i].type !== 'pink');
+            const sortedByY = [...validIdx].sort((a, b) => this.pegs[b].pos.y - this.pegs[a].pos.y);
+            const used = new Set();
+            // 也排除已被模块产生的 specialSlots 占用的钉子
+            for (const s of this.specialSlots) {
+                if (s.pegIndex !== undefined) used.add(s.pegIndex);
+                if (s.pegIndex2 !== undefined) used.add(s.pegIndex2);
+            }
+            let created = 0;
+            for (let i = 0; i < sortedByY.length && created < effectiveSlotCount; i++) {
+                const idxA = sortedByY[i];
+                if (used.has(idxA)) continue;
+                let bestIdxB = -1;
+                let bestDist = Infinity;
+                for (let j = i + 1; j < sortedByY.length; j++) {
+                    const idxB = sortedByY[j];
+                    if (used.has(idxB)) continue;
+                    const dx = this.pegs[idxA].pos.x - this.pegs[idxB].pos.x;
+                    const dy = this.pegs[idxA].pos.y - this.pegs[idxB].pos.y;
+                    const d = Math.sqrt(dx * dx + dy * dy);
+                    if (d < bestDist && d < 80) { bestDist = d; bestIdxB = idxB; }
+                }
+                if (bestIdxB === -1) continue;
+                const pegA = this.pegs[idxA];
+                const pegB = this.pegs[bestIdxB];
+                const type = effectiveSlots[created % effectiveSlots.length];
+                const slot = new SpecialSlot(pegA.pos.x, pegA.pos.y, pegB.pos.x, pegB.pos.y, type);
+                slot.pegIndex = idxA;
+                slot.pegIndex2 = bestIdxB;
+                this.specialSlots.push(slot);
+                used.add(idxA); used.add(bestIdxB);
+                created++;
+            }
+        }
+
+        // [初始 wind/sword 钉子] 仅第 1 回合且非继承时
+        if (this.round === 1 && !shouldInherit) {
+            const replaceWithSpecial = (count, type) => {
+                if (!count || count <= 0) return;
+                const normalPegs = this.pegs.filter(p => p.type === 'normal');
+                for (let i = normalPegs.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    [normalPegs[i], normalPegs[j]] = [normalPegs[j], normalPegs[i]];
+                }
+                for (let i = 0; i < Math.min(count, normalPegs.length); i++) {
+                    normalPegs[i].type = type;
+                    normalPegs[i].level = 1;
+                }
+            };
+            const windPegsCount = this._isTutorialRun && this._tutorialInitWindPegs
+                ? this._tutorialInitWindPegs : (cfg.initWindPegs || 0);
+            const swordPegsCount = this._isTutorialRun && this._tutorialInitSwordPegs
+                ? this._tutorialInitSwordPegs : (cfg.initSwordPegs || 0);
+            replaceWithSpecial(windPegsCount, 'wind');
+            replaceWithSpecial(swordPegsCount, 'flying_sword');
+            if (this._isTutorialRun) {
+                this.pegs.forEach(p => {
+                    if (p.type === 'wind' || p.type === 'flying_sword') p.level = 3;
+                });
+            }
+        }
+
+        // ==================== [v2 符文融合] 应用 pendingFusions ====================
+        // 将玩家在模块编辑器选择的符文随机注入到普通钉子上
+        if (Array.isArray(this.pendingFusions) && this.pendingFusions.length > 0) {
+            for (const f of this.pendingFusions) {
+                if (!f || !f.element || !f.count) continue;
+                const blanks = this.pegs.filter(p => p.type === 'normal');
+                const targetCount = Math.min(f.count, blanks.length);
+                for (let i = blanks.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    [blanks[i], blanks[j]] = [blanks[j], blanks[i]];
+                }
+                for (let i = 0; i < targetCount; i++) {
+                    blanks[i].type = f.element;
+                    blanks[i].level = 1;
+                }
+            }
+            this.pendingFusions = [];
+        }
+
+        // [兼容] boardLayout='triangle' 仍然在底部生成两个倍率转盘
+        this.ghostPegs = [];
+        this.triangleSideWheels = [];
+        if ((this.boardLayout || 'default') === 'triangle') {
+            const wheelY = maxPegY + 40;
+            const wheelXLeft = canvasWidth * 0.15;
+            const wheelXRight = canvasWidth * 0.85;
+            this.triangleSideWheels = [
+                new TriangleSideWheel(wheelXLeft, wheelY, 'left', this),
+                new TriangleSideWheel(wheelXRight, wheelY, 'right', this),
+            ];
+        }
+
+        this.currentLayout = this.boardLayout || 'default';
+        this._dropDistribution = null;
+        this._heatmapData = null;
+        this.ui_updateGatheringQueueUI();
+        this.ui_renderRecipeHUD();
+        console.log(`[Plinko v2] 模块化钉板初始化完成: ${this.pegs.length} 钉, ${this.specialSlots.length} 特殊槽, ${slotsToBuild}/${totalSlots} 槽位`);
+    },
+
+    // ==================== [兼容包装] ====================
+    // 调用 v2 模块化实现；旧的 phase_gathering_initPachinko_legacy 保留作参考
     phase_gathering_initPachinko(shouldInherit = false) {
+        return this.phase_gathering_initPachinko_v2(shouldInherit);
+    },
+
+    // [legacy] 旧的 10×5 平铺钉板生成器，保留作参考但不再被默认调用
+    phase_gathering_initPachinko_legacy(shouldInherit = false) {
         // [修复] 使用动态行数
         const rows = this.currentRows || CONFIG.gameplay.rows;
         const baseCols = CONFIG.gameplay.cols || 10;
@@ -1429,6 +1631,25 @@ phase_gathering_getRandomPegType() {
             // [局内存档] 每回合结算完毕后自动存档，防止刷新丢失进度
             // round-start resolver 会在存档恢复时继续处理 pendingRoundStartRewards。
             this.sys_saveRunState();
+
+            // ==================== [v2 局内商店] 每 N 场战斗弹出一次 ====================
+            const cfg = CONFIG.gameplay || {};
+            const interval = cfg.runShopInterval || 2;
+            const curRound = this.round || 1;
+            const shouldOpenShop = (curRound > 0)
+                && (curRound % interval === 0)
+                && (this._runShopOpenedRound !== curRound)
+                && (typeof this.ui_showRunShop === 'function')
+                && !this._isTutorialRun
+                && !(this.ownedRelics && this.ownedRelics.includes('chaos_pact'));
+            if (shouldOpenShop) {
+                this._runShopOpenedRound = curRound;
+                this.ui_showRunShop(() => {
+                    this.sys_startRoundStartResolver();
+                });
+                return;
+            }
+
             this.sys_startRoundStartResolver();
         }
     },

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -428,6 +428,23 @@ export const game_system = {
         this.bossDefeatedLog = [];
         // [词条 Hook] 嗜血初锋 (bloodthirst_growth) - 每局重置击杀计数（跨回合持久）
         this.runewordKillCount = 0;
+
+        // ==================== [v2 钉板模块化] 模块系统状态 ====================
+        // 钉板由 4×3 = 12 个模块槽组成，按 row-major 顺序解锁
+        // 默认开放第 1 行 3 个槽，预填 std_stagger
+        this.unlockedModuleTypes = ['std_stagger', 'dense_stagger', 'bouncer', 'funnel'];
+        this.unlockedModuleSlots = 3;
+        this.currentModuleLayout = ['std_stagger', 'std_stagger', 'std_stagger',
+            null, null, null, null, null, null, null, null, null];
+        // pendingFusions: 模块编辑器关闭时写入；phase_gathering_initPachinko 末尾消费
+        // 形如 [{ element: 'pyro', count: 1, runeUid: '...' }]
+        this.pendingFusions = [];
+
+        // ==================== [v2 局内商店 + 符文碎片经济] ====================
+        this.runFragments = 0;          // 局内当前持有符文碎片
+        this.runShopInventory = [];     // 当前刷新结果
+        this.runShopRefreshes = 0;      // 已刷新次数
+        this._runShopOpenedRound = -1;  // 防止同回合重复打开
     },
 
     /**

--- a/src/pinboard_modules.js
+++ b/src/pinboard_modules.js
@@ -1,0 +1,279 @@
+/**
+ * pinboard_modules.js - 钉板模块化（v2 养成深化）
+ *
+ * 钉板由 4×3 = 12 个模块槽组成。每个模块在自己的矩形区域内独立生成
+ * 一组实体（普通钉子、特殊钉子、固定特殊槽等）。
+ *
+ * 主入口：buildModuleEntities(moduleId, originX, originY, w, h, ctx, slotIdx)
+ *   返回 { pegs: Peg[], specialSlots: SpecialSlot[] }
+ *
+ * 设计约束：
+ *   - 模块内部仍然走"交错"逻辑（用户已确认）
+ *   - 所有 peg 默认 type='normal'，元素属性由"符文融合"步骤后置赋予
+ *     （见 rune_system.fuseRuneIntoBoard / phase_gathering_initPachinko 的末尾步骤）
+ *   - 例外：cryo_pyro_pair 模块固定预置 1 cryo + 1 pyro
+ *
+ * MVP 实现说明：
+ *   - wheel_module 复用 SpecialSlot type='wheel'（已有的转盘触发机制）
+ *   - baffle 模块用一排粉色高弹性钉子模拟"挡板反弹"，复用 pink peg 物理
+ *   - fixed_slot 模块复用 SpecialSlot 类（multicast/recall/split 轮换）
+ */
+
+import { Peg, SpecialSlot } from './entities.js';
+
+/**
+ * 在指定矩形内按交错模式生成普通钉子。
+ */
+function generateStaggeredPegs(originX, originY, w, h, cols, rows, type = 'normal') {
+    const pegs = [];
+    if (cols < 1 || rows < 1) return pegs;
+    const spacingX = cols > 1 ? (w / cols) : w;
+    const spacingY = rows > 1 ? (h / (rows + 0.5)) : h;
+    for (let r = 0; r < rows; r++) {
+        const isOdd = r % 2 !== 0;
+        const colsThisRow = isOdd ? Math.max(1, cols - 1) : cols;
+        const baseLeftPad = (w - (colsThisRow - 1) * spacingX) / 2;
+        for (let c = 0; c < colsThisRow; c++) {
+            const x = originX + baseLeftPad + c * spacingX;
+            const y = originY + spacingY * 0.5 + r * spacingY;
+            const p = new Peg(x, y, type);
+            p.row = r;
+            p.col = c;
+            p.level = 1;
+            pegs.push(p);
+        }
+    }
+    return pegs;
+}
+
+/**
+ * 在矩形内按"漏斗"形态生成（顶宽底窄）。
+ */
+function generateFunnelPegs(originX, originY, w, h, topCols, rows) {
+    const pegs = [];
+    if (rows < 1) return pegs;
+    const spacingY = h / (rows + 0.5);
+    for (let r = 0; r < rows; r++) {
+        const colsThisRow = Math.max(1, topCols - r);
+        const spacingX = colsThisRow > 1 ? (w * 0.85) / colsThisRow : w * 0.85;
+        const baseLeftPad = (w - (colsThisRow - 1) * spacingX) / 2;
+        for (let c = 0; c < colsThisRow; c++) {
+            const x = originX + baseLeftPad + c * spacingX;
+            const y = originY + spacingY * 0.5 + r * spacingY;
+            const p = new Peg(x, y, 'normal');
+            p.row = r;
+            p.col = c;
+            p.level = 1;
+            pegs.push(p);
+        }
+    }
+    return pegs;
+}
+
+/**
+ * 模块定义注册表
+ */
+export const MODULE_DEFS = {
+    std_stagger: {
+        id: 'std_stagger',
+        name: '標準交錯',
+        icon: '▦',
+        desc: '3×3 普通釘子，標準交錯排列。',
+        rarity: 'common',
+        price: 0,
+        build(ox, oy, w, h) {
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
+            return { pegs, specialSlots: [] };
+        },
+    },
+    dense_stagger: {
+        id: 'dense_stagger',
+        name: '密集交錯',
+        icon: '▩',
+        desc: '4×3 密集普通釘子，弹珠碰撞次數多。',
+        rarity: 'common',
+        price: 0,
+        build(ox, oy, w, h) {
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 4, 3, 'normal');
+            return { pegs, specialSlots: [] };
+        },
+    },
+    bouncer: {
+        id: 'bouncer',
+        name: '反彈室',
+        icon: '✦',
+        desc: '中央 1 顆高彈性粉色釘子，弹珠在此區域劇烈反彈。',
+        rarity: 'common',
+        price: 0,
+        build(ox, oy, w, h) {
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
+            if (pegs.length > 0) {
+                let bestIdx = 0;
+                let bestDist = Infinity;
+                const cx = ox + w / 2;
+                const cy = oy + h / 2;
+                for (let i = 0; i < pegs.length; i++) {
+                    const dx = pegs[i].pos.x - cx;
+                    const dy = pegs[i].pos.y - cy;
+                    const d = dx * dx + dy * dy;
+                    if (d < bestDist) { bestDist = d; bestIdx = i; }
+                }
+                pegs[bestIdx].type = 'pink';
+            }
+            return { pegs, specialSlots: [] };
+        },
+    },
+    funnel: {
+        id: 'funnel',
+        name: '漏斗',
+        icon: '▽',
+        desc: '頂寬底窄的三角形交錯，弹珠向中央匯集。',
+        rarity: 'common',
+        price: 0,
+        build(ox, oy, w, h) {
+            const pegs = generateFunnelPegs(ox, oy, w, h, 4, 3);
+            return { pegs, specialSlots: [] };
+        },
+    },
+    wheel_module: {
+        id: 'wheel_module',
+        name: '幸運轉盤',
+        icon: '🎰',
+        desc: '在底部生成一個 [輪盤槽]，弹珠穿越時觸發屬性翻倍輪盤。',
+        rarity: 'rare',
+        price: 60,
+        build(ox, oy, w, h) {
+            // 顶部一排普通钉子 + 底部两颗钉子之间夹一个 wheel slot
+            const pegs = [];
+            const sx = w / 4;
+            for (let i = 0; i < 3; i++) {
+                const p = new Peg(ox + sx + i * sx, oy + h * 0.25, 'normal');
+                p.level = 1; p.row = 0; p.col = i; pegs.push(p);
+            }
+            // 底部两颗钉子（用作 SpecialSlot 锚点）
+            const pegA = new Peg(ox + w * 0.25, oy + h * 0.85, 'normal');
+            pegA.row = 1; pegA.col = 0; pegA.level = 1;
+            const pegB = new Peg(ox + w * 0.75, oy + h * 0.85, 'normal');
+            pegB.row = 1; pegB.col = 1; pegB.level = 1;
+            pegs.push(pegA, pegB);
+            const slot = new SpecialSlot(pegA.pos.x, pegA.pos.y, pegB.pos.x, pegB.pos.y, 'wheel');
+            return { pegs, specialSlots: [slot] };
+        },
+    },
+    baffle: {
+        id: 'baffle',
+        name: '斜擋板',
+        icon: '⫽',
+        desc: '一排傾斜的粉色高彈性釘子，將弹珠導向側方。',
+        rarity: 'rare',
+        price: 50,
+        build(ox, oy, w, h) {
+            // 沿对角线排布 4 颗 pink 钉子模拟挡板
+            const pegs = [];
+            const steps = 4;
+            for (let i = 0; i < steps; i++) {
+                const t = i / (steps - 1);
+                const x = ox + w * (0.15 + t * 0.7);
+                const y = oy + h * (0.85 - t * 0.55);
+                const p = new Peg(x, y, 'pink');
+                p.row = 0; p.col = i; p.level = 1;
+                pegs.push(p);
+            }
+            // 顶部 2 颗普通钉子提供初始反弹
+            for (let i = 0; i < 2; i++) {
+                const x = ox + w * (0.3 + i * 0.4);
+                const y = oy + h * 0.15;
+                const p = new Peg(x, y, 'normal');
+                p.row = 1; p.col = i; p.level = 1;
+                pegs.push(p);
+            }
+            return { pegs, specialSlots: [] };
+        },
+    },
+    fixed_slot: {
+        id: 'fixed_slot',
+        name: '固定機關',
+        icon: '◈',
+        desc: '在固定位置生成一個特殊槽（連射/回溯/分裂依槽位輪換）。',
+        rarity: 'epic',
+        price: 80,
+        build(ox, oy, w, h, ctx, slotIdx) {
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 2, 'normal');
+            let pegA = null, pegB = null;
+            if (pegs.length >= 2) {
+                const lastRow = pegs[pegs.length - 1].row;
+                const bottomRowPegs = pegs.filter(p => p.row === lastRow).sort((a, b) => a.pos.x - b.pos.x);
+                if (bottomRowPegs.length >= 2) {
+                    pegA = bottomRowPegs[0];
+                    pegB = bottomRowPegs[1];
+                }
+            }
+            const specialSlots = [];
+            if (pegA && pegB) {
+                const types = ['multicast', 'recall', 'split'];
+                const type = types[(slotIdx || 0) % types.length];
+                specialSlots.push(new SpecialSlot(pegA.pos.x, pegA.pos.y, pegB.pos.x, pegB.pos.y, type));
+            }
+            return { pegs, specialSlots };
+        },
+    },
+    cryo_pyro_pair: {
+        id: 'cryo_pyro_pair',
+        name: '冰火元素對',
+        icon: '❄🔥',
+        desc: '左 cryo + 右 pyro 固定釘子對，搭配普通釘子。無需融合。',
+        rarity: 'rare',
+        price: 70,
+        build(ox, oy, w, h) {
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
+            const midRowPegs = pegs.filter(p => p.row === 1).sort((a, b) => a.pos.x - b.pos.x);
+            if (midRowPegs.length >= 2) {
+                midRowPegs[0].type = 'cryo';
+                midRowPegs[midRowPegs.length - 1].type = 'pyro';
+            }
+            return { pegs, specialSlots: [] };
+        },
+    },
+};
+
+/**
+ * 主入口：根据模块 ID 在指定矩形内构造实体集合
+ */
+export function buildModuleEntities(moduleId, originX, originY, width, height, ctx, slotIdx) {
+    const def = MODULE_DEFS[moduleId];
+    if (!def) {
+        return { pegs: [], specialSlots: [] };
+    }
+    return def.build(originX, originY, width, height, ctx, slotIdx);
+}
+
+/**
+ * 计算单个模块槽位的矩形（基于画布尺寸和 CONFIG.gameplay）
+ */
+export function calcModuleSlotRect(slotIdx, canvasWidth, canvasHeight, cfg) {
+    const cols = cfg.moduleCols || 4;
+    const rows = cfg.moduleRows || 3;
+    const topY = cfg.moduleAreaTopY || 60;
+    const bottomMargin = cfg.moduleAreaBottomMargin || 80;
+    const spacingX = cfg.moduleSpacingX || 4;
+    const spacingY = cfg.moduleSpacingY || 4;
+    const totalW = canvasWidth - 20;
+    const totalH = Math.max(120, canvasHeight - topY - bottomMargin);
+    const cellW = (totalW - (cols - 1) * spacingX) / cols;
+    const cellH = (totalH - (rows - 1) * spacingY) / rows;
+    const r = Math.floor(slotIdx / cols);
+    const c = slotIdx % cols;
+    return {
+        x: 10 + c * (cellW + spacingX),
+        y: topY + r * (cellH + spacingY),
+        w: cellW,
+        h: cellH,
+    };
+}
+
+/**
+ * 列出所有可放置的模块 ID（受 unlockedModuleTypes 限制）
+ */
+export function listAvailableModules(unlockedModuleTypes) {
+    return (unlockedModuleTypes || []).filter(id => MODULE_DEFS[id]);
+}

--- a/src/rune_system.js
+++ b/src/rune_system.js
@@ -441,4 +441,57 @@ function getNewRunewordsOnPlacement(currentGrid, cellIndex, runeEntry, runewordD
     });
 }
 
-export { parseRuneGrid, calcRuneBaseStats, getRuneId, rune_merge, rune_reforge, getNewRunewordsOnPlacement };
+/**
+ * fuseRuneIntoBoard - [v2 钉板模块化] 把符文消耗到钉板上
+ *
+ * 把一颗符文从 game.runeInventory 中移除，并把其元素属性写入 game.pendingFusions，
+ * 由 phase_gathering_initPachinko 在采集阶段开始前应用到随机普通钉子。
+ *
+ * 融合数量上限 = 符文等级（高级符文一次注入更多）。
+ *
+ * @param {Object} game - 游戏实例（含 runeInventory / pendingFusions）
+ * @param {Object} runeEntry - 要融合的符文 { id, level, uid? }
+ * @param {Array}  runeDb - RUNE_DB
+ * @returns {{ ok: boolean, message: string, element?: string, count?: number }}
+ */
+function fuseRuneIntoBoard(game, runeEntry, runeDb) {
+    if (!game || !runeEntry) {
+        return { ok: false, message: '无效的符文或游戏实例' };
+    }
+    const runeId = getRuneId(runeEntry);
+    if (!runeId) return { ok: false, message: '无法识别符文 ID' };
+
+    const runeDef = (runeDb || []).find(r => r.id === runeId);
+    if (!runeDef) return { ok: false, message: '符文定义不存在' };
+
+    const element = runeDef.element || runeDef.baseStat;
+    if (!element) return { ok: false, message: '该符文没有可融合的元素属性' };
+
+    const level = (typeof runeEntry.level === 'number' && runeEntry.level > 0) ? runeEntry.level : 1;
+
+    // 从 inventory 移除（按 uid 优先，否则按 id+level 第一个匹配）
+    if (Array.isArray(game.runeInventory) && game.runeInventory.length > 0) {
+        let removeIdx = -1;
+        if (runeEntry.uid) {
+            removeIdx = game.runeInventory.findIndex(r => r && r.uid === runeEntry.uid);
+        }
+        if (removeIdx === -1) {
+            removeIdx = game.runeInventory.findIndex(r => {
+                const id = getRuneId(r);
+                const lv = (typeof r === 'object' && typeof r.level === 'number') ? r.level : 1;
+                return id === runeId && lv === level;
+            });
+        }
+        if (removeIdx === -1) {
+            return { ok: false, message: '符文不在背包中' };
+        }
+        game.runeInventory.splice(removeIdx, 1);
+    }
+
+    if (!Array.isArray(game.pendingFusions)) game.pendingFusions = [];
+    game.pendingFusions.push({ element, count: level, runeId, sourceLevel: level });
+
+    return { ok: true, message: `已融合 ${runeDef.name || runeId} → 钉板将赋予 ${level} 颗 ${element} 钉子`, element, count: level };
+}
+
+export { parseRuneGrid, calcRuneBaseStats, getRuneId, rune_merge, rune_reforge, getNewRunewordsOnPlacement, fuseRuneIntoBoard };

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -786,13 +786,30 @@ export const spawn_system = {
      * @description 增加分数并提高分数乘数。
      * @param {number} amount - **重要参数** 基础分数。
      */
-    spawn_addScore(amount) { 
+    spawn_addScore(amount) {
         const finalScore = Math.floor(amount * this.scoreMultiplier);
         this.score += finalScore;
         const resourceGain = Math.floor(0.523 * Math.pow(finalScore, 0.63));
-        // [已移除] runCurrency 累积：符文碎片改为合成时直接获取，不再通过局内货币结算
+        // [v2 局内符文碎片] 击杀按概率掉落碎片，累计到 this.runFragments；
+        // 局结束时按 runShopEndOfRunFragmentSettle 比例转换到 saveData.runeFragments。
+        const cfg = (typeof CONFIG !== 'undefined' && CONFIG.gameplay) ? CONFIG.gameplay : {};
+        const baseChance = cfg.enemyDropFragmentChance != null ? cfg.enemyDropFragmentChance : 0.45;
+        const roundBonus = (cfg.enemyDropFragmentRoundBonus || 0) * (this.round || 1);
+        const fragChance = Math.min(0.95, baseChance + roundBonus);
+        if (Math.random() < fragChance) {
+            const baseAmount = cfg.enemyDropFragmentBaseAmount || 1;
+            const bonus = Math.floor(Math.log2(Math.max(2, finalScore)) - 4);
+            const gained = Math.max(1, baseAmount + Math.max(0, bonus));
+            if (typeof this.runFragments !== 'number') this.runFragments = 0;
+            this.runFragments += gained;
+            if (typeof this.runRuneFragmentsGained !== 'number') this.runRuneFragmentsGained = 0;
+            this.runRuneFragmentsGained += gained;
+            if (typeof this.spawn_createFloatingText === 'function') {
+                this.spawn_createFloatingText(this.width / 2, 60, `+${gained} 🔮`, '#a855f7');
+            }
+        }
         this.scoreMultiplier = parseFloat((this.scoreMultiplier + 0.2).toFixed(1)); // 乘数增加 0.2
-        this.ui_updateMultiplierUI(); 
+        this.ui_updateMultiplierUI();
     },
 
 /**

--- a/src/ui/game_over.js
+++ b/src/ui/game_over.js
@@ -14,7 +14,7 @@
  */
 
 import { RUNE_DB } from '../rune_config.js';
-import { RELIC_DB } from '../config.js';
+import { RELIC_DB, CONFIG } from '../config.js';
 
 // ==================== Boss 元数据（用于节点图标注） ====================
 const BOSS_META = {
@@ -38,6 +38,19 @@ export const game_over_mixin = {
      * 使用 setTimeout 延迟一帧，确保渲染循环安全退出后再切换阶段。
      */
     _gameover_triggerPhase() {
+        // ==================== [v2 局内符文碎片结算] ====================
+        // 局结束时把未消费的 runFragments 按比例转换为 saveData.runeFragments
+        // 避免玩家屯币不花。比例由 CONFIG.gameplay.runShopEndOfRunFragmentSettle 控制。
+        const cfg = (CONFIG && CONFIG.gameplay) || {};
+        const ratio = cfg.runShopEndOfRunFragmentSettle != null ? cfg.runShopEndOfRunFragmentSettle : 0.3;
+        const leftover = Math.max(0, this.runFragments || 0);
+        const settled = Math.floor(leftover * ratio);
+        if (settled > 0) {
+            if (!this.saveData) this.saveData = { runeFragments: 0 };
+            this.saveData.runeFragments = (this.saveData.runeFragments || 0) + settled;
+        }
+        this.runFragments = 0;
+
         // [局内存档] 游戏结束时清除局内存档，防止下次进入 meta 时错误提示继续游戏
         this.sys_clearRunState();
         // 延迟一帧，确保当前渲染帧安全完成

--- a/src/ui/run_shop.js
+++ b/src/ui/run_shop.js
@@ -1,0 +1,201 @@
+/**
+ * run_shop.js - [v2] 局内商店
+ *
+ * 玩家用局内累计的符文碎片 (game.runFragments) 购买：
+ *   - 钉板模块（解锁未拥有的模块类型）
+ *   - 单个符文（按稀有度定价）
+ *   - 模块槽位扩张（一次性 +1）
+ *
+ * 出现时机：每场战斗结束后，每 N 场（CONFIG.gameplay.runShopInterval）触发一次。
+ * 关闭时直接进入下一阶段（round-start resolver）。
+ *
+ * 与 meta `src/ui/shop.js` 不同：
+ *   - meta shop 是局间永久商店，使用 saveData.runeFragments
+ *   - 本商店是局内，使用 game.runFragments，购买的内容只在本局有效
+ *   - 局结束时未消费的 runFragments 按比例转换为 saveData.runeFragments
+ */
+
+import { CONFIG } from '../config.js';
+import { RUNE_DB } from '../rune_config.js';
+import { MODULE_DEFS } from '../pinboard_modules.js';
+
+const RUNE_PRICE_BY_RARITY = {
+    common: 18,
+    rare: 40,
+    epic: 80,
+    legendary: 140,
+};
+
+const SLOT_EXPAND_PRICE = 100;
+
+/**
+ * 生成商品列表
+ */
+function generateInventory(game, count) {
+    const cfg = CONFIG.gameplay || {};
+    const items = [];
+    const runesRatio = cfg.runShopRunesRatio != null ? cfg.runShopRunesRatio : 0.6;
+    const runeCount = Math.max(1, Math.floor(count * runesRatio));
+    const moduleCount = count - runeCount;
+
+    // 模块商品：来自 MODULE_DEFS 中价格 > 0 且玩家未解锁的
+    const lockedModules = Object.values(MODULE_DEFS).filter(d => d.price > 0 && (!game.unlockedModuleTypes || !game.unlockedModuleTypes.includes(d.id)));
+    for (let i = 0; i < moduleCount && lockedModules.length > 0; i++) {
+        const def = lockedModules[Math.floor(Math.random() * lockedModules.length)];
+        items.push({ kind: 'module', moduleId: def.id, name: def.name, icon: def.icon, desc: def.desc, price: def.price });
+    }
+
+    // 槽位扩张（每次商店至少出现一次，若槽位未满）
+    const totalSlots = (cfg.moduleCols || 4) * (cfg.moduleRows || 3);
+    if ((game.unlockedModuleSlots || cfg.moduleDefaultSlots || 3) < totalSlots) {
+        items.push({ kind: 'slot_expand', name: '模块槽位 +1', icon: '⊞', desc: `当前 ${game.unlockedModuleSlots || cfg.moduleDefaultSlots || 3}/${totalSlots}`, price: SLOT_EXPAND_PRICE });
+    }
+
+    // 符文商品：从 RUNE_DB 随机抽
+    const allRunes = (RUNE_DB || []).filter(r => r && r.id);
+    for (let i = 0; i < runeCount && allRunes.length > 0; i++) {
+        const r = allRunes[Math.floor(Math.random() * allRunes.length)];
+        const price = RUNE_PRICE_BY_RARITY[r.rarity] || 25;
+        items.push({ kind: 'rune', runeId: r.id, name: r.name || r.id, icon: r.icon || '🔮', desc: r.desc || `${r.element} 符文`, price, rarity: r.rarity });
+    }
+
+    return items;
+}
+
+export const run_shop = {
+    /**
+     * 打开局内商店
+     * @param {Function} onClose - 关闭后的回调
+     */
+    ui_showRunShop(onClose) {
+        const cfg = CONFIG.gameplay || {};
+        if (!Array.isArray(this.runShopInventory) || this.runShopInventory.length === 0) {
+            this.runShopInventory = generateInventory(this, cfg.runShopItemsPerOffer || 5);
+        }
+        this._runShopOnClose = onClose || null;
+
+        let overlay = document.getElementById('run-shop-overlay');
+        if (!overlay) {
+            overlay = document.createElement('div');
+            overlay.id = 'run-shop-overlay';
+            overlay.style.cssText = `
+                position: fixed; inset: 0; z-index: 245;
+                background: rgba(8, 12, 24, 0.92);
+                display: flex; align-items: center; justify-content: center;
+                padding: 16px; box-sizing: border-box;
+                font-family: 'Cinzel', 'Microsoft YaHei', sans-serif;
+                color: #e2e8f0;
+            `;
+            document.body.appendChild(overlay);
+        }
+        overlay.style.display = 'flex';
+        this.ui_renderRunShop();
+    },
+
+    ui_hideRunShop() {
+        const overlay = document.getElementById('run-shop-overlay');
+        if (overlay) overlay.style.display = 'none';
+        const cb = this._runShopOnClose;
+        this._runShopOnClose = null;
+        if (typeof cb === 'function') cb();
+    },
+
+    ui_renderRunShop() {
+        const overlay = document.getElementById('run-shop-overlay');
+        if (!overlay) return;
+        const cfg = CONFIG.gameplay || {};
+        const inventory = Array.isArray(this.runShopInventory) ? this.runShopInventory : [];
+        const fragments = this.runFragments || 0;
+        const refreshCost = cfg.runShopRefreshCost || 10;
+
+        const itemsHtml = inventory.map((it, i) => {
+            const canAfford = fragments >= it.price;
+            const opacity = canAfford ? '1' : '0.5';
+            const cursor = canAfford ? 'pointer' : 'not-allowed';
+            const rarityColor = it.rarity === 'legendary' ? '#facc15' :
+                it.rarity === 'epic' ? '#a855f7' :
+                    it.rarity === 'rare' ? '#3b82f6' : '#94a3b8';
+            return `<div data-item-idx="${i}" class="run-shop-item" style="cursor:${cursor};opacity:${opacity};background:rgba(30, 41, 59, 0.7);border:1px solid ${rarityColor};border-radius:8px;padding:10px;display:flex;flex-direction:column;gap:6px;transition:all 0.15s;">
+                <div style="display:flex;align-items:center;justify-content:space-between;">
+                    <div style="font-size:22px;">${it.icon}</div>
+                    <div style="font-size:12px;font-weight:bold;color:${rarityColor};">${it.price} 🔮</div>
+                </div>
+                <div style="font-size:13px;font-weight:bold;">${it.name}</div>
+                <div style="font-size:10px;color:#94a3b8;line-height:1.4;">${it.desc}</div>
+            </div>`;
+        }).join('');
+
+        overlay.innerHTML = `
+            <div style="background: rgba(15, 23, 42, 0.96); border: 1px solid rgba(168, 85, 247, 0.4); border-radius: 12px; padding: 18px; max-width: 760px; width: 100%; max-height: 92vh; overflow: auto; display: flex; flex-direction: column; gap: 14px;">
+                <div style="display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid rgba(168, 85, 247, 0.3);padding-bottom:10px;">
+                    <div style="font-size:18px;font-weight:bold;color:#c084fc;">局内商店</div>
+                    <div style="font-size:13px;">持有: <span style="color:#fbbf24;font-weight:bold;">${fragments} 🔮</span></div>
+                </div>
+                <div style="display:grid;grid-template-columns:repeat(auto-fill, minmax(160px, 1fr));gap:10px;">
+                    ${itemsHtml || '<div style="color:#64748b;font-size:12px;">商店为空</div>'}
+                </div>
+                <div style="display:flex;justify-content:space-between;align-items:center;border-top:1px solid rgba(168, 85, 247, 0.3);padding-top:10px;">
+                    <button id="run-shop-refresh-btn" style="padding:6px 12px;background:rgba(56, 189, 248, 0.4);color:#fff;border:1px solid rgba(56, 189, 248, 0.7);border-radius:6px;cursor:pointer;font-size:12px;">刷新 (${refreshCost} 🔮)</button>
+                    <button id="run-shop-close-btn" style="padding:8px 18px;background:rgba(34, 197, 94, 0.55);color:#fff;border:1px solid rgba(34, 197, 94, 0.8);border-radius:6px;cursor:pointer;font-weight:bold;">离开商店</button>
+                </div>
+            </div>
+        `;
+
+        overlay.querySelectorAll('.run-shop-item').forEach(el => {
+            el.addEventListener('click', () => {
+                const idx = parseInt(el.dataset.itemIdx, 10);
+                this.ui_buyRunShopItem(idx);
+            });
+        });
+        const refreshBtn = overlay.querySelector('#run-shop-refresh-btn');
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', () => {
+                if ((this.runFragments || 0) < refreshCost) {
+                    if (window.showToast) window.showToast('碎片不足');
+                    return;
+                }
+                this.runFragments -= refreshCost;
+                this.runShopInventory = generateInventory(this, cfg.runShopItemsPerOffer || 5);
+                this.runShopRefreshes = (this.runShopRefreshes || 0) + 1;
+                this.ui_renderRunShop();
+            });
+        }
+        const closeBtn = overlay.querySelector('#run-shop-close-btn');
+        if (closeBtn) {
+            closeBtn.addEventListener('click', () => {
+                this.runShopInventory = []; // 离开后清空，下次重新生成
+                this.ui_hideRunShop();
+            });
+        }
+    },
+
+    ui_buyRunShopItem(idx) {
+        const inventory = Array.isArray(this.runShopInventory) ? this.runShopInventory : [];
+        const it = inventory[idx];
+        if (!it) return;
+        if ((this.runFragments || 0) < it.price) {
+            if (window.showToast) window.showToast('碎片不足');
+            return;
+        }
+        const cfg = CONFIG.gameplay || {};
+        if (it.kind === 'module') {
+            if (!Array.isArray(this.unlockedModuleTypes)) this.unlockedModuleTypes = [];
+            if (!this.unlockedModuleTypes.includes(it.moduleId)) {
+                this.unlockedModuleTypes.push(it.moduleId);
+            }
+            if (window.showToast) window.showToast(`已解锁模块: ${it.name}`);
+        } else if (it.kind === 'slot_expand') {
+            const totalSlots = (cfg.moduleCols || 4) * (cfg.moduleRows || 3);
+            this.unlockedModuleSlots = Math.min(totalSlots, (this.unlockedModuleSlots || cfg.moduleDefaultSlots || 3) + 1);
+            if (window.showToast) window.showToast(`钉板槽位 +1（当前 ${this.unlockedModuleSlots}/${totalSlots}）`);
+        } else if (it.kind === 'rune') {
+            if (!Array.isArray(this.runeInventory)) this.runeInventory = [];
+            this.runeInventory.push({ id: it.runeId, level: 1 });
+            if (window.showToast) window.showToast(`获得符文: ${it.name}`);
+        }
+        this.runFragments -= it.price;
+        // 售出后从商店列表移除
+        inventory.splice(idx, 1);
+        this.ui_renderRunShop();
+    },
+};

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -242,6 +242,22 @@ export const shop_system = {
             if (typeof this.sys_queueRoundStartReward === 'function') {
                 this.sys_queueRoundStartReward({ type: 'chaos_essence', source: 'relic', sourceRelicId: relic.id, sourceRelicName: relic.name, round: this.round });
             }
+        }
+        // ==================== [v2 钉板模块化] 新遗物分支 ====================
+        else if (relic.effect === 'module_slot_up') {
+            const cfg = (typeof CONFIG !== 'undefined' && CONFIG.gameplay) || {};
+            const totalSlots = (cfg.moduleCols || 4) * (cfg.moduleRows || 3);
+            const amount = (typeof relic.amount === 'number' && relic.amount > 0) ? relic.amount : 1;
+            this.unlockedModuleSlots = Math.min(totalSlots, (this.unlockedModuleSlots || cfg.moduleDefaultSlots || 3) + amount);
+            if (window.showToast) showToast(`钉板模块槽位 +${amount}（当前 ${this.unlockedModuleSlots}/${totalSlots}）`);
+        }
+        else if (relic.effect === 'unlock_module_type') {
+            if (!Array.isArray(this.unlockedModuleTypes)) this.unlockedModuleTypes = [];
+            const moduleId = relic.moduleId;
+            if (moduleId && !this.unlockedModuleTypes.includes(moduleId)) {
+                this.unlockedModuleTypes.push(moduleId);
+                if (window.showToast) showToast(`已解锁钉板模块：${relic.name || moduleId}`);
+            }
         } else if (relic.effect === 'row_count_up') {
             this.currentRows = (this.currentRows || 0) + 2;
             if (typeof this.phase_gathering_initPachinko === 'function') this.phase_gathering_initPachinko(true);

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -2,6 +2,8 @@ import { eventBus, EVENT_TYPES } from './event_bus.js';
 import { RUNE_DB } from './rune_config.js';
 import { CONFIG, RELIC_DB } from './config.js';
 import { getAmmoIconSrcByKey } from './bitmap_icons.js';
+import { MODULE_DEFS, listAvailableModules } from './pinboard_modules.js';
+import { fuseRuneIntoBoard, getRuneId } from './rune_system.js';
 
 export const ui_system = {
     // @section:ui_fly_effects - 飞行特效池管理
@@ -1183,5 +1185,236 @@ export const ui_system = {
                 </div>`;
         }).join('');
         list.innerHTML = html;
+    },
+
+    // ======================================================================
+    // [v2 钉板模块化] 模块编辑器
+    // ======================================================================
+    // 在每场遗物阶段后、采集阶段开始前打开。玩家可以：
+    //   1) 在 4×3 网格里摆放已解锁的钉板模块（受 unlockedModuleSlots 限制）
+    //   2) 在右侧融合区把符文消耗到钉板（写入 pendingFusions，
+    //      在 phase_gathering_initPachinko 末尾随机赋予普通钉子元素属性）
+    //   3) 点击"开始采集"关闭编辑器并进入采集阶段
+    _moduleEditorState: null,
+
+    ui_showModuleEditor(onComplete) {
+        const cfg = CONFIG.gameplay || {};
+        const cols = cfg.moduleCols || 4;
+        const rows = cfg.moduleRows || 3;
+        const totalSlots = cols * rows;
+
+        // 确保 layout / unlocked 字段已初始化
+        if (!Array.isArray(this.currentModuleLayout) || this.currentModuleLayout.length !== totalSlots) {
+            this.currentModuleLayout = new Array(totalSlots).fill(null);
+            for (let i = 0; i < (cfg.moduleDefaultSlots || 3); i++) {
+                this.currentModuleLayout[i] = 'std_stagger';
+            }
+        }
+        if (!Array.isArray(this.unlockedModuleTypes)) {
+            this.unlockedModuleTypes = ['std_stagger', 'dense_stagger', 'bouncer', 'funnel'];
+        }
+        if (typeof this.unlockedModuleSlots !== 'number') {
+            this.unlockedModuleSlots = cfg.moduleDefaultSlots || 3;
+        }
+
+        // 每次打开重置 selection
+        this._moduleEditorState = {
+            selectedModuleId: null,  // 当前选中的模块 ID（待放入网格）
+            selectedRuneIdx: null,   // 当前选中的符文 inventory 索引
+            onComplete: onComplete || null,
+        };
+
+        let overlay = document.getElementById('module-editor-overlay');
+        if (!overlay) {
+            overlay = document.createElement('div');
+            overlay.id = 'module-editor-overlay';
+            overlay.style.cssText = `
+                position: fixed; inset: 0; z-index: 240;
+                background: rgba(8, 12, 24, 0.92);
+                display: flex; align-items: center; justify-content: center;
+                padding: 16px; box-sizing: border-box;
+                font-family: 'Cinzel', 'Microsoft YaHei', sans-serif;
+                color: #e2e8f0;
+            `;
+            document.body.appendChild(overlay);
+        }
+        overlay.style.display = 'flex';
+        this.ui_renderModuleEditor();
+    },
+
+    ui_hideModuleEditor() {
+        const overlay = document.getElementById('module-editor-overlay');
+        if (overlay) overlay.style.display = 'none';
+        this._moduleEditorState = null;
+    },
+
+    ui_renderModuleEditor() {
+        const overlay = document.getElementById('module-editor-overlay');
+        if (!overlay) return;
+        const cfg = CONFIG.gameplay || {};
+        const cols = cfg.moduleCols || 4;
+        const rows = cfg.moduleRows || 3;
+        const totalSlots = cols * rows;
+        const unlockedSlots = this.unlockedModuleSlots || cfg.moduleDefaultSlots || 3;
+        const layout = this.currentModuleLayout || [];
+        const available = listAvailableModules(this.unlockedModuleTypes || []);
+        const state = this._moduleEditorState || {};
+        const selModule = state.selectedModuleId;
+        const selRune = state.selectedRuneIdx;
+        const inventory = Array.isArray(this.runeInventory) ? this.runeInventory : [];
+        const pendingFusions = Array.isArray(this.pendingFusions) ? this.pendingFusions : [];
+
+        // ---- 模块网格 cells ----
+        const gridCellsHtml = (() => {
+            let html = '';
+            for (let i = 0; i < totalSlots; i++) {
+                const isUnlocked = i < unlockedSlots;
+                const moduleId = layout[i];
+                const def = moduleId ? MODULE_DEFS[moduleId] : null;
+                const bg = !isUnlocked
+                    ? 'rgba(30, 41, 59, 0.4)'
+                    : (def ? 'rgba(56, 189, 248, 0.18)' : 'rgba(30, 41, 59, 0.7)');
+                const border = !isUnlocked
+                    ? '1px dashed rgba(100,116,139,0.5)'
+                    : '1px solid rgba(56, 189, 248, 0.55)';
+                const labelMain = def ? `<div style="font-size:18px;line-height:1;">${def.icon || '▦'}</div><div style="font-size:10px;margin-top:4px;text-align:center;">${def.name}</div>` : (isUnlocked ? '<div style="font-size:11px;color:#64748b;">空槽</div>' : '<div style="font-size:14px;color:#475569;">🔒</div>');
+                html += `<div data-slot-idx="${i}" class="module-grid-cell" style="cursor:${isUnlocked ? 'pointer' : 'not-allowed'};background:${bg};border:${border};border-radius:8px;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:80px;padding:6px;transition:all 0.15s;">${labelMain}</div>`;
+            }
+            return html;
+        })();
+
+        // ---- 模块库 ----
+        const paletteHtml = available.map(id => {
+            const def = MODULE_DEFS[id];
+            if (!def) return '';
+            const selBg = (selModule === id) ? 'rgba(56, 189, 248, 0.45)' : 'rgba(30, 41, 59, 0.7)';
+            return `<div data-module-id="${id}" class="module-palette-item" style="cursor:pointer;background:${selBg};border:1px solid rgba(56, 189, 248, 0.4);border-radius:6px;padding:8px;display:flex;flex-direction:column;align-items:center;text-align:center;transition:all 0.15s;">
+                <div style="font-size:20px;">${def.icon}</div>
+                <div style="font-size:11px;margin-top:4px;font-weight:bold;">${def.name}</div>
+                <div style="font-size:9px;color:#94a3b8;margin-top:3px;line-height:1.3;">${def.desc}</div>
+            </div>`;
+        }).join('');
+
+        // ---- 符文融合区 ----
+        const runeListHtml = inventory.length > 0 ? inventory.map((r, idx) => {
+            const id = getRuneId(r);
+            const def = (RUNE_DB || []).find(d => d.id === id);
+            if (!def) return '';
+            const lv = (typeof r === 'object' && typeof r.level === 'number') ? r.level : 1;
+            const selBg = (selRune === idx) ? 'rgba(168, 85, 247, 0.45)' : 'rgba(30, 41, 59, 0.7)';
+            return `<div data-rune-idx="${idx}" class="rune-fusion-item" style="cursor:pointer;background:${selBg};border:1px solid rgba(168, 85, 247, 0.4);border-radius:6px;padding:6px;display:flex;align-items:center;gap:6px;">
+                <div style="font-size:16px;">${def.icon || '🔮'}</div>
+                <div style="flex:1;min-width:0;">
+                    <div style="font-size:11px;font-weight:bold;">${def.name || id} <span style="color:#fbbf24;">L${lv}</span></div>
+                    <div style="font-size:9px;color:#94a3b8;">融合后赋予 ${lv} 颗 ${def.element || ''} 钉子</div>
+                </div>
+            </div>`;
+        }).join('') : '<div style="color:#64748b;font-size:11px;padding:8px;">背包没有符文</div>';
+
+        const pendingHtml = pendingFusions.length > 0
+            ? '<div style="margin-top:8px;padding:6px;background:rgba(168, 85, 247, 0.12);border-radius:6px;font-size:10px;">待融合: ' + pendingFusions.map(f => `${f.element}×${f.count}`).join(', ') + '</div>'
+            : '';
+
+        overlay.innerHTML = `
+            <div style="background: rgba(15, 23, 42, 0.96); border: 1px solid rgba(56, 189, 248, 0.35); border-radius: 12px; padding: 18px; max-width: 960px; width: 100%; max-height: 92vh; overflow: auto; display: flex; flex-direction: column; gap: 14px;">
+                <div style="display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid rgba(56, 189, 248, 0.25);padding-bottom:10px;">
+                    <div style="font-size:18px;font-weight:bold;color:#7dd3fc;">钉板模块编辑器</div>
+                    <div style="font-size:11px;color:#94a3b8;">已开放槽位: <span style="color:#fbbf24;font-weight:bold;">${unlockedSlots}/${totalSlots}</span></div>
+                </div>
+                <div style="display:grid;grid-template-columns: 2fr 1.2fr;gap:14px;">
+                    <div>
+                        <div style="font-size:12px;color:#94a3b8;margin-bottom:6px;">模块网格 (点击空槽放置已选模块；点击已放置模块清除)</div>
+                        <div id="module-editor-grid" style="display:grid;grid-template-columns:repeat(${cols}, 1fr);gap:6px;">
+                            ${gridCellsHtml}
+                        </div>
+                    </div>
+                    <div style="display:flex;flex-direction:column;gap:10px;">
+                        <div>
+                            <div style="font-size:12px;color:#94a3b8;margin-bottom:6px;">模块库 (点击选中)</div>
+                            <div id="module-editor-palette" style="display:grid;grid-template-columns:repeat(2, 1fr);gap:6px;">
+                                ${paletteHtml}
+                            </div>
+                        </div>
+                        <div>
+                            <div style="font-size:12px;color:#94a3b8;margin-bottom:6px;">符文融合 (点击符文 → 点击"融合"消耗到钉板)</div>
+                            <div id="module-editor-runes" style="display:flex;flex-direction:column;gap:4px;max-height:160px;overflow-y:auto;">
+                                ${runeListHtml}
+                            </div>
+                            <button id="module-editor-fuse-btn" style="margin-top:8px;width:100%;padding:6px;background:rgba(168, 85, 247, 0.5);color:#fff;border:1px solid rgba(168, 85, 247, 0.7);border-radius:6px;cursor:pointer;font-size:12px;">融合选中符文</button>
+                            ${pendingHtml}
+                        </div>
+                    </div>
+                </div>
+                <div style="display:flex;justify-content:space-between;align-items:center;border-top:1px solid rgba(56, 189, 248, 0.25);padding-top:10px;">
+                    <div style="font-size:10px;color:#64748b;">提示：摆放完模块后，可消耗符文将元素属性"融合"到钉板的随机普通钉子上。</div>
+                    <button id="module-editor-start-btn" style="padding:8px 18px;background:rgba(34, 197, 94, 0.55);color:#fff;border:1px solid rgba(34, 197, 94, 0.8);border-radius:6px;cursor:pointer;font-weight:bold;">开始采集</button>
+                </div>
+            </div>
+        `;
+
+        // ---- 事件绑定 ----
+        const grid = overlay.querySelector('#module-editor-grid');
+        if (grid) {
+            grid.querySelectorAll('.module-grid-cell').forEach(cell => {
+                cell.addEventListener('click', () => {
+                    const idx = parseInt(cell.dataset.slotIdx, 10);
+                    if (idx >= unlockedSlots) return; // 锁定槽
+                    const st = this._moduleEditorState || {};
+                    if (this.currentModuleLayout[idx]) {
+                        // 已有模块 → 清除
+                        this.currentModuleLayout[idx] = null;
+                    } else if (st.selectedModuleId) {
+                        this.currentModuleLayout[idx] = st.selectedModuleId;
+                    }
+                    this.ui_renderModuleEditor();
+                });
+            });
+        }
+        const palette = overlay.querySelector('#module-editor-palette');
+        if (palette) {
+            palette.querySelectorAll('.module-palette-item').forEach(item => {
+                item.addEventListener('click', () => {
+                    const id = item.dataset.moduleId;
+                    if (!this._moduleEditorState) return;
+                    this._moduleEditorState.selectedModuleId = (this._moduleEditorState.selectedModuleId === id) ? null : id;
+                    this.ui_renderModuleEditor();
+                });
+            });
+        }
+        const runeList = overlay.querySelector('#module-editor-runes');
+        if (runeList) {
+            runeList.querySelectorAll('.rune-fusion-item').forEach(item => {
+                item.addEventListener('click', () => {
+                    const idx = parseInt(item.dataset.runeIdx, 10);
+                    if (!this._moduleEditorState) return;
+                    this._moduleEditorState.selectedRuneIdx = (this._moduleEditorState.selectedRuneIdx === idx) ? null : idx;
+                    this.ui_renderModuleEditor();
+                });
+            });
+        }
+        const fuseBtn = overlay.querySelector('#module-editor-fuse-btn');
+        if (fuseBtn) {
+            fuseBtn.addEventListener('click', () => {
+                const st = this._moduleEditorState;
+                if (!st || st.selectedRuneIdx === null) {
+                    if (window.showToast) window.showToast('请先选中要融合的符文');
+                    return;
+                }
+                const rune = (this.runeInventory || [])[st.selectedRuneIdx];
+                if (!rune) return;
+                const result = fuseRuneIntoBoard(this, rune, RUNE_DB);
+                if (window.showToast) window.showToast(result.message);
+                if (result.ok) st.selectedRuneIdx = null;
+                this.ui_renderModuleEditor();
+            });
+        }
+        const startBtn = overlay.querySelector('#module-editor-start-btn');
+        if (startBtn) {
+            startBtn.addEventListener('click', () => {
+                const onComplete = (this._moduleEditorState || {}).onComplete;
+                this.ui_hideModuleEditor();
+                if (typeof onComplete === 'function') onComplete();
+            });
+        }
     }
 };


### PR DESCRIPTION
## Summary

把"钉板的养成完成度"绑定到玩家可见的扩张/解锁/摆放路径上，避免靠提高钉板出现频次来强化养成感（用户明确不希望钉板更频繁）。改动覆盖三个互锁系统：

### 系统一：钉板模块化
- 把固定 10×5 钉板拆为 **4×3 = 12 模块槽**（默认开放第 1 行 3 槽，受 `unlockedModuleSlots` 限制）
- 8 种模块：`std_stagger` / `dense_stagger` / `bouncer` / `funnel`（初始）/ `wheel_module` / `baffle` / `fixed_slot` / `cryo_pyro_pair`（解锁）
- `phase_gathering_initPachinko` 重写为模块化生成（旧实现保留为 `_legacy` 作为参考）
- 新增 6 项遗物：`module_slot_expander` / `module_row_unlock` / `unlock_module_*`
- 新文件：`src/pinboard_modules.js`（含 `MODULE_DEFS`、`buildModuleEntities`、`calcModuleSlotRect`）

### 系统二：符文 ↔ 钉板融合（取消符文对子弹的属性附加）
- **删除** `combat_system.js:2479-2524` 把 `activeRunewordStats` 与 `calcRuneBaseStats` 直接叠加到 `finalRecipe` 的两段
- 新增 `rune_system.fuseRuneIntoBoard()`：玩家在模块编辑器消耗符文 → 写入 `pendingFusions` → `phase_gathering_initPachinko` 末尾随机把若干普通钉子改为对应元素钉子
- 融合数量上限 = 符文等级
- 保留符文词条的非属性效果（mutation / skill unlock）

### 系统三：局内商店 + 符文碎片经济
- 重新启用 `spawn_addScore` 中曾被注释为"已移除"的局内符文碎片掉落
- 每 N 场战斗后弹出 `ui_showRunShop`：购买模块解锁 / 符文 / 槽位扩张 / 刷新（10 碎片）
- 局结束（`_gameover_triggerPhase`）按 `runShopEndOfRunFragmentSettle`（30%）转换未消费碎片到 `saveData.runeFragments`，避免屯币不花
- 新文件：`src/ui/run_shop.js`

### 平衡曲线
- 早期 3 模块 ≈ 27 钉（< 旧版 50 钉，节奏更快）
- 中期 6 模块 ≈ 50 钉
- 后期 12 模块 ≈ 100+ 钉 + 多机关

钉板出现频次保持每场战斗 1 次。`selectionReq` / `initTriggerThreshold` 不变。

## Test plan

- [ ] `python3 -m http.server` → 浏览器打开 `index.html`，新游戏
- [ ] 第一场遗物结束 → 模块编辑器弹出，默认顶部 3 槽预填 std_stagger
- [ ] 进入采集 → 钉板只占顶部一片，弹珠落下行为正常
- [ ] 持有 1 颗 pyro 符文 → 编辑器右侧选中 → 点击"融合选中符文" → 进入采集后应可见 1 颗 normal 钉变为 pyro 钉
- [ ] 战斗中 dev console 检查 `finalRecipe` 不再含来自 runeword 的属性加成
- [ ] 击杀敌人后 HUD 应有 "+1 🔮" 飘字累加 `runFragments`
- [ ] 第 2 场战斗结束 → 局内商店弹出 → 购买模块/符文/槽位/刷新均工作
- [ ] 拿到 `module_slot_expander` 遗物 → 编辑器多 1 个解锁槽
- [ ] 拿到 `unlock_module_wheel` 遗物 → 模块库出现转盘
- [ ] 触发游戏结束 → `saveData.runeFragments` 增加（=未消费 runFragments × 0.3）
- [ ] 旧 `boardLayout` 遗物（triangle/diamond 等）触发后 boardLayout 字段更新但不影响模块化（兼容路径）

## 不在此次范围

- 不改钉板出现频次
- 不重做 chaos essence 触发逻辑
- 不改 meta 商店；只新增局内商店
- 不引入跨场永久钉板（每场可重摆已确认）
- 没有为 `baffle` 新增 `Wall` 物理类，改用一排 pink 钉子模拟反弹（MVP 选择，可后续升级）

https://claude.ai/code/session_01Pkvmb8AhZRjDg63cz4qo4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkvmb8AhZRjDg63cz4qo4p)_