### PR TITLE
fix: 修复交错钉板横向拼接第2行出现空格的问题

### DIFF
--- a/src/pinboard_modules.js
+++ b/src/pinboard_modules.js
@@ -85,8 +85,11 @@ function generateStaggeredPegs(originX, originY, w, h, cols, rows, type = 'norma
     const spacingY = effectiveRows > 1 ? (h / effectiveRows) : h;
     for (let r = 0; r < effectiveRows; r++) {
         const isOdd = r % 2 !== 0;
-        const colsThisRow = isOdd ? Math.max(1, effectiveCols - 1) : effectiveCols;
-        const baseLeftPad = (w - (colsThisRow - 1) * spacingX) / 2;
+        // 奇数行从左边缘起始（baseLeftPad=0），右边距=spacingX；
+        // 偶数行居中（baseLeftPad=spacingX/2），两侧各 spacingX/2。
+        // 两种情况下横向拼接缝隙均为 spacingX+moduleSpacingX，消除第2行空格。
+        const colsThisRow = effectiveCols;
+        const baseLeftPad = isOdd ? 0 : (w - (colsThisRow - 1) * spacingX) / 2;
         for (let c = 0; c < colsThisRow; c++) {
             const x = originX + baseLeftPad + c * spacingX;
             const y = originY + spacingY * 0.5 + r * spacingY;
@@ -259,8 +262,10 @@ export const MODULE_DEFS = {
                 const lastRow = pegs[pegs.length - 1].row;
                 const bottomRowPegs = pegs.filter(p => p.row === lastRow).sort((a, b) => a.pos.x - b.pos.x);
                 if (bottomRowPegs.length >= 2) {
-                    pegA = bottomRowPegs[0];
-                    pegB = bottomRowPegs[1];
+                    // 取中间两颗钉作为特殊槽锚点，确保槽居中显示
+                    const midIdx = Math.floor((bottomRowPegs.length - 1) / 2);
+                    pegA = bottomRowPegs[midIdx];
+                    pegB = bottomRowPegs[midIdx + 1];
                 }
             }
             const specialSlots = [];


### PR DESCRIPTION
## Summary

- **根本原因**：旧交错逻辑奇数行（第2行）使用 `cols-1` 个钉居中，两侧各留 `spacingX` 边距，导致横向模块拼接处 = `2×spacingX + moduleSpacingX`，而偶数行只有 `spacingX + moduleSpacingX`，第2行空格明显更宽。
- **修复方式**：奇数行改为同样 `effectiveCols` 个钉，从左边缘起始（`baseLeftPad = 0`），右边距 = `spacingX`。拼接缝隙：A右边距（`spacingX`）+ moduleSpacingX + B左边距（`0`）= `spacingX + moduleSpacingX`，与偶数行完全一致。
- **视觉保留**：奇数行仍整体偏移 `spacingX/2`，保持标准交错（diamond）布局，且每行钉子密度不变。
- **附带修复**：`fixed_slot` 模块取底部行中间两颗钉作为特殊槽锚点，避免奇数行新增钉子后槽偏移到左侧。

## Test plan

- [ ] 放置两个横向相邻的标准交错模块，确认第1行（偶数行）与第2行（奇数行）拼接处间距一致
- [ ] 检查 `bouncer`、`mirror_module`、`cryo_pyro_pair` 等依赖 `generateStaggeredPegs` 的模块视觉正常
- [ ] 确认 `fixed_slot` 的特殊槽（轮盘/连射/回溯）居中显示

https://claude.ai/code/session_01VERRJgcP2TdM4sQs3nZWj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VERRJgcP2TdM4sQs3nZWj6)_