### PR TITLE
fix: 回滚行间距变大 + 修正最小钉子间距公式

### DIFF
--- a/src/pinboard_modules.js
+++ b/src/pinboard_modules.js
@@ -24,10 +24,11 @@ import { Peg, SpecialSlot } from './entities.js';
 // 与 game_phase.phase_gathering_getRandomPegType 保持一致：laser / lightning 不生成钉子。
 const RANDOMIZABLE_PEG_TYPES = ['bounce', 'pierce', 'scatter', 'damage', 'cryo', 'pyro', 'wind'];
 
-// 倍化弹珠半径 = marbleRadius(7.7) + maxSizeBonus(2.5)；间距不得小于其直径，
-// 确保倍化弹珠能在相邻钉子间通过。
-const DOUBLED_MARBLE_RADIUS = 10.2;
-const MIN_PEG_SPACING = DOUBLED_MARBLE_RADIUS * 2; // 20.4 px，中心到中心最小间距
+// 倍化弹珠半径 = marbleRadius(7.7) + maxSizeBonus(2.5)
+const PEG_RADIUS = 6;               // 与 entities.js Peg.radius 一致
+const DOUBLED_MARBLE_RADIUS = 10.2; // marbleRadius(7.7) + maxSizeBonus(2.5)
+// 最小中心到中心间距 = 两侧钉子半径 + 倍化弹珠直径，确保倍化弹珠能通过
+const MIN_PEG_SPACING = 2 * PEG_RADIUS + 2 * DOUBLED_MARBLE_RADIUS; // = 32.4 px
 
 /**
  * 按当前局内属性权重随机生成 peg 类型。
@@ -80,9 +81,7 @@ function generateStaggeredPegs(originX, originY, w, h, cols, rows, type = 'norma
     const effectiveCols = cols > 1 ? Math.min(cols, Math.max(1, Math.floor(w / MIN_PEG_SPACING))) : 1;
     const effectiveRows = rows > 1 ? Math.min(rows, Math.max(1, Math.floor(h / MIN_PEG_SPACING))) : 1;
     const spacingX = effectiveCols > 1 ? (w / effectiveCols) : w;
-    // 用 h/rows（非 h/(rows+0.5)）使顶部和底部边距相等（均为 spacingY/2），
-    // 从而消除模块拼接处比模块内部多出半格的空隙。
-    const spacingY = effectiveRows > 1 ? (h / effectiveRows) : h;
+    const spacingY = effectiveRows > 1 ? (h / (effectiveRows + 0.5)) : h;
     for (let r = 0; r < effectiveRows; r++) {
         const isOdd = r % 2 !== 0;
         // 奇数行从左边缘起始（baseLeftPad=0），右边距=spacingX；
@@ -109,7 +108,7 @@ function generateStaggeredPegs(originX, originY, w, h, cols, rows, type = 'norma
 function generateFunnelPegs(originX, originY, w, h, topCols, rows) {
     const pegs = [];
     if (rows < 1) return pegs;
-    const spacingY = rows > 1 ? h / rows : h;
+    const spacingY = rows > 1 ? h / (rows + 0.5) : h;
     const maxColsForW = Math.max(1, Math.floor((w * 0.85) / MIN_PEG_SPACING));
     for (let r = 0; r < rows; r++) {
         const colsThisRow = Math.min(Math.max(1, topCols - r), maxColsForW);
@@ -322,7 +321,7 @@ MODULE_DEFS.diamond_module = {
     build(ox, oy, w, h) {
         const pegs = [];
         const rows = 5;
-        const spacingY = h / rows;
+        const spacingY = h / (rows + 0.5);
         const widths = [2, 3, 4, 3, 2];
         const maxColsForW = Math.max(1, Math.floor((w * 0.85) / MIN_PEG_SPACING));
         for (let r = 0; r < rows; r++) {
@@ -349,7 +348,7 @@ MODULE_DEFS.sparse_module = {
     price: 60,
     build(ox, oy, w, h) {
         const rows = 4;
-        const spacingY = h / rows;
+        const spacingY = h / (rows + 0.5);
         const maxCols = Math.max(1, Math.floor(w / MIN_PEG_SPACING));
         const pegs = [];
         for (let r = 0; r < rows; r++) {
@@ -393,7 +392,7 @@ MODULE_DEFS.wide_narrow_module = {
     price: 40,
     build(ox, oy, w, h) {
         const rows = 4;
-        const spacingY = h / rows;
+        const spacingY = h / (rows + 0.5);
         const maxCols = Math.max(1, Math.floor(w / MIN_PEG_SPACING));
         const pegs = [];
         for (let r = 0; r < rows; r++) {


### PR DESCRIPTION
## Summary

- **行间距过大（回滚）**：将 `spacingY = h/rows` 回滚为 `h/(rows+0.5)`（共5处），消除上次改动导致行间距比原来多17%的问题。
- **列间距公式修正**：旧 `MIN_PEG_SPACING = 2 × doubledMarbleRadius = 20.4` 漏掉了两侧钉子半径（各6px），允许4列时表面间隙只有9px，弹珠（直径15px）无法通过。新公式 `MIN_PEG_SPACING = 2×PEG_RADIUS + 2×DOUBLED_MARBLE_RADIUS = 32.4px`，确保倍化弹珠（直径20.4px）能在任意相邻钉子间通过。

## 实际效果

| 屏幕宽度 | 最大列数 | 列间距 | 表面间隙 |
|---|---|---|---|
| 375px | 2列 | ~42.9px | ~30.9px ✓ |
| 480px | 3列 | ~37.3px | ~25.3px ✓ |

## Test plan

- [ ] 各模块行间距与列间距视觉上接近，无"行稀疏列拥挤"的失衡感
- [ ] 装备「倍化之术」后，弹珠能在任意相邻钉子间正常通过，不卡死
- [ ] 375px 与 480px 屏幕下分别确认列数自动调整正确

https://claude.ai/code/session_01VERRJgcP2TdM4sQs3nZWj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VERRJgcP2TdM4sQs3nZWj6)_