### PR TITLE
refactor: 商店不再每回合弹出 + 钉板/特殊槽遗物迁移

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1277,15 +1277,8 @@ const CONFIG = {
 // 所有影响钉盘结构（行数、布局形态）的遗物 ID，单局内只能选择其中一个
 // [v2 模块化] 行数/布局遗物保留作为 boardLayout 兼容入口（映射为预设模块组合），
 // 不影响新增的 module_slot_up / unlock_module_type 系列遗物（这些可叠加）。
-const BOARD_STRUCTURE_RELICS = new Set([
-    'dimension_shard',       // 行数遗物：增加钉盘行数（1行）
-    'dimension_crystal',     // 行数遗物：增加钉盘行数（2行）
-    'triangle_formation',    // 布局遗物：三角阵形
-    'diamond_formation',     // 布局遗物：菱形阵形
-    'sparse_interval',       // 布局遗物：稀疏间隔
-    'mirror_sync',           // 布局遗物：镜像同步
-    'wide_narrow',           // 布局遗物：宽窄交替
-]);
+// [v2 模块化] 钉盘结构遗物已全部迁移为 pinboard_modules.js 中的模块；保留空集合以维持导出兼容。
+const BOARD_STRUCTURE_RELICS = new Set();
 
 // ==================== 遗物数据库 ====================
 
@@ -1321,26 +1314,9 @@ const RELIC_DB = [
     effect: 'pure_essence',
     maxStacks: 1
     },
-    // 维度碎片拆分为 rare(+1行×3) 和 legendary(+2行×2)
-    { 
-        id: 'dimension_shard', 
-        name: '維度碎片', 
-        icon: '🌌', 
-        desc: '收集階段：釘板高度延伸，額外增加 1 行釘子。（最多疊加 3 次）立刻觸發一次混沌精華。', 
-        rarity: 'rare', 
-        effect: 'row_count_up_1', maxStacks: 3,
-        recommended: true,
-        tags: ['收益增幅', '新手友好'],
-        recommendTip: '更多行釘子意味着每回合可收集更多属性，弹珠伤害将大幅提升！'
-    },
-    { 
-        id: 'dimension_crystal', 
-        name: '維度結晶', 
-        icon: '💠', 
-        desc: '收集階段：釘板高度大幅延伸，額外增加 2 行釘子。（最多疊加 2 次）立刻觸發一次混沌精華。', 
-        rarity: 'legendary', 
-        effect: 'row_count_up', maxStacks: 2
-    },
+    // [v2 模块化] 旧 dimension_shard / dimension_crystal 行数遗物已移除，迁移为
+    // pinboard_modules.js 中的 dim_shard_module / dim_crystal_module（高密度釘板模块），
+    // 通过商店购买后挂载到模块槽位。
     { id: 'stars_shines', name: '群星闪烁', icon: '✨', desc: '解鎖 [回响彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆回响彈珠。', rarity: 'rare', effect: 'unlock_marble', marbleType: 'resonance', boost: 8, maxStacks: 1 },
     { id: 'optical_lens', name: '聚焦透鏡', icon: '🔭', desc: '解鎖 [光球彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆光球彈珠。', rarity: 'legendary', effect: 'unlock_marble', marbleType: 'laser', boost: 10, maxStacks: 1 },
     //  1. 粉色钉子遗物
@@ -1349,13 +1325,9 @@ const RELIC_DB = [
     //  2. 战斗底部反弹墙（诅咒：所有墙体都消耗反弹/穿透）
     { id: 'energy_shield', name: '力場護盾', icon: '🛡️', desc: '戰鬥階段：底部邊界可反彈子彈。但子彈觸碰任何墻體（左/右/頂/底）都會額外消耗一次反彈或穿透次數。', rarity: 'cursed', effect: 'combat_wall' ,maxStacks: 1},
 
-    //  3. 特殊槽解锁 (三种槽位)
-    { id: 'unlock_recall', name: '時光沙漏', icon: '⏳', desc: '收集階段：解鎖 [回溯槽] 的出現 (若無槽位則+1)。立刻觸發一次混沌精華。', rarity: 'rare', effect: 'unlock_slot', slotType: 'recall' ,maxStacks: 1},
-    { id: 'unlock_multicast', name: '雙子魔鏡', icon: '♊', desc: '收集階段：解鎖 [連射槽] 的出現 (若無槽位則+1)。立刻觸發一次混沌精華。', rarity: 'rare', effect: 'unlock_slot', slotType: 'multicast' ,maxStacks: 1},
-    { id: 'unlock_split', name: '裂變核心', icon: '☢️', desc: '收集階段：解鎖 [分裂槽] 的出現 (若無槽位則+1)。立刻觸發一次混沌精華。', rarity: 'rare', effect: 'unlock_slot', slotType: 'split' ,maxStacks: 1},
-
-    //  4. 增加特殊槽数量
-    { id: 'slot_expander', name: '空間鑿子', icon: '🔨', desc: '收集階段：特殊槽出現數量 +1。立刻觸發一次混沌精華。', rarity: 'common', effect: 'slot_count_up', maxStacks: 3, recommended: true, tags: ['连击增幅', '新手友好'], recommendTip: '更多特殊槽意味着更多触发机会，是快速提升伤害的关键！'},
+    // [v2 模块化] 特殊槽解锁 (unlock_recall / unlock_multicast / unlock_split) 和
+    // 槽数 +1 (slot_expander) 已从遗物池移除，迁移到局内商店出售
+    // （详见 src/ui/run_shop.js 中 slot_unlock / slot_count 商品）。
     //  獨立元素遺物
     { id: 'cryo_stone', name: '永恆凍土', icon: '❄️', desc: '解鎖 [冰霜彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆冰霜彈珠；此 2 顆彈珠同化概率永久翻倍。', rarity: 'rare', effect: 'unlock_marble', marbleType: 'cryo', boost: 15, maxStacks: 1 },
     { id: 'pyro_stone', name: '不滅火種', icon: '🔥', desc: '解鎖 [火焰彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆火焰彈珠；此 2 顆彈珠同化概率永久翻倍。', rarity: 'rare', effect: 'unlock_marble', marbleType: 'pyro', boost: 15, maxStacks: 1 },
@@ -1370,18 +1342,10 @@ const RELIC_DB = [
     { id: 'prism_shard', name: '七彩稜鏡', icon: '🌈', desc: '解鎖 [彩虹彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆彩虹彈珠。', rarity: 'legendary', effect: 'unlock_marble', marbleType: 'rainbow', boost: 5, maxStacks: 1 },
     { id: 'russian_doll', name: '俄羅斯套娃', icon: '🪆', desc: '解鎖 [套娃彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆套娃彈珠。', rarity: 'legendary', effect: 'unlock_marble', marbleType: 'matryoshka', boost: 5, maxStacks: 1 },
 
-    // ==================== 钉盘形态遗物（异型布局）====================
-    // 每种只能获取一次（maxStacks: 1），均与行数遗物有联合效果
-    // 策略1：三角阵形 - 漏斗流（行越多三角越尖，弹珠越集中于底部中央）
-    { id: 'triangle_formation', name: '三角陣形', icon: '🔺', desc: '釘盤展開為三角形，頂行最寬，每行遞減 1 列。「漏斗共鳴」：弹珠碰撞屬性釘子時，20% 機率額外再收集一次該屬性。「底部倍率轉盤」：底部左右各有一個小型轉盤，弹珠落入即觸發；轉盤層次由內到外：空（高機率）→1x→2x→3x→5x（低機率），中獎後對已收集屬性翻倍。釘盤 +3 行。立刻觸發一次混沌精華。', rarity: 'rare', effect: 'board_layout_triangle', maxStacks: 1 },
-    // 策略2：菱形阵形 - 中段爆发流（行越多菱形越饱满，中段碰撞最频繁）
-    { id: 'diamond_formation', name: '菱形陣形', icon: '🔷', desc: '釘盤展開為菱形，前半段擴展、後半段收縮。「中段爆發」：弹珠碰撞菱形中段釘子時，充能計數額外 +1。「裂變回響」：中段屬性釘子被碰撞時，30% 機率在對角方向裂變出虚影釘子（半透明閃爍），弹珠碰撞虚影即額外收集一次該屬性。釘盤 +2 行。立刻觸發一次混沌精華。', rarity: 'legendary', effect: 'board_layout_diamond', maxStacks: 1 },
-    // 策略3：稀疏间隔 - 通道流（宽窄行交替，形成弹珠通道）
-    { id: 'sparse_interval', name: '稀疏間隔', icon: '〰️', desc: '偶數行正常列數，奇數行減 4 列形成寬窄通道。「通道蓄力」：弹珠穿越窄行未碰撞任何釘子時，下次碰撞收集的屬性等級 +1（加速蓄力後爆發）。「底部粉色陷阱」：最後兩行永遠交錯排列粉色釘子，弹珠落底前必經高彈性區域。釘盤 +4 行。立刻觸發一次混沌精華。', rarity: 'rare', effect: 'board_layout_sparse', maxStacks: 1 },
-    // 策略4：镜像同步 - 直线穿透流（列数减少但行对齐，弹珠更易直线下落）
-    { id: 'mirror_sync', name: '鏡像同步', icon: '🪞', desc: '收集階段：釘盤列數減少且對齊。釘子被同化/突變時，鏡像位置的釘子同步轉化；特殊槽位鏡像呈現（數量翻倍）。「鏡像裂分」：中軸線設有特殊鏡像釘（✦），弹珠撞擊後有 35% 機率在對稱位置複製出一顆相同速度的分身弹珠，分身弹珠的後續收集屬性歸入原弹珠。立刻觸發一次混沌精華。', rarity: 'legendary', effect: 'board_layout_mirror_sync', maxStacks: 1 },
-    // 策略5：宽窄交替 - 边缘捕获流（宽行捕获偏移弹珠，窄行提供通道）
-    { id: 'wide_narrow', name: '寬窄交替', icon: '📐', desc: '偶數行 +2 列，奇數行 -2 列，寬窄交替。「邊緣共振」：弹珠碰撞寬行邊緣釘子（列號 0/1 或倒數 0/1）時，65% 機率額外再收集一次該屬性。釘盤 +2 行。立刻觸發一次混沌精華。', rarity: 'common', effect: 'board_layout_wide_narrow', maxStacks: 1 },
+    // [v2 模块化] 旧的钉盘布局遗物（triangle_formation / diamond_formation /
+    // sparse_interval / mirror_sync / wide_narrow）已从遗物池移除，迁移为
+    // pinboard_modules.js 中的 triangle_module / diamond_module / sparse_module /
+    // mirror_module / wide_narrow_module，通过商店购买后挂载到模块槽位。
     // ==================== 属性弹珠解锁遗物 ====================
     // 效果：解锁该属性弹珠，立即触发一次混沌精华，并保证带有 2 颗该属性弹珠；同化概率永久翻倍
     { id: 'surge_bounce', name: '彈性潮涌', icon: '🔵', desc: '解鎖 [彈性彈珠]。立刻觸發一次混沌精華，並保證帶有 2 顆彈性彈珠；此 2 顆彈珠同化概率永久翻倍。', rarity: 'rare', effect: 'unlock_marble', marbleType: 'bounce', boost: 10, maxStacks: 1 },

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1635,24 +1635,7 @@ phase_gathering_getRandomPegType() {
             // round-start resolver 会在存档恢复时继续处理 pendingRoundStartRewards。
             this.sys_saveRunState();
 
-            // ==================== [v2 局内商店] 每 N 场战斗弹出一次 ====================
-            const cfg = CONFIG.gameplay || {};
-            const interval = cfg.runShopInterval || 2;
-            const curRound = this.round || 1;
-            const shouldOpenShop = (curRound > 0)
-                && (curRound % interval === 0)
-                && (this._runShopOpenedRound !== curRound)
-                && (typeof this.ui_showRunShop === 'function')
-                && !this._isTutorialRun
-                && !(this.ownedRelics && this.ownedRelics.includes('chaos_pact'));
-            if (shouldOpenShop) {
-                this._runShopOpenedRound = curRound;
-                this.ui_showRunShop(() => {
-                    this.sys_startRoundStartResolver();
-                });
-                return;
-            }
-
+            // [v2 局内商店] 不再每回合自动弹出；商店仅在「跳过遗物」(ui_skipRelic) 路径下打开。
             this.sys_startRoundStartResolver();
         }
     },

--- a/src/pinboard_modules.js
+++ b/src/pinboard_modules.js
@@ -280,6 +280,174 @@ export const MODULE_DEFS = {
     },
 };
 
+// ==================== [钉板形态遗物→模块] 由旧布局遗物迁移而来的模块 ====================
+// 旧的钉板布局/行数遗物（dimension_shard / dimension_crystal / triangle_formation /
+// diamond_formation / sparse_interval / mirror_sync / wide_narrow）在 v2 模块化下不再
+// 通过 boardLayout / currentRows 整体改写钉盘，而是改造为可在单个模块槽位内放置的模块。
+MODULE_DEFS.triangle_module = {
+    id: 'triangle_module',
+    name: '三角陣形',
+    icon: '🔺',
+    desc: '頂寬底窄的三角交錯，弹珠向中心聚焦。',
+    rarity: 'rare',
+    price: 60,
+    build(ox, oy, w, h) {
+        const pegs = generateFunnelPegs(ox, oy, w, h, 4, 4);
+        return { pegs, specialSlots: [] };
+    },
+};
+MODULE_DEFS.diamond_module = {
+    id: 'diamond_module',
+    name: '菱形陣形',
+    icon: '🔷',
+    desc: '上下窄、中段寬的菱形排布，中段碰撞密集。',
+    rarity: 'epic',
+    price: 80,
+    build(ox, oy, w, h) {
+        const pegs = [];
+        const rows = 5;
+        const spacingY = h / (rows + 0.5);
+        const widths = [2, 3, 4, 3, 2];
+        for (let r = 0; r < rows; r++) {
+            const colsThisRow = widths[r];
+            const spacingX = colsThisRow > 1 ? (w * 0.85) / colsThisRow : w * 0.85;
+            const baseLeftPad = (w - (colsThisRow - 1) * spacingX) / 2;
+            for (let c = 0; c < colsThisRow; c++) {
+                const x = ox + baseLeftPad + c * spacingX;
+                const y = oy + spacingY * 0.5 + r * spacingY;
+                const p = new Peg(x, y, 'normal');
+                p.row = r; p.col = c; p.level = 1;
+                pegs.push(p);
+            }
+        }
+        return { pegs, specialSlots: [] };
+    },
+};
+MODULE_DEFS.sparse_module = {
+    id: 'sparse_module',
+    name: '稀疏間隔',
+    icon: '〰️',
+    desc: '寬窄行交替形成通道；底部一排粉色高彈性釘子。',
+    rarity: 'rare',
+    price: 60,
+    build(ox, oy, w, h) {
+        const rows = 4;
+        const spacingY = h / (rows + 0.5);
+        const pegs = [];
+        for (let r = 0; r < rows; r++) {
+            const cols = (r % 2 === 0) ? 4 : 2;
+            const spacingX = cols > 1 ? w / cols : w;
+            const pad = (w - (cols - 1) * spacingX) / 2;
+            const isLastRow = r === rows - 1;
+            for (let c = 0; c < cols; c++) {
+                const x = ox + pad + c * spacingX;
+                const y = oy + spacingY * 0.5 + r * spacingY;
+                const p = new Peg(x, y, isLastRow ? 'pink' : 'normal');
+                p.row = r; p.col = c; p.level = 1;
+                pegs.push(p);
+            }
+        }
+        return { pegs, specialSlots: [] };
+    },
+};
+MODULE_DEFS.mirror_module = {
+    id: 'mirror_module',
+    name: '鏡像同步',
+    icon: '🪞',
+    desc: '左右對稱排列。中軸高彈釘子使弹珠頻繁鏡像反彈。',
+    rarity: 'epic',
+    price: 80,
+    build(ox, oy, w, h) {
+        const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
+        // 中轴（col=1）的钉子改为粉色高弹，模拟"镜像裂分"近似效果
+        for (const p of pegs) {
+            if (p.col === 1) p.type = 'pink';
+        }
+        return { pegs, specialSlots: [] };
+    },
+};
+MODULE_DEFS.wide_narrow_module = {
+    id: 'wide_narrow_module',
+    name: '寬窄交替',
+    icon: '📐',
+    desc: '偶數行寬、奇數行窄，邊緣捕獲偏離弹珠。',
+    rarity: 'common',
+    price: 40,
+    build(ox, oy, w, h) {
+        const rows = 4;
+        const spacingY = h / (rows + 0.5);
+        const pegs = [];
+        for (let r = 0; r < rows; r++) {
+            const cols = (r % 2 === 0) ? 5 : 2;
+            const spacingX = cols > 1 ? w / cols : w;
+            const pad = (w - (cols - 1) * spacingX) / 2;
+            for (let c = 0; c < cols; c++) {
+                const x = ox + pad + c * spacingX;
+                const y = oy + spacingY * 0.5 + r * spacingY;
+                const p = new Peg(x, y, 'normal');
+                p.row = r; p.col = c; p.level = 1;
+                pegs.push(p);
+            }
+        }
+        return { pegs, specialSlots: [] };
+    },
+};
+MODULE_DEFS.dim_shard_module = {
+    id: 'dim_shard_module',
+    name: '維度碎片',
+    icon: '🌌',
+    desc: '更高密度的 4×4 交錯釘子，碰撞次數倍增。',
+    rarity: 'rare',
+    price: 60,
+    build(ox, oy, w, h) {
+        const pegs = generateStaggeredPegs(ox, oy, w, h, 4, 4, 'normal');
+        return { pegs, specialSlots: [] };
+    },
+};
+MODULE_DEFS.dim_crystal_module = {
+    id: 'dim_crystal_module',
+    name: '維度結晶',
+    icon: '💠',
+    desc: '極高密度 5×5 交錯釘子，弹珠路徑充滿碰撞。',
+    rarity: 'legendary',
+    price: 120,
+    build(ox, oy, w, h) {
+        const pegs = generateStaggeredPegs(ox, oy, w, h, 5, 5, 'normal');
+        return { pegs, specialSlots: [] };
+    },
+};
+
+// ==================== [属性钉板] 商店随机属性钉板 ====================
+// 每个属性对应一个 attr_pin_<type> 模块，所有 normal 钉子被强制赋予该属性，
+// 且不参与 unlockedWeights 随机覆盖（applyWeightedPegTypes 仅替换 type === 'normal'）。
+export const ATTR_PIN_TYPES = ['bounce', 'pierce', 'scatter', 'damage', 'cryo', 'pyro', 'wind'];
+const ATTR_PIN_META = {
+    bounce: { name: '彈性釘板', icon: '🔵' },
+    pierce: { name: '穿透釘板', icon: '↗' },
+    scatter: { name: '散射釘板', icon: '🔱' },
+    damage: { name: '增幅釘板', icon: '⚔️' },
+    cryo:   { name: '冰霜釘板', icon: '❄️' },
+    pyro:   { name: '火焰釘板', icon: '🔥' },
+    wind:   { name: '疾風釘板', icon: '💨' },
+};
+ATTR_PIN_TYPES.forEach(type => {
+    const meta = ATTR_PIN_META[type];
+    MODULE_DEFS[`attr_pin_${type}`] = {
+        id: `attr_pin_${type}`,
+        name: meta.name,
+        icon: meta.icon,
+        desc: `3×3 釘板，全部釘子強制為「${type}」屬性。`,
+        rarity: 'rare',
+        price: 0, // 由商店动态定价；不通过通用 module 列表暴露
+        attribute: type,
+        isAttrPin: true,
+        build(ox, oy, w, h) {
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, type);
+            return { pegs, specialSlots: [] };
+        },
+    };
+});
+
 /**
  * 主入口：根据模块 ID 在指定矩形内构造实体集合
  */

--- a/src/ui/run_shop.js
+++ b/src/ui/run_shop.js
@@ -17,7 +17,7 @@
 
 import { CONFIG } from '../config.js';
 import { RUNE_DB } from '../rune_config.js';
-import { MODULE_DEFS } from '../pinboard_modules.js';
+import { MODULE_DEFS, ATTR_PIN_TYPES } from '../pinboard_modules.js';
 
 const RUNE_PRICE_BY_RARITY = {
     common: 18,
@@ -27,6 +27,36 @@ const RUNE_PRICE_BY_RARITY = {
 };
 
 const SLOT_EXPAND_PRICE = 100;
+
+// [v2] 旧的「特殊槽解锁/数量+1」遗物迁移到商店出售
+const SLOT_UNLOCK_PRICE = 60;
+const SLOT_COUNT_PRICE = 50;
+const SLOT_TYPE_META = {
+    recall:    { name: '解鎖回溯槽',  icon: '⏳', desc: '加入「回溯」特殊槽到鑒池。' },
+    multicast: { name: '解鎖連射槽',  icon: '♊', desc: '加入「連射」特殊槽到鑒池。' },
+    split:     { name: '解鎖分裂槽',  icon: '☢️', desc: '加入「分裂」特殊槽到鑒池。' },
+};
+
+// [v2] 属性钉板：商店随机刷新一个带某属性的钉板模块（按当前属性权重）
+const ATTR_PIN_PRICE = 70;
+const ATTR_PIN_LABEL = {
+    bounce: '彈性', pierce: '穿透', scatter: '散射',
+    damage: '增幅', cryo: '冰霜',   pyro: '火焰', wind: '疾風',
+};
+
+function rollAttributePinType(game) {
+    const weights = (game && game.unlockedWeights) || {};
+    const candidates = [];
+    let total = 0;
+    for (const t of ATTR_PIN_TYPES) {
+        const w = Math.max(0, weights[t] || 0);
+        if (w > 0) { candidates.push({ type: t, w }); total += w; }
+    }
+    if (total <= 0 || candidates.length === 0) return null;
+    let r = Math.random() * total;
+    for (const c of candidates) { if (r < c.w) return c.type; r -= c.w; }
+    return candidates[candidates.length - 1].type;
+}
 
 /**
  * 生成商品列表
@@ -38,8 +68,8 @@ function generateInventory(game, count) {
     const runeCount = Math.max(1, Math.floor(count * runesRatio));
     const moduleCount = count - runeCount;
 
-    // 模块商品：来自 MODULE_DEFS 中价格 > 0 且玩家未解锁的
-    const lockedModules = Object.values(MODULE_DEFS).filter(d => d.price > 0 && (!game.unlockedModuleTypes || !game.unlockedModuleTypes.includes(d.id)));
+    // 模块商品：来自 MODULE_DEFS 中价格 > 0 且玩家未解锁的（不含 attr_pin_*：那些由属性钉板分支独立刷新）
+    const lockedModules = Object.values(MODULE_DEFS).filter(d => d.price > 0 && !d.isAttrPin && (!game.unlockedModuleTypes || !game.unlockedModuleTypes.includes(d.id)));
     for (let i = 0; i < moduleCount && lockedModules.length > 0; i++) {
         const def = lockedModules[Math.floor(Math.random() * lockedModules.length)];
         items.push({ kind: 'module', moduleId: def.id, name: def.name, icon: def.icon, desc: def.desc, price: def.price });
@@ -49,6 +79,39 @@ function generateInventory(game, count) {
     const totalSlots = (cfg.moduleCols || 4) * (cfg.moduleRows || 3);
     if ((game.unlockedModuleSlots || cfg.moduleDefaultSlots || 3) < totalSlots) {
         items.push({ kind: 'slot_expand', name: '模块槽位 +1', icon: '⊞', desc: `当前 ${game.unlockedModuleSlots || cfg.moduleDefaultSlots || 3}/${totalSlots}`, price: SLOT_EXPAND_PRICE });
+    }
+
+    // [v2] 特殊槽解锁：未解锁的类型作为商品出售
+    const unlockedSlotSet = new Set(game.unlockedSlots || []);
+    for (const slotType of Object.keys(SLOT_TYPE_META)) {
+        if (!unlockedSlotSet.has(slotType)) {
+            const meta = SLOT_TYPE_META[slotType];
+            items.push({ kind: 'slot_unlock', slotType, name: meta.name, icon: meta.icon, desc: meta.desc, price: SLOT_UNLOCK_PRICE });
+        }
+    }
+    // [v2] 特殊槽数量 +1（最多 3）
+    if ((game.slotCount || 0) < 3) {
+        items.push({ kind: 'slot_count', name: '特殊槽數量 +1', icon: '🔨', desc: `當前 ${game.slotCount || 0}/3`, price: SLOT_COUNT_PRICE });
+    }
+
+    // [v2] 属性钉板：按当前属性权重随机刷出一个带属性的钉板模块
+    const attrPinType = rollAttributePinType(game);
+    if (attrPinType) {
+        const moduleId = `attr_pin_${attrPinType}`;
+        const def = MODULE_DEFS[moduleId];
+        const alreadyUnlocked = (game.unlockedModuleTypes || []).includes(moduleId);
+        if (def && !alreadyUnlocked) {
+            items.push({
+                kind: 'attr_pin',
+                moduleId,
+                attribute: attrPinType,
+                name: def.name,
+                icon: def.icon,
+                desc: `3×3 釘板，全部釘子為 [${ATTR_PIN_LABEL[attrPinType] || attrPinType}] 屬性。`,
+                price: ATTR_PIN_PRICE,
+                rarity: 'rare',
+            });
+        }
     }
 
     // 符文商品：从 RUNE_DB 随机抽
@@ -178,7 +241,7 @@ export const run_shop = {
             return;
         }
         const cfg = CONFIG.gameplay || {};
-        if (it.kind === 'module') {
+        if (it.kind === 'module' || it.kind === 'attr_pin') {
             if (!Array.isArray(this.unlockedModuleTypes)) this.unlockedModuleTypes = [];
             if (!this.unlockedModuleTypes.includes(it.moduleId)) {
                 this.unlockedModuleTypes.push(it.moduleId);
@@ -188,6 +251,16 @@ export const run_shop = {
             const totalSlots = (cfg.moduleCols || 4) * (cfg.moduleRows || 3);
             this.unlockedModuleSlots = Math.min(totalSlots, (this.unlockedModuleSlots || cfg.moduleDefaultSlots || 3) + 1);
             if (window.showToast) window.showToast(`钉板槽位 +1（当前 ${this.unlockedModuleSlots}/${totalSlots}）`);
+        } else if (it.kind === 'slot_unlock') {
+            if (!Array.isArray(this.unlockedSlots)) this.unlockedSlots = [];
+            if (!this.unlockedSlots.includes(it.slotType)) {
+                this.unlockedSlots.push(it.slotType);
+            }
+            if ((this.slotCount || 0) === 0) this.slotCount = 1;
+            if (window.showToast) window.showToast(`已解锁特殊槽: ${it.name}`);
+        } else if (it.kind === 'slot_count') {
+            this.slotCount = Math.min(3, (this.slotCount || 0) + 1);
+            if (window.showToast) window.showToast(`特殊槽數量 +1（當前 ${this.slotCount}/3）`);
         } else if (it.kind === 'rune') {
             if (!Array.isArray(this.runeInventory)) this.runeInventory = [];
             this.runeInventory.push({ id: it.runeId, level: 1 });


### PR DESCRIPTION
## Summary

按需求重构商店与遗物：

1. **商店不再每回合自动弹出**：移除 `game_phase.js` 中战斗结算后按 `runShopInterval` 触发的逻辑；商店仍保留「跳过遗物」(ui_skipRelic) 入口。
2. **旧钉板遗物移除并改造为模块**：`dimension_shard` / `dimension_crystal` / `triangle_formation` / `diamond_formation` / `sparse_interval` / `mirror_sync` / `wide_narrow` 从 `RELIC_DB` 移除，迁移为 `pinboard_modules.js` 中对应的钉板模块（`dim_shard_module` / `triangle_module` 等）；通过商店购买后挂载到模块槽位。`BOARD_STRUCTURE_RELICS` 集合保留为空，维持导出兼容。
3. **特殊槽遗物移到商店**：`unlock_recall` / `unlock_multicast` / `unlock_split` / `slot_expander` 从 `RELIC_DB` 移除；商店新增 `slot_unlock`（解锁回溯/连射/分裂槽）和 `slot_count`（特殊槽 +1）两类商品。
4. **属性钉板**：商店每次刷新按 `unlockedWeights` 中各属性权重抽取一个属性，提供对应的 3×3 全属性钉板模块（`attr_pin_<type>`）作为商品。

## 修改文件

- `src/game_phase.js` — 移除每回合商店触发块
- `src/config.js` — 删除旧钉板/特殊槽遗物条目；清空 `BOARD_STRUCTURE_RELICS`
- `src/pinboard_modules.js` — 新增 7 个旧布局对应模块 + 7 个属性钉板模块
- `src/ui/run_shop.js` — 新增 `slot_unlock` / `slot_count` / `attr_pin` 商品种类与购买逻辑

## Test plan

- [ ] 战斗结算后商店不再自动弹出；跳过遗物仍能打开商店
- [ ] 遗物选择池中已不出现 `dimension_*` / `*_formation` / `mirror_sync` / `wide_narrow` / `unlock_*` / `slot_expander`
- [ ] 商店中可看到并购买：解锁回溯/连射/分裂槽、特殊槽 +1、属性钉板
- [ ] 购买带属性钉板后，可在模块面板中放置；放置后该槽位生成对应属性的 3×3 钉子
- [ ] 已存在的存档（含旧钉盘遗物 ID）不会因移除条目而崩溃

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHbYUGN9fLeUgPKyC3uzso)_