### PR TITLE
fix(pegboard): 全部 12 槽显示 + 1.5 弹珠墙距 + 多格模块占位

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -751,11 +751,13 @@ const CONFIG = {
         // ==================== [v2 钉板模块化] 模块网格 ====================
         moduleCols: 4,                 // 模块网格列数
         moduleRows: 3,                 // 模块网格行数（共 12 槽）
-        moduleDefaultSlots: 3,         // 默认开放的模块槽位数（顶部第 1 行）
+        moduleDefaultSlots: 12,        // 默认开放的模块槽位数（全部 4×3 = 12 槽）
         moduleAreaTopY: 60,            // 模块区域起始 Y 坐标（画布顶部留白）
         moduleAreaBottomMargin: 80,    // 模块区域底部留白
         moduleSpacingX: 4,             // 模块横向间距 px
         moduleSpacingY: 4,             // 模块纵向间距 px
+        // 钉板左右两侧到画布墙的留白（每侧 1.5 个弹珠直径 = 1.5 × 2 × 7.7 ≈ 23 px）
+        moduleAreaSideMargin: 23,
         // ==================== [v2 局内商店 + 符文碎片经济] ====================
         runShopInterval: 2,            // 每 N 场战斗弹出一次局内商店
         runShopRefreshCost: 10,        // 刷新一次商店消耗碎片

--- a/src/core.js
+++ b/src/core.js
@@ -260,9 +260,12 @@ class Game {
 
         // ==================== [v2 钉板模块化] 模块系统状态 ====================
         this.unlockedModuleTypes = ['std_stagger', 'dense_stagger', 'bouncer', 'funnel'];
-        this.unlockedModuleSlots = 3;
-        this.currentModuleLayout = ['std_stagger', 'std_stagger', 'std_stagger',
-            null, null, null, null, null, null, null, null, null];
+        this.unlockedModuleSlots = 12;
+        this.currentModuleLayout = [
+            'std_stagger', 'std_stagger', 'std_stagger', 'std_stagger',
+            'std_stagger', 'std_stagger', 'std_stagger', 'std_stagger',
+            'std_stagger', 'std_stagger', 'std_stagger', 'std_stagger',
+        ];
         this.pendingFusions = [];
 
         // ==================== [v2 局内商店 + 符文碎片经济] ====================

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -19,7 +19,7 @@ import {
     getLayoutParams,
     getAllLayoutHints,
 } from './plinko_physics.js';
-import { buildModuleEntities, calcModuleSlotRect, MODULE_DEFS } from './pinboard_modules.js';
+import { buildModuleEntities, calcModuleSlotRect, MODULE_DEFS, getModuleSpan } from './pinboard_modules.js';
 
 export const game_phase = {
 /**
@@ -188,9 +188,14 @@ export const game_phase = {
         const slotsToBuild = Math.min(this.unlockedModuleSlots || cfg.moduleDefaultSlots || 3, totalSlots);
 
         for (let i = 0; i < slotsToBuild; i++) {
-            const moduleId = this.currentModuleLayout[i];
+            const entry = this.currentModuleLayout[i];
+            // 跳过空槽和被多格模块覆盖的非锚点槽（{ ref: anchorIdx }）
+            if (!entry) continue;
+            if (typeof entry === 'object' && entry.ref !== undefined) continue;
+            const moduleId = (typeof entry === 'string') ? entry : entry.id;
             if (!moduleId) continue;
-            const rect = calcModuleSlotRect(i, canvasWidth, canvasHeight, cfg);
+            const span = getModuleSpan(moduleId);
+            const rect = calcModuleSlotRect(i, canvasWidth, canvasHeight, cfg, span);
             const result = buildModuleEntities(moduleId, rect.x, rect.y, rect.w, rect.h, moduleBuildCtx, i);
             if (result.pegs && result.pegs.length > 0) {
                 for (const p of result.pegs) {

--- a/src/pinboard_modules.js
+++ b/src/pinboard_modules.js
@@ -184,11 +184,12 @@ export const MODULE_DEFS = {
         id: 'funnel',
         name: '漏斗',
         icon: '▽',
-        desc: '頂寬底窄的三角形交錯，弹珠向中央匯集。',
+        desc: '頂寬底窄的三角形交錯，弹珠向中央匯集。占用 2×1 槽。',
         rarity: 'common',
         price: 0,
+        span: { cols: 2, rows: 1 },
         build(ox, oy, w, h) {
-            const pegs = generateFunnelPegs(ox, oy, w, h, 4, 3);
+            const pegs = generateFunnelPegs(ox, oy, w, h, 6, 3);
             return { pegs, specialSlots: [] };
         },
     },
@@ -196,9 +197,10 @@ export const MODULE_DEFS = {
         id: 'wheel_module',
         name: '幸運轉盤',
         icon: '🎰',
-        desc: '在底部生成一個 [輪盤槽]，弹珠穿越時觸發屬性翻倍輪盤。',
+        desc: '在底部生成一個 [輪盤槽]，弹珠穿越時觸發屬性翻倍輪盤。占用 1×2 槽。',
         rarity: 'rare',
         price: 60,
+        span: { cols: 1, rows: 2 },
         build(ox, oy, w, h) {
             // 顶部一排普通钉子 + 底部两颗钉子之间夹一个 wheel slot
             const pegs = [];
@@ -481,26 +483,61 @@ export function buildModuleEntities(moduleId, originX, originY, width, height, c
 
 /**
  * 计算单个模块槽位的矩形（基于画布尺寸和 CONFIG.gameplay）
+ * span: { cols, rows } 多格模块占位（默认 1×1）
  */
-export function calcModuleSlotRect(slotIdx, canvasWidth, canvasHeight, cfg) {
+export function calcModuleSlotRect(slotIdx, canvasWidth, canvasHeight, cfg, span) {
     const cols = cfg.moduleCols || 4;
     const rows = cfg.moduleRows || 3;
     const topY = cfg.moduleAreaTopY || 60;
     const bottomMargin = cfg.moduleAreaBottomMargin || 80;
     const spacingX = cfg.moduleSpacingX || 4;
     const spacingY = cfg.moduleSpacingY || 4;
-    const totalW = canvasWidth - 20;
+    // 左右两侧距墙 1.5 个弹珠直径，使倍化弹珠不会与墙完全贴死
+    const sideMargin = (cfg.moduleAreaSideMargin != null) ? cfg.moduleAreaSideMargin : 23;
+    const totalW = canvasWidth - 2 * sideMargin;
     const totalH = Math.max(120, canvasHeight - topY - bottomMargin);
     const cellW = (totalW - (cols - 1) * spacingX) / cols;
     const cellH = (totalH - (rows - 1) * spacingY) / rows;
     const r = Math.floor(slotIdx / cols);
     const c = slotIdx % cols;
+    const sCols = (span && span.cols) ? span.cols : 1;
+    const sRows = (span && span.rows) ? span.rows : 1;
     return {
-        x: 10 + c * (cellW + spacingX),
+        x: sideMargin + c * (cellW + spacingX),
         y: topY + r * (cellH + spacingY),
-        w: cellW,
-        h: cellH,
+        w: cellW * sCols + spacingX * (sCols - 1),
+        h: cellH * sRows + spacingY * (sRows - 1),
     };
+}
+
+/**
+ * 获取模块的占位（多格）。默认 1×1。
+ */
+export function getModuleSpan(moduleId) {
+    const def = MODULE_DEFS[moduleId];
+    if (def && def.span) {
+        return { cols: def.span.cols || 1, rows: def.span.rows || 1 };
+    }
+    return { cols: 1, rows: 1 };
+}
+
+/**
+ * 给定锚点 slotIdx 和 span，返回所有覆盖到的 slot 索引（含锚点本身）。
+ * 若超出网格边界则返回 null。
+ */
+export function getCoveredSlots(anchorIdx, span, totalCols, totalRows) {
+    const sCols = (span && span.cols) ? span.cols : 1;
+    const sRows = (span && span.rows) ? span.rows : 1;
+    const ar = Math.floor(anchorIdx / totalCols);
+    const ac = anchorIdx % totalCols;
+    if (ar + sRows > totalRows || ac + sCols > totalCols) return null;
+    const out = [];
+    for (let r = 0; r < sRows; r++) {
+        for (let c = 0; c < sCols; c++) {
+            out.push((ar + r) * totalCols + (ac + c));
+        }
+    }
+    return out;
 }
 
 /**

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -2,7 +2,7 @@ import { eventBus, EVENT_TYPES } from './event_bus.js';
 import { RUNE_DB } from './rune_config.js';
 import { CONFIG, RELIC_DB } from './config.js';
 import { getAmmoIconSrcByKey } from './bitmap_icons.js';
-import { MODULE_DEFS, listAvailableModules } from './pinboard_modules.js';
+import { MODULE_DEFS, listAvailableModules, getModuleSpan, getCoveredSlots } from './pinboard_modules.js';
 import { fuseRuneIntoBoard, getRuneId } from './rune_system.js';
 import { showToast } from './utils/math_utils.js';
 
@@ -1710,7 +1710,11 @@ export const ui_system = {
         const selRune = state.selectedRuneIdx;
         const inventory = Array.isArray(this.runeInventory) ? this.runeInventory : [];
         const pendingFusions = Array.isArray(this.pendingFusions) ? this.pendingFusions : [];
-        const placedCount = layout.filter(Boolean).length;
+        // 锚点 = 字符串条目（多格模块的 ref 占位用 {ref} 表示）
+        const isAnchor = (e) => typeof e === 'string';
+        const isRef = (e) => e && typeof e === 'object' && e.ref !== undefined;
+        // 占用格子总数（含 ref），用于上限判断
+        const placedCount = layout.filter(e => e !== null && e !== undefined).length;
         const canPlaceMore = placedCount < unlockedSlots;
 
         // ---- 视口检测：决定结构变体（mobile / tablet / desktop） ----
@@ -1722,27 +1726,45 @@ export const ui_system = {
         overlay.classList.toggle('is-desktop', !isMobile && !isTablet);
 
         // ---- 钉板网格 ----
+        // 支持多格模块（span: {cols, rows}）：锚点用 string，被覆盖的格用 {ref: anchorIdx}。
         const gridCellsHtml = (() => {
             let html = '';
             for (let i = 0; i < totalSlots; i++) {
-                const moduleId = layout[i];
+                const entry = layout[i];
+                // 被多格模块覆盖的非锚点格不渲染按钮（由锚点的 grid-span 占据视觉位置）
+                if (isRef(entry)) continue;
+
+                const moduleId = isAnchor(entry) ? entry : null;
                 const def = moduleId ? MODULE_DEFS[moduleId] : null;
+                const span = def ? getModuleSpan(moduleId) : { cols: 1, rows: 1 };
+
                 const isPickPreview = !def && selModule && canPlaceMore;
                 const previewDef = isPickPreview ? MODULE_DEFS[selModule] : null;
+                const previewSpan = previewDef ? getModuleSpan(selModule) : { cols: 1, rows: 1 };
+
                 let cls = 'me-cell';
                 if (def) cls += ' is-placed';
                 else if (isPickPreview) cls += ' is-preview';
                 else if (!canPlaceMore) cls += ' is-full';
                 else cls += ' is-empty';
 
+                // 显式 grid 定位以兼容多格模块
+                const r = Math.floor(i / cols);
+                const c = i % cols;
+                const useSpan = def ? span : { cols: 1, rows: 1 };
+                const styleAttr = `grid-column: ${c + 1} / span ${useSpan.cols}; grid-row: ${r + 1} / span ${useSpan.rows};`;
+
                 let inner;
                 if (def) {
+                    const sizeTag = (span.cols > 1 || span.rows > 1) ? `<div class="me-cell-size">${span.cols}×${span.rows}</div>` : '';
                     inner = `<div class="me-cell-icon">${def.icon || '▦'}</div>
                         <div class="me-cell-name">${def.name}</div>
+                        ${sizeTag}
                         <div class="me-cell-action">点击移除</div>`;
                 } else if (isPickPreview && previewDef) {
+                    const sizeHint = (previewSpan.cols > 1 || previewSpan.rows > 1) ? ` (${previewSpan.cols}×${previewSpan.rows})` : '';
                     inner = `<div class="me-cell-icon me-cell-icon--preview">${previewDef.icon || '▦'}</div>
-                        <div class="me-cell-action me-cell-action--preview">点击放置</div>`;
+                        <div class="me-cell-action me-cell-action--preview">点击放置${sizeHint}</div>`;
                 } else if (canPlaceMore) {
                     inner = `<div class="me-cell-icon me-cell-icon--empty">＋</div>
                         <div class="me-cell-action">空槽</div>`;
@@ -1750,7 +1772,7 @@ export const ui_system = {
                     inner = `<div class="me-cell-icon me-cell-icon--full">·</div>
                         <div class="me-cell-action">已满</div>`;
                 }
-                html += `<button type="button" data-slot-idx="${i}" class="${cls}">${inner}</button>`;
+                html += `<button type="button" data-slot-idx="${i}" class="${cls}" style="${styleAttr}">${inner}</button>`;
             }
             return html;
         })();
@@ -1859,15 +1881,37 @@ export const ui_system = {
             cell.addEventListener('click', () => {
                 const idx = parseInt(cell.dataset.slotIdx, 10);
                 const st = this._moduleEditorState || {};
-                if (this.currentModuleLayout[idx]) {
-                    this.currentModuleLayout[idx] = null;
+                const layoutArr = this.currentModuleLayout;
+                const cur = layoutArr[idx];
+
+                // 点击 anchor → 移除该多格模块（清空所有覆盖格）
+                if (typeof cur === 'string') {
+                    const span = getModuleSpan(cur);
+                    const covered = getCoveredSlots(idx, span, cols, rows) || [idx];
+                    for (const ci of covered) layoutArr[ci] = null;
                 } else if (st.selectedModuleId) {
-                    const currentPlaced = (this.currentModuleLayout || []).filter(Boolean).length;
-                    if (currentPlaced >= unlockedSlots) {
-                        showToast(`已达放置上限 ${unlockedSlots} 个，请先移除一个`);
+                    // 放置：检查跨格不溢出 + 所有覆盖格为空 + 不超过上限
+                    const span = getModuleSpan(st.selectedModuleId);
+                    const covered = getCoveredSlots(idx, span, cols, rows);
+                    if (!covered) {
+                        showToast(`该模块占用 ${span.cols}×${span.rows} 格，超出网格边界`);
                         return;
                     }
-                    this.currentModuleLayout[idx] = st.selectedModuleId;
+                    for (const ci of covered) {
+                        if (layoutArr[ci] !== null && layoutArr[ci] !== undefined) {
+                            showToast('该位置已被其他模块占用');
+                            return;
+                        }
+                    }
+                    const currentPlaced = layoutArr.filter(e => e !== null && e !== undefined).length;
+                    if (currentPlaced + covered.length > unlockedSlots) {
+                        showToast(`已达放置上限 ${unlockedSlots} 格，请先移除一个`);
+                        return;
+                    }
+                    layoutArr[idx] = st.selectedModuleId;
+                    for (const ci of covered) {
+                        if (ci !== idx) layoutArr[ci] = { ref: idx };
+                    }
                 } else {
                     showToast('请先在"模块库"中选中一个模块');
                     return;


### PR DESCRIPTION
## 背景

针对钉板模块反馈的三个问题：

1. 目前除了第一行，其他行全都配置了不显示
2. 钉板模块左右两侧距离墙应该留出 1.5 个弹珠的距离
3. 类似漏斗/奖励之类的模块可以做成占位更多的模块（1×2 / 2×1）

## 修改

### 1. 默认开放全部 12 个模块槽位
- `CONFIG.gameplay.moduleDefaultSlots`: 3 → 12
- `core.js` 初始 `unlockedModuleSlots`: 3 → 12
- 默认 `currentModuleLayout` 全部填充 `std_stagger`，使 4×3 全部行可见

### 2. 1.5 弹珠墙距
- 新增 `CONFIG.gameplay.moduleAreaSideMargin = 23`（≈ 1.5 × 2 × marbleRadius(7.7)）
- `calcModuleSlotRect` 改用 `sideMargin` 替代写死的 10/20

### 3. 多格模块支持（span）
- `MODULE_DEFS` 新增可选 `span: { cols, rows }`，默认 1×1
- 漏斗 → 2×1（顶部加宽到 6 列），幸运转盘 → 1×2
- `calcModuleSlotRect(slotIdx, w, h, cfg, span)` 接受 span 计算多格矩形
- 新增工具：`getModuleSpan(id)`、`getCoveredSlots(anchor, span, cols, rows)`（越界返回 null）
- `currentModuleLayout` 支持 `{ ref: anchorIdx }` 表示被多格模块覆盖的非锚点格
- `phase_gathering_initPachinko_v2` 跳过 ref 槽，仅在锚点构建并使用对应 span 的矩形
- 编辑器 UI：
  - 多格模块按钮使用 `grid-column / grid-row` 跨格渲染，ref 格不渲染按钮
  - 放置时校验：越界、覆盖冲突、是否超过槽位上限（按格数）
  - 移除时清空全部覆盖格

## 自检

`getCoveredSlots` 边界用例：
- slot 0, 2×1 → `[0, 1]` ✓
- slot 3, 2×1 → `null`（列溢出）✓
- slot 8, 1×2 → `null`（行溢出）✓

`calcModuleSlotRect`：
- 1×1 @ 400×600：x=23（左墙距）
- 2×1 @ 400×600：宽度由 85.5 → 175

## 测试计划

- [ ] 进入收集阶段，确认全部 12 槽被构建（之前只有第一行）
- [ ] 钉板左右两侧距离画布墙 ≈ 23 px，倍化弹珠不会贴墙
- [ ] 编辑器：选中漏斗 → 在末列点击应提示越界；在前 3 列可放置，按钮跨 2 格
- [ ] 编辑器：选中幸运转盘 → 在最后一行点击应提示越界
- [ ] 多格模块点击移除可同时清空 ref 格


---
_Generated by [Claude Code](https://claude.ai/code/session_01XAjM4MpxqTNipYc5HrAUww)_