### PR TITLE
优化符文发射器编辑体验

### DIFF
--- a/index.html
+++ b/index.html
@@ -2955,7 +2955,7 @@
             <div class="mb-4">
                 <div class="flex items-center justify-between mb-3">
                     <div class="text-xs text-slate-400/60 tracking-widest uppercase">符文庫存 <span id="rune-inventory-count" class="text-purple-300">(0)</span></div>
-                    <span id="rune-selected-count" class="text-xs text-slate-500">已选中 0/3</span>
+                    <span id="rune-placement-hint" class="text-xs text-slate-500">點擊符文選中，再點空格放置</span>
                 </div>
                 <div id="rune-inventory-container" class="flex flex-wrap gap-2 min-h-[60px] p-3 bg-slate-900/40 border border-slate-700/30 rounded-xl">
                     <!-- 库存符文由 JS 动态生成，支持点击选中/取消 -->
@@ -2996,13 +2996,24 @@
             <!-- 符文管理面板（熔炼 / 重铸） -->
             <div id="rune-management-panel" class="hidden">
                 <div class="text-xs text-slate-400/70 mb-3 leading-relaxed">
-                    在此頁面熔煉或重鑄符文。請先在「配置」頁面選中 3 個符文，再返回此頁執行操作。
+                    在此頁面選中 3 個符文後，可進行熔煉或重鑄操作。
                 </div>
 
                 <!-- 当前选中状态 -->
                 <div class="mb-4 px-3 py-2 bg-slate-900/40 border border-slate-700/40 rounded-lg flex items-center justify-between">
                     <span class="text-[11px] text-slate-400">當前選中</span>
-                    <span id="rune-management-selected-count" class="text-xs text-purple-300 font-bold">0 / 3</span>
+                    <div class="flex items-center gap-2">
+                        <span id="rune-management-selected-count" class="text-xs text-purple-300 font-bold">0 / 3</span>
+                        <button id="rune-management-clear-btn" onclick="game._selectedRuneIndices && game._selectedRuneIndices.clear(); game._ui_updateRuneInventoryDisplay && game._ui_updateRuneInventoryDisplay();" class="text-[10px] text-slate-400 hover:text-slate-200 underline">清除</button>
+                    </div>
+                </div>
+
+                <!-- 符文仓库（管理页专属选择列表） -->
+                <div class="mb-4">
+                    <div class="text-xs text-slate-400/60 tracking-widest uppercase mb-2">符文倉庫 <span id="rune-management-inventory-count" class="text-purple-300">(0)</span></div>
+                    <div id="rune-management-inventory" class="flex flex-wrap gap-2 min-h-[60px] p-3 bg-slate-900/40 border border-slate-700/30 rounded-xl">
+                        <div id="rune-management-inventory-empty" class="w-full text-center text-slate-600 text-xs py-2">暫無符文</div>
+                    </div>
                 </div>
 
                 <!-- 合成区域 -->
@@ -3041,9 +3052,16 @@
 
             <!-- 词条图鉴面板 -->
             <div id="rune-codex-panel" class="hidden">
-                <div class="flex items-center justify-between mb-4">
+                <div class="flex items-center justify-between mb-3">
                     <div class="text-xs text-slate-400/60 tracking-widest uppercase">詞條圖鑑</div>
                     <div class="text-xs text-purple-300/70">已發現 <span id="rune-codex-discovered-count" class="font-bold text-purple-200">0</span> / <span id="rune-codex-total-count" class="text-slate-400">0</span></div>
+                </div>
+                <!-- 按符文筛选 -->
+                <div class="mb-3">
+                    <div class="text-[10px] text-slate-500 mb-1.5">按符文篩選</div>
+                    <div id="rune-codex-filter-bar" class="flex flex-wrap gap-1.5">
+                        <!-- 由 JS 动态生成 -->
+                    </div>
                 </div>
                 <div id="rune-codex-list" class="space-y-3">
                     <!-- 由 JS 动态生成 -->

--- a/src/ui/rune_launcher.js
+++ b/src/ui/rune_launcher.js
@@ -168,6 +168,7 @@ export const rune_launcher_system = {
             if (panel2) panel2.style.overflow = '';
         }
          this._pendingRuneGridIndex = null;
+         this._pendingPlacementRuneIdx = null;
         // [BUGFIX] 关闭符文发射器面板时，恢复教程卡片和遮罩层的显示（与 ui_openRuneLauncher 中的隐藏操作对应）
         if (this._tutorialActive) {
             const tutCard = document.getElementById('tutorial-card');
@@ -231,6 +232,19 @@ export const rune_launcher_system = {
                     this.ui_updateRuneGrid();
                     // @section:rune_grid_remove_audio - 符文格移除音效（400Hz，轻柔确认）
                     audio.playTone(400, 'sine', 0.08, 0.15);
+                } else if (this._pendingPlacementRuneIdx != null) {
+                    // 空格 + 已选中库存符文：直接放置
+                    const pIdx = this._pendingPlacementRuneIdx;
+                    const pEntry = this.runeInventory[pIdx];
+                    if (pEntry) {
+                        this.runeInventory.splice(pIdx, 1);
+                        this.runeGrid[i] = pEntry;
+                        this._pendingPlacementRuneIdx = null;
+                        this.ui_updateRuneGrid();
+                        audio.playTone(600, 'sine', 0.1, 0.2);
+                    } else {
+                        this._pendingPlacementRuneIdx = null;
+                    }
                 } else {
                     // 空格：打开符文选择器
                     this._pendingRuneGridIndex = i;
@@ -253,6 +267,8 @@ export const rune_launcher_system = {
             if (window.showToast) showToast('库存中没有符文');
             return;
         }
+        // 打开 picker 时取消「待放置」状态，避免索引错位
+        this._pendingPlacementRuneIdx = null;
 
         const overlay = document.getElementById('rune-picker-overlay');
         const list = document.getElementById('rune-picker-list');
@@ -574,39 +590,137 @@ export const rune_launcher_system = {
      * @private
      */
     _ui_updateRuneInventoryDisplay() {
+        // 初始化选中状态
+        if (!this._selectedRuneIndices) this._selectedRuneIndices = new Set();
+        // 校验 _selectedRuneIndices 中的索引仍在范围内
+        const len = this.runeInventory ? this.runeInventory.length : 0;
+        for (const idx of Array.from(this._selectedRuneIndices)) {
+            if (idx >= len) this._selectedRuneIndices.delete(idx);
+        }
+        // 校验 pending 放置索引
+        if (this._pendingPlacementRuneIdx != null && this._pendingPlacementRuneIdx >= len) {
+            this._pendingPlacementRuneIdx = null;
+        }
+
+        this._ui_renderLauncherInventory();
+        this._ui_renderManagementInventory();
+        this._ui_updateRuneActionButtons();
+    },
+
+
+    /**
+     * 渲染发射器（配置 Tab）的符文库存
+     * 点击行为：选中符文进入「待放置」模式，再点 3×3 空格即放置
+     * @private
+     */
+    _ui_renderLauncherInventory() {
         const container = document.getElementById('rune-inventory-container');
         const countEl = document.getElementById('rune-inventory-count');
         const emptyEl = document.getElementById('rune-inventory-empty');
+        const hintEl = document.getElementById('rune-placement-hint');
         if (!container) return;
 
-        // 初始化选中状态
-        if (!this._selectedRuneIndices) this._selectedRuneIndices = new Set();  // [Mixin 正常用法：读取 Game 实例状态]
-
-        // 移除旧的符文按鈕（保留 empty 提示）
         Array.from(container.children).forEach(child => {
             if (child.id !== 'rune-inventory-empty') child.remove();
         });
 
-        if (countEl) countEl.textContent = `(${this.runeInventory.length})`;  // [Mixin 正常用法：读取 Game 实例状态]
+        if (countEl) countEl.textContent = `(${this.runeInventory.length})`;
 
-        if (!this.runeInventory || this.runeInventory.length === 0) {  // [Mixin 正常用法：读取 Game 实例状态]
+        if (!this.runeInventory || this.runeInventory.length === 0) {
             if (emptyEl) emptyEl.classList.remove('hidden');
-            // 清空选中状态
-            this._selectedRuneIndices.clear();  // [Mixin 正常用法：读取 Game 实例状态]
-            this._ui_updateRuneActionButtons();
+            if (hintEl) {
+                hintEl.textContent = '點擊符文選中，再點空格放置';
+                hintEl.className = 'text-xs text-slate-500';
+            }
             return;
         }
         if (emptyEl) emptyEl.classList.add('hidden');
 
-        this.runeInventory.forEach((runeEntry, idx) => {  // [Mixin 正常用法：读取 Game 实例状态]
-            // 兼容新旧格式：提取符文 ID
+        // 更新提示
+        if (hintEl) {
+            if (this._pendingPlacementRuneIdx != null) {
+                const pe = this.runeInventory[this._pendingPlacementRuneIdx];
+                const pid = getRuneId(pe);
+                const pdef = RUNE_DB.find(r => r.id === pid);
+                hintEl.textContent = pdef ? `已選中 ${pdef.name}，請點擊 3×3 空格放置` : '已選中符文，請點擊 3×3 空格放置';
+                hintEl.className = 'text-xs text-amber-300 font-bold';
+            } else {
+                hintEl.textContent = '點擊符文選中，再點空格放置';
+                hintEl.className = 'text-xs text-slate-500';
+            }
+        }
+
+        this.runeInventory.forEach((runeEntry, idx) => {
             const runeId = getRuneId(runeEntry);
             if (!runeId) return;
             const runeDef = RUNE_DB.find(r => r.id === runeId);
             if (!runeDef) return;
-            // 获取符文等级（新格式有 level，旧格式默认为 1）
             const runeLevel = (typeof runeEntry === 'object' && runeEntry.level) ? runeEntry.level : 1;
-            const isSelected = this._selectedRuneIndices.has(idx);  // [Mixin 正常用法：读取 Game 实例状态]
+            const isPending = this._pendingPlacementRuneIdx === idx;
+
+            const card = document.createElement('div');
+            card.className = [
+                'flex items-center gap-2 p-2 rounded-xl cursor-pointer select-none transition-all duration-150',
+                isPending
+                    ? 'bg-amber-700/30 border-2 border-amber-400/80 shadow-[0_0_8px_rgba(251,191,36,0.5)]'
+                    : 'bg-slate-800/60 border-2 border-slate-700/40 hover:border-amber-500/50',
+            ].join(' ');
+            card.innerHTML = `
+                <div class="w-10 h-10 flex items-center justify-center shrink-0" style="font-size:22px;">
+                    ${_ui_buildRuneIconHTML(runeDef, runeLevel)}
+                </div>
+                <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-1.5">
+                        <span class="text-xs font-bold text-purple-200 truncate">${runeDef.name}</span>
+                    </div>
+                    <div class="text-[9px] text-slate-500 truncate">${runeDef.element}</div>
+                </div>
+                ${isPending ? '<span class="text-amber-300 text-sm shrink-0">→</span>' : ''}
+            `;
+            card.addEventListener('click', () => {
+                if (this._pendingPlacementRuneIdx === idx) {
+                    this._pendingPlacementRuneIdx = null;
+                } else {
+                    this._pendingPlacementRuneIdx = idx;
+                }
+                this._ui_renderLauncherInventory();
+                try { audio.playTone(700, 'sine', 0.06, 0.08); } catch(e) {}
+            });
+            container.appendChild(card);
+        });
+    },
+
+
+    /**
+     * 渲染管理 Tab 的符文仓库（带多选用于熔炼/重铸）
+     * @private
+     */
+    _ui_renderManagementInventory() {
+        const container = document.getElementById('rune-management-inventory');
+        const countEl = document.getElementById('rune-management-inventory-count');
+        const emptyEl = document.getElementById('rune-management-inventory-empty');
+        if (!container) return;
+
+        Array.from(container.children).forEach(child => {
+            if (child.id !== 'rune-management-inventory-empty') child.remove();
+        });
+
+        if (countEl) countEl.textContent = `(${this.runeInventory.length})`;
+
+        if (!this.runeInventory || this.runeInventory.length === 0) {
+            if (emptyEl) emptyEl.classList.remove('hidden');
+            this._selectedRuneIndices.clear();
+            return;
+        }
+        if (emptyEl) emptyEl.classList.add('hidden');
+
+        this.runeInventory.forEach((runeEntry, idx) => {
+            const runeId = getRuneId(runeEntry);
+            if (!runeId) return;
+            const runeDef = RUNE_DB.find(r => r.id === runeId);
+            if (!runeDef) return;
+            const runeLevel = (typeof runeEntry === 'object' && runeEntry.level) ? runeEntry.level : 1;
+            const isSelected = this._selectedRuneIndices.has(idx);
 
             const card = document.createElement('div');
             card.className = [
@@ -628,18 +742,20 @@ export const rune_launcher_system = {
                 ${isSelected ? '<span class="text-purple-300 text-sm shrink-0">✓</span>' : ''}
             `;
             card.addEventListener('click', () => {
-                if (this._selectedRuneIndices.has(idx)) {  // [Mixin 正常用法：读取 Game 实例状态]
-                    this._selectedRuneIndices.delete(idx);  // [Mixin 正常用法：读取 Game 实例状态]
+                if (this._selectedRuneIndices.has(idx)) {
+                    this._selectedRuneIndices.delete(idx);
                 } else {
-                    this._selectedRuneIndices.add(idx);  // [Mixin 正常用法：读取 Game 实例状态]
+                    if (this._selectedRuneIndices.size >= 3) {
+                        if (window.showToast) showToast('最多選中 3 個符文');
+                        return;
+                    }
+                    this._selectedRuneIndices.add(idx);
                 }
-                this._ui_updateRuneInventoryDisplay();
+                this._ui_renderManagementInventory();
+                this._ui_updateRuneActionButtons();
             });
             container.appendChild(card);
         });
-
-        // 更新按鈕状态
-        this._ui_updateRuneActionButtons();
     },
 
 
@@ -853,14 +969,6 @@ export const rune_launcher_system = {
         if (!this._selectedRuneIndices) this._selectedRuneIndices = new Set();  // [Mixin 正常用法：读取 Game 实例状态]
         const selectedCount = this._selectedRuneIndices.size;  // [Mixin 正常用法：读取 Game 实例状态]
 
-        // 更新选中计数显示
-        const countEl = document.getElementById('rune-selected-count');
-        if (countEl) {
-            countEl.textContent = `已选中 ${selectedCount}/3`;
-            countEl.className = selectedCount > 0
-                ? 'text-xs text-purple-300 font-bold'
-                : 'text-xs text-slate-500';
-        }
         // 同步管理页选中计数
         const mgCountEl = document.getElementById('rune-management-selected-count');
         if (mgCountEl) {
@@ -1246,9 +1354,26 @@ export const rune_launcher_system = {
         if (discoveredCountEl) discoveredCountEl.textContent = discoveredCount;
         if (totalCountEl) totalCountEl.textContent = total;
 
+        // 渲染按符文筛选条
+        this._ui_renderCodexFilterBar();
+
+        // 应用筛选
+        const filterRune = this._codexRuneFilter || null;
+        const filteredDB = filterRune
+            ? RUNEWORD_DB.filter(rw => rw.pattern && rw.pattern.includes(filterRune))
+            : RUNEWORD_DB;
+
         list.innerHTML = '';
 
-        RUNEWORD_DB.forEach(rw => {
+        if (filteredDB.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'text-center text-slate-500 text-xs py-6';
+            empty.textContent = '此符文暫無相關詞條';
+            list.appendChild(empty);
+            return;
+        }
+
+        filteredDB.forEach(rw => {
             const isDiscovered = discovered.includes(rw.id);
             const card = document.createElement('div');
 
@@ -1325,6 +1450,49 @@ export const rune_launcher_system = {
             }
 
             list.appendChild(card);
+        });
+    },
+
+
+    /**
+     * 渲染图鉴的「按符文筛选」条
+     * 列出 RUNEWORD_DB pattern 中出现过的所有符文，每个一个芯片可切换筛选
+     * @private
+     */
+    _ui_renderCodexFilterBar() {
+        const bar = document.getElementById('rune-codex-filter-bar');
+        if (!bar) return;
+        bar.innerHTML = '';
+
+        // 收集所有出现在词条 pattern 中的符文 id（去重，按 RUNE_DB 顺序）
+        const usedIds = new Set();
+        RUNEWORD_DB.forEach(rw => (rw.pattern || []).forEach(rid => usedIds.add(rid)));
+        const orderedIds = RUNE_DB.filter(r => usedIds.has(r.id)).map(r => r.id);
+
+        const current = this._codexRuneFilter || null;
+
+        const makeChip = (label, runeId, iconHTML) => {
+            const isActive = current === runeId;
+            const btn = document.createElement('button');
+            btn.className = [
+                'flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold transition-all duration-150 border',
+                isActive
+                    ? 'bg-amber-600/70 text-amber-100 border-amber-400/60'
+                    : 'bg-slate-800/60 text-slate-400 border-slate-700/40 hover:bg-slate-700/60 hover:text-slate-200',
+            ].join(' ');
+            btn.innerHTML = (iconHTML ? iconHTML + ' ' : '') + `<span>${label}</span>`;
+            btn.onclick = () => {
+                this._codexRuneFilter = runeId;
+                this.ui_renderRuneCodex();
+            };
+            return btn;
+        };
+
+        bar.appendChild(makeChip('全部', null, ''));
+        orderedIds.forEach(rid => {
+            const rd = RUNE_DB.find(r => r.id === rid);
+            if (!rd) return;
+            bar.appendChild(makeChip(rd.name, rid, _ui_buildRuneIconHTML(rd, 1)));
         });
     },
 


### PR DESCRIPTION
## Summary
针对反馈整理的符文发射器三处 UX 改进：

- **配置 Tab 库存交互重构**：原本「在配置页库存里点击 = 多选用于熔炼/重铸」的语义会让"想把符文放进 3×3"的玩家迷惑。改为「点击符文 → 该符文进入待放置态 → 点击空格直接放入」的双向流程；同时空格仍可点击打开原 picker，互不冲突。顶部提示文案随状态切换。
- **管理 Tab 拥有独立符文仓库**：管理页新增 `#rune-management-inventory` 容器并把多选语义迁移到这里；玩家不再需要回到配置 Tab 选符文，再来管理 Tab 才能熔炼。
- **图鉴按符文筛选**：图鉴页顶部新增筛选条，列出 `RUNEWORD_DB.pattern` 中出现的所有符文，点击芯片即可过滤出含该符文的词条；带"全部"复位按钮。

## Test plan
- [ ] 配置 Tab：点击库存符文 → 提示变金色；再点空格 → 符文放入并清除待放置态
- [ ] 配置 Tab：直接点空格仍能弹出 picker
- [ ] 管理 Tab：库存独立显示，最多选 3 个；熔炼/重铸条件按选择联动
- [ ] 图鉴 Tab：点击某个符文芯片，列表只显示含该符文的词条；点"全部"复位

https://claude.ai/code/session_01Nii9sqqYrMQmTenbeMLBoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nii9sqqYrMQmTenbeMLBoa)_