### PR TITLE
fix: boss animation, nail board second row, perf quality UI, enemy sprite/HP

### DIFF
--- a/index.html
+++ b/index.html
@@ -2052,6 +2052,35 @@
             border-color: #10b981;
             color: #34d399;
         }
+        .pause-perf-row {
+            display: flex;
+            align-items: center;
+            padding: 10px 14px;
+            border-radius: 10px;
+            background: rgba(30, 41, 59, 0.5);
+            border: 1px solid rgba(71, 85, 105, 0.3);
+            margin-bottom: 6px;
+            gap: 8px;
+        }
+        .pause-perf-row .ps-icon { font-size: 1.1rem; width: 24px; text-align: center; flex-shrink: 0; }
+        .pause-perf-row .ps-label { flex: 1; margin-left: 2px; font-size: 0.82rem; color: #cbd5e1; }
+        .pause-perf-btns { display: flex; gap: 5px; }
+        .pause-perf-btn {
+            font-size: 0.68rem;
+            background: rgba(71,85,105,0.5);
+            border: 1px solid #475569;
+            border-radius: 5px;
+            padding: 3px 9px;
+            color: #94a3b8;
+            cursor: pointer;
+            transition: all 0.15s;
+        }
+        .pause-perf-btn:hover { background: rgba(51, 65, 85, 0.9); color: #cbd5e1; }
+        .pause-perf-btn.active {
+            background: rgba(16, 185, 129, 0.2);
+            border-color: #10b981;
+            color: #34d399;
+        }
         .pause-relic-card {
             display: flex;
             align-items: flex-start;
@@ -3468,6 +3497,16 @@
                         <span class="ps-badge" id="pause-crt-badge">关闭</span>
                     </div>
 
+                    <div class="pause-perf-row">
+                        <span class="ps-icon">⚡</span>
+                        <span class="ps-label">渲染品质</span>
+                        <div class="pause-perf-btns">
+                            <button class="pause-perf-btn" id="pause-perf-low"  onclick="game.sys_setPerfQuality('low')">低</button>
+                            <button class="pause-perf-btn" id="pause-perf-medium" onclick="game.sys_setPerfQuality('medium')">中</button>
+                            <button class="pause-perf-btn" id="pause-perf-high" onclick="game.sys_setPerfQuality('high')">高</button>
+                            <button class="pause-perf-btn" id="pause-perf-auto" onclick="game.sys_setPerfQuality('auto')">自动</button>
+                        </div>
+                    </div>
 
                 </div>
 

--- a/src/core.js
+++ b/src/core.js
@@ -355,6 +355,8 @@ class Game {
         this._perfDownTimer = 0;
         // 升级计时器（秒）：连续高帧时累加，达到阈值才真正升级
         this._perfUpTimer = 0;
+        // 手动性能模式：null = 自动自适应；'high'|'medium'|'low' = 手动锁定
+        this._perfManualMode = null;
         // [Phase 5B] 预加载所有 Sprite Sheet（在游戏循环开始前触发异步加载）
         preloadAllSprites();
         // 启动游戏主循环

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -2384,10 +2384,9 @@ class Enemy {
         }
 
         // === [Phase 5B Task 5.B3] Layer 3.95: Sprite Sheet 覆盖层（在血条和内部特效之后）===
-        // Arc Boss 的 sprite 需在 clip 区域外绘制（否则被圆环裁剪），此处跳过它们
-        // 非 arc boss 的 sprite 在 clip 内正常绘制
-        if (this._spriteRenderer && this._spriteRenderer.ready &&
-            !(this.type === 'boss' && this.collisionShape === 'arc')) {
+        // Boss 的 sprite 统一由 _drawBossDecoration 在 Layer 3.8 绘制，此处跳过所有 boss
+        // Arc Boss 的 sprite 另在 Layer 3.95b 裁剪区域外绘制
+        if (this._spriteRenderer && this._spriteRenderer.ready && this.type !== 'boss') {
             // [V2 资源协议] 大型基底（cols 或 rows >= 2）需用整个占格作为绘制区，
             // 避免 min(w,h) 把 3×1 装甲横梁压成中央小方块；小型敌人保留原行为。
             const isLargeV2 = !!this.baseArchetype && ((this.gridCols || 1) > 1 || (this.gridRows || 1) > 1);
@@ -2396,7 +2395,7 @@ class Enemy {
                 this._spriteRenderer.draw(ctx, -w/2 + padX, -h/2 + padY, w - padX*2, h - padY*2, 0.92);
             } else {
                 const sprSize1 = Math.min(w, h);
-                const sprOffsetY1 = h * 0.15;
+                const sprOffsetY1 = h * -0.1;
                 this._spriteRenderer.draw(ctx, -sprSize1/2, -sprSize1/2 + sprOffsetY1, sprSize1, sprSize1, 0.85);
             }
         }
@@ -2735,10 +2734,10 @@ class Enemy {
         // 文字层：保留血量数字显示
         // [修复] 即使被冻结也显示生命值数字，除非生命值为 0
         if (this.displayHp > 0) {
-            ctx.fillStyle = '#fff'; ctx.font = 'bold 14px sans-serif'; 
-            ctx.textAlign = 'center'; ctx.textBaseline = 'middle'; 
+            ctx.fillStyle = '#fff'; ctx.font = 'bold 14px sans-serif';
+            ctx.textAlign = 'center'; ctx.textBaseline = 'top';
             if (this.displayHp > this.hp + 1) ctx.fillStyle = '#fca5a5';
-            ctx.fillText(Math.ceil(this.displayHp), 0, 2);
+            ctx.fillText(Math.ceil(this.displayHp), 0, -h/2 + 3);
         }
         
         // 受击闪白
@@ -4747,11 +4746,8 @@ class Enemy {
         // Sprite 不替换矢量装饰，而是与其叠加（矢量层提供动态效果，Sprite 层提供角色外观）
         // 这里的 SpriteRenderer.draw() 在 Layer 3.8 调用，已在 ctx.save()/restore() 块内
         if (this._spriteRenderer && this._spriteRenderer.ready) {
-            // Boss Sprite 保持正方形比例（取 min(w,h) 作为边长），居中偏下绘制
-            // Boss 贴图同样偏下，与普通/精英敌人保持视觉一致性
-            const sprSize2 = Math.min(w, h);
-            const sprOffsetY2 = h * 0.15; // 向下偏移量
-            this._spriteRenderer.draw(ctx, -sprSize2/2, -sprSize2/2 + sprOffsetY2, sprSize2, sprSize2, 0.7);
+            // Boss Sprite 填充整个实体区域，确保动画帧在正确位置显示
+            this._spriteRenderer.draw(ctx, -w/2, -h/2, w, h, 0.85);
         }
 
         const t = Date.now() / 1000;

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -42,7 +42,8 @@ export const game_system = {
                 this.avgFps = Math.round(1000 / _avgDt);
 
                 // 仅在采样窗口满后才开始评估等级（避免启动时误判）
-                if (_samples.length >= _perfCfg.fpsSampleWindow) {
+                // 手动模式下跳过自适应调整
+                if (_samples.length >= _perfCfg.fpsSampleWindow && !this._perfManualMode) {
                     const _dtSec = _dt / 1000; // 本帧时长（秒），用于计时器累加
                     const _level = this.perfQualityLevel;
 
@@ -431,11 +432,12 @@ export const game_system = {
 
         // ==================== [v2 钉板模块化] 模块系统状态 ====================
         // 钉板由 4×3 = 12 个模块槽组成，按 row-major 顺序解锁
-        // 默认开放第 1 行 3 个槽，预填 std_stagger
+        // 默认开放全部 12 个槽，预填 std_stagger
         this.unlockedModuleTypes = ['std_stagger', 'dense_stagger', 'bouncer', 'funnel'];
-        this.unlockedModuleSlots = 3;
-        this.currentModuleLayout = ['std_stagger', 'std_stagger', 'std_stagger',
-            null, null, null, null, null, null, null, null, null];
+        this.unlockedModuleSlots = CONFIG.gameplay.moduleDefaultSlots || 12;
+        this.currentModuleLayout = new Array(
+            (CONFIG.gameplay.moduleCols || 4) * (CONFIG.gameplay.moduleRows || 3)
+        ).fill('std_stagger');
         // pendingFusions: 模块编辑器关闭时写入；phase_gathering_initPachinko 末尾消费
         // 形如 [{ element: 'pyro', count: 1, runeUid: '...' }]
         this.pendingFusions = [];
@@ -484,6 +486,26 @@ export const game_system = {
         } catch (e) {
             console.error('[sys_saveData] Save failed:', e);
         }
+    },
+
+    /**
+     * 手动设置渲染性能等级
+     * @param {'low'|'medium'|'high'|'auto'} level
+     */
+    sys_setPerfQuality(level) {
+        const perfCfg = CONFIG.performance;
+        if (level === 'auto') {
+            this._perfManualMode = null;
+            this._perfDownTimer = 0;
+            this._perfUpTimer = 0;
+        } else if (perfCfg[level]) {
+            this._perfManualMode = level;
+            this.perfQualityLevel = level;
+            this.shadowBlurEnabled = perfCfg[level].shadowBlurEnabled !== false;
+            this._perfDownTimer = 0;
+            this._perfUpTimer = 0;
+        }
+        if (typeof this.ui_syncPauseSettings === 'function') this.ui_syncPauseSettings();
     },
 
     /**

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -1602,6 +1602,15 @@ export const ui_system = {
 
     ui_syncPauseSettings() {
         if (typeof this.ui_renderPauseRelics === 'function') this.ui_renderPauseRelics();
+        // 同步渲染品质按钮高亮
+        const activeLevel = this.perfQualityLevel;
+        const isAuto = !this._perfManualMode;
+        ['low', 'medium', 'high', 'auto'].forEach(id => {
+            const btn = document.getElementById(`pause-perf-${id}`);
+            if (!btn) return;
+            const isActive = id === 'auto' ? isAuto : (!isAuto && id === activeLevel);
+            btn.classList.toggle('active', isActive);
+        });
     },
     ui_renderPauseRelics() {
         const list = document.getElementById('pause-relic-list');


### PR DESCRIPTION
## Summary

- **Fix 1 — Boss #1 (ignis) sprite animation glitch**: The sprite was being drawn twice per frame — once in `_drawBossDecoration` (Layer 3.8, alpha 0.7) and again in Layer 3.95 (alpha 0.85, condition only excluded arc-shape bosses). Consolidated to a single draw in `_drawBossDecoration` using full entity bounds `(-w/2, -h/2, w, h)` instead of a misaligned square offset.
- **Fix 2 — Nail board second row not appearing**: `game_system.js` run init was hardcoding `unlockedModuleSlots = 3` and filling only the first 3 slots of `currentModuleLayout`, overriding core.js's value of 12. Now uses `CONFIG.gameplay.moduleDefaultSlots` (12) and fills all 12 slots with `'std_stagger'`.
- **Fix 3 — Manual render quality setting**: Added `sys_setPerfQuality('low'|'medium'|'high'|'auto')` method; adaptive auto-adjust loop is skipped when `_perfManualMode` is set; pause panel gets a 4-button row (低/中/高/自动) with active-state highlighting via `ui_syncPauseSettings`.
- **Fix 4 — Enemy sprite/HP text positioning**: Non-boss sprite vertical offset changed from `+0.15h` (downward) to `-0.1h` (upward); HP number changed from `textBaseline='middle'` centered at y=2 to `textBaseline='top'` at y=`-h/2+3` (top-aligned).

## Test plan

- [ ] Start a run, reach boss #1 (ignis) — verify sprite is stable (no rightward sliding animation)
- [ ] Open nail board editor, configure modules in rows 2 and 3 — verify they appear in the pachinko phase
- [ ] Open pause panel during a run — verify 低/中/高/自动 buttons appear; clicking each changes quality immediately and highlights the active button
- [ ] Observe normal/elite enemies — verify sprite is positioned slightly higher; HP number appears at top of the entity card

https://claude.ai/code/session_01XN9iz56otntd13DB1rAfpC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN9iz56otntd13DB1rAfpC)_