### PR TITLE
修复共鸣和剧毒钉子缺少专属样式与属性面板显示

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -315,6 +315,7 @@ const CONFIG = {
         matWind: '#34d399',
         matWind_lv2: '#10b981', // 进阶深绿
         matWind_lv3: '#059669', // 终极墨绿
+        matVenom: '#4ade80', // 剧毒绿
         marbleWhite: '#f8fafc',
         matMatryoshka: '#d946ef',
         marbleRedStripe: '#fca5a5',

--- a/src/entities.js
+++ b/src/entities.js
@@ -253,7 +253,7 @@ class FortuneWheel {
         
         // [修改] 1. 过滤不可叠加属性 (如 pierce, bounce, scatter, flying_sword 等通常不适合转盘直接翻倍)
         // 我们只允许元素属性和增幅属性进入转盘
-        const stackableTypes = ["bounce","pierce","scatter",'damage', 'cryo', 'pyro', 'lightning', 'laser', 'wind', 'resonance', 'explosive'];
+        const stackableTypes = ["bounce","pierce","scatter",'damage', 'cryo', 'pyro', 'lightning', 'laser', 'wind', 'resonance', 'venom', 'explosive'];
         
         // 统计当前弹珠拥有的可叠加属性
         const counts = {};
@@ -864,6 +864,8 @@ class Peg {
             case 'wind': color = CONFIG.colors.matWind; break;
             case 'pink': color = CONFIG.colors.pegPink; break;
             case 'laser': color = CONFIG.colors.laser; break;
+            case 'resonance': color = CONFIG.colors.resonance; break;
+            case 'venom': color = CONFIG.colors.matVenom; break;
         }
         return color
     }
@@ -1080,6 +1082,16 @@ class Peg {
             ctx.shadowBlur = _sb(12 + pulse * 8);
             ctx.shadowColor = CONFIG.colors.matWind;
             ctx.fillStyle = isLit ? '#ffffff' : color;
+        } else if (this.type === 'resonance') {
+            const pulse = (Math.sin(Date.now() / 400) + 1) / 2;
+            ctx.shadowBlur = _sb(10 + pulse * 8);
+            ctx.shadowColor = CONFIG.colors.resonance;
+            ctx.fillStyle = isLit ? '#ffffff' : color;
+        } else if (this.type === 'venom') {
+            const pulse = (Math.sin(Date.now() / 500) + 1) / 2;
+            ctx.shadowBlur = _sb(8 + pulse * 6);
+            ctx.shadowColor = CONFIG.colors.matVenom;
+            ctx.fillStyle = isLit ? '#ffffff' : color;
         } else if (isLit) {
             ctx.fillStyle = '#ffffff';
             ctx.shadowBlur = _sb(15);
@@ -1161,6 +1173,8 @@ class Peg {
         if (this.type === 'damage')    this.drawDamagePeg(ctx, currentRadius, isLit);
         if (this.type === 'laser')     this.drawLaserPeg(ctx, currentRadius, isLit);
         if (this.type === 'pink')      this.drawPinkPeg(ctx, currentRadius, isLit);
+        if (this.type === 'resonance') this.drawResonancePeg(ctx, currentRadius, isLit);
+        if (this.type === 'venom')     this.drawVenomPeg(ctx, currentRadius, isLit);
 
         // [Glacies 狂暴] 冻结 Peg 蓝色光晕
         if (this.frozenTurns > 0) {
@@ -1632,6 +1646,80 @@ class Peg {
         ctx.bezierCurveTo(s, -s * 0.1, s * 0.1, -s * 0.1, 0, s * 0.4);
         ctx.closePath();
         ctx.fill();
+        ctx.restore();
+    }
+
+    /**
+     * [resonance] 共鸣属性：同心弧波纹
+     * 三圈由内向外扩散的圆弧，模拟声波/共鸣振动
+     */
+    drawResonancePeg(ctx, r, isLit) {
+        const time = Date.now() / 1000;
+        ctx.save();
+        ctx.translate(this.pos.x, this.pos.y);
+        const ic = isLit ? 'rgba(0,0,0,0.5)' : 'rgba(255,255,255,0.9)';
+        ctx.strokeStyle = ic;
+        ctx.lineCap = 'round';
+        // 三圈弧线，左右对称，模拟声波辐射
+        const radii = [r * 0.25, r * 0.48, r * 0.70];
+        const arcSpan = Math.PI * 0.72;
+        radii.forEach((ar, i) => {
+            ctx.lineWidth = r * (0.15 - i * 0.03);
+            // 左侧弧
+            ctx.beginPath();
+            ctx.arc(0, 0, ar, Math.PI - arcSpan / 2, Math.PI + arcSpan / 2);
+            ctx.stroke();
+            // 右侧弧
+            ctx.beginPath();
+            ctx.arc(0, 0, ar, -arcSpan / 2, arcSpan / 2);
+            ctx.stroke();
+        });
+        // 中心小圆点（波源）
+        ctx.fillStyle = ic;
+        ctx.beginPath();
+        ctx.arc(0, 0, r * 0.12, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+    }
+
+    /**
+     * [venom] 剧毒属性：骷髅轮廓
+     * 圆形头骨 + 两条交叉骨骼，经典毒素符号
+     */
+    drawVenomPeg(ctx, r, isLit) {
+        ctx.save();
+        ctx.translate(this.pos.x, this.pos.y);
+        const ic = isLit ? 'rgba(0,0,0,0.5)' : 'rgba(255,255,255,0.9)';
+        ctx.strokeStyle = ic;
+        ctx.fillStyle = ic;
+        ctx.lineWidth = r * 0.13;
+        ctx.lineCap = 'round';
+        // 头骨圆形（上半部分）
+        ctx.beginPath();
+        ctx.arc(0, -r * 0.12, r * 0.42, Math.PI * 0.15, Math.PI * 0.85, true);
+        ctx.stroke();
+        // 下颌底边
+        ctx.beginPath();
+        ctx.moveTo(-r * 0.38, r * 0.10);
+        ctx.lineTo(r * 0.38, r * 0.10);
+        ctx.stroke();
+        // 两个眼孔（实心小圆）
+        ctx.beginPath();
+        ctx.arc(-r * 0.17, -r * 0.18, r * 0.10, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(r * 0.17, -r * 0.18, r * 0.10, 0, Math.PI * 2);
+        ctx.fill();
+        // 交叉骨骼（下方）
+        ctx.lineWidth = r * 0.11;
+        ctx.beginPath();
+        ctx.moveTo(-r * 0.38, r * 0.55);
+        ctx.lineTo(r * 0.38, r * 0.20);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(r * 0.38, r * 0.55);
+        ctx.lineTo(-r * 0.38, r * 0.20);
+        ctx.stroke();
         ctx.restore();
     }
 

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -487,7 +487,9 @@ export const hud_system = {
                         { k: 'pyro', i: CONFIG.ui.attributeDisplay.pyro.icon },
                         { k: 'lightning', i: CONFIG.ui.attributeDisplay.lightning.icon },
                         { k: 'laser', i: CONFIG.ui.attributeDisplay.laser.icon },
-                        { k: 'wind', i: CONFIG.ui.attributeDisplay.wind.icon }
+                        { k: 'wind', i: CONFIG.ui.attributeDisplay.wind.icon },
+                        { k: 'resonance', i: CONFIG.ui.attributeDisplay.resonance.icon },
+                        { k: 'venom', i: CONFIG.ui.attributeDisplay.venom.icon }
                     ];
                     let hasStats = false;
                     stats.forEach(s => {
@@ -582,7 +584,9 @@ export const hud_system = {
             'pyro': { c: CONFIG.colors.matPyro, l: CONFIG.ui.attributeDisplay.pyro.icon, n: '熱' },
             'lightning': { c: CONFIG.colors.matLightning, l: CONFIG.ui.attributeDisplay.lightning.icon, n: '雷' },
             'laser': { c: CONFIG.colors.laser, l: CONFIG.ui.attributeDisplay.laser.icon, n: '光' },
-            'wind': { c: CONFIG.colors.matWind, l: CONFIG.ui.attributeDisplay.wind.icon, n: '風' }
+            'wind': { c: CONFIG.colors.matWind, l: CONFIG.ui.attributeDisplay.wind.icon, n: '風' },
+            'resonance': { c: CONFIG.colors.resonance, l: CONFIG.ui.attributeDisplay.resonance.icon, n: '鳴' },
+            'venom': { c: CONFIG.colors.matVenom, l: CONFIG.ui.attributeDisplay.venom.icon, n: '毒' }
         };
 
         Object.keys(counts).forEach(type => { 


### PR DESCRIPTION
## Summary

- 为共鸣（resonance）和剧毒（venom）钉子添加专属几何图标绘制方法
- 补充两种类型在属性面板（HUD 卡片）中的颜色与图标条目
- 修复因类型缺失导致钉子外观和属性窗口空白的问题

## 变更详情

### `src/entities.js`
- `getColor()`：新增 `resonance`（琥珀色 `#f59e0b`）和 `venom`（毒绿 `#4ade80`）颜色分支
- 基础填充段：为两种类型添加脉冲发光（`shadowBlur` + `shadowColor`）
- 绘制分发块：调用 `drawResonancePeg()` / `drawVenomPeg()`
- 新增 `drawResonancePeg()`：三对左右对称同心弧线 + 中心波源点，模拟声波共鸣
- 新增 `drawVenomPeg()`：圆形头骨轮廓 + 双眼孔 + 交叉骨骼，经典毒素符号
- `stackableTypes`：补充 `venom`，使其可参与属性叠加轮盘

### `src/config.js`
- `colors`：新增 `matVenom: '#4ade80'`

### `src/ui/hud.js`
- 战斗 HUD `stats` 数组：补充 `resonance` / `venom` 条目，使属性计数显示在配方卡片中
- 收集阶段 `colors` 映射：补充 `resonance`（🔔 鳴）/ `venom`（☠️ 毒）条目

## Test plan

- [ ] 游戏内出现共鸣钉子时，钉子上应显示同心弧波纹图标，并有琥珀色发光
- [ ] 游戏内出现剧毒钉子时，钉子上应显示骷髅 + 交叉骨骼图标，并有绿色发光
- [ ] 收集阶段弹珠卡片中，共鸣属性显示 🔔 鳴N，剧毒属性显示 ☠️ 毒N
- [ ] 战斗阶段弹药 HUD 属性栏中，两种属性均正确显示图标与数值
- [ ] 其他已有钉子类型样式无回归

https://claude.ai/code/session_016TVT2MntvtQ8h254ru8uwF

---
_Generated by [Claude Code](https://claude.ai/code/session_016TVT2MntvtQ8h254ru8uwF)_