### PR TITLE
fix(projectile): 优化子弹反弹算法 — 防穿模 & 修复连续反弹回原物体被忽略

### DIFF
--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -289,6 +289,10 @@ class Projectile {
 
         if (hitResult) {
             const { closestX, closestY, distSq, distVecX, distVecY, normal: shapeNormal } = hitResult;
+            // [反弹算法优化] 命中冷却仅作用于"最近一次接触的同一目标"，
+            // 防止同一帧/连续子步内对同一敌人重复结算（数值稳定性）。
+            // 一旦子弹接触了任何其他敌人或墙壁（见反弹分支与 _applyMove 中的 hitCooldowns.clear），
+            // 该冷却即被清除——这样"反弹 A → 反弹 B → 回到 A"会正确再次反弹，而非穿过。
             if (this.hitCooldowns.has(e)) return;
             this.hitCooldowns.set(e, CONFIG.gameplay.hitCooldowns);
             this.lastHitEnemy = e;
@@ -436,8 +440,9 @@ class Projectile {
                     normal = new Vec2(distVecX / dist, distVecY / dist);
                 }
 
-                // 位置修正 (Push Out)：将子弹推离敌人表面
-                const pushOutDist = this.radius + 0.1;
+                // [反弹算法优化] 位置修正 (Push Out)：使用更大的安全间隙，
+                // 避免高速反弹时下一子步因浮点误差/外力（gravityWell 等）再次穿入。
+                const pushOutDist = this.radius + 1.0;
                 this.pos.x = closestX + normal.x * pushOutDist;
                 this.pos.y = closestY + normal.y * pushOutDist;
 
@@ -446,6 +451,23 @@ class Projectile {
                 if (dot < 0) {
                     this.vel = this.vel.sub(normal.mult(2 * dot));
                 }
+
+                // [反弹算法优化] 反向速度下限：保证反弹后法向分量足够大，
+                // 防止切向滑过 + 微小法向速度时被外力反向拉回造成穿模/粘连。
+                const outwardSpeed = this.vel.x * normal.x + this.vel.y * normal.y;
+                const minOutward = Math.max(0.5, this.radius * 0.15);
+                if (outwardSpeed < minOutward) {
+                    const correction = minOutward - outwardSpeed;
+                    this.vel.x += normal.x * correction;
+                    this.vel.y += normal.y * correction;
+                }
+
+                // [反弹算法优化] 反弹后清除其他敌人的命中冷却，仅保留对当前敌人 e 的冷却。
+                // 语义：子弹"接触了一个新物体"，与所有先前敌人之间的关系即被重置；
+                // 因此再次接触它们时会正常反弹/造成伤害，而不是被旧冷却误判为可穿过。
+                const _selfCd = this.hitCooldowns.get(e);
+                this.hitCooldowns.clear();
+                if (_selfCd != null) this.hitCooldowns.set(e, _selfCd);
 
                 // 视觉挤压效果
                 this.deformation = { x: 1.3, y: 0.7 };
@@ -563,6 +585,9 @@ class Projectile {
                 const wallShake = (2 + Math.min(1, this.config.damage / 20) * 5) * 0.6; // 1.2~4.2px
                 game.triggerScreenShake(wallShake);
             }
+            // [反弹算法优化] 接触墙壁视为"接触新物体"，重置敌人冷却，
+            // 保证墙弹回后再撞同一敌人能正常反弹。
+            this.hitCooldowns.clear();
             if (handleRelicWallHit('top')) return;
         }
         if (this.pos.y > height - this.radius) {


### PR DESCRIPTION
## 背景
两个反弹相关问题：
1. **快速反弹下穿模**：高速子弹反弹时下一子步可能再次穿入敌人。
2. **回弹被误判为穿过**：子弹反弹 A → 反弹 B → 短时间内回到 A 时，A 的命中冷却尚未结束（17 帧），子弹被错误地"穿过"而非再次反弹。

## 修改 (`src/entities/projectile.js`)
- **位置推离增大**：`pushOutDist` 从 `radius + 0.1` 提升到 `radius + 1.0`。
- **最小法向出射速度**：反弹后若法向分量 < `max(0.5, radius*0.15)`，沿法线方向补足，防止 gravityWell 等外力把子弹拉回穿入。
- **冷却语义重做**：反弹时清空其他敌人的 `hitCooldowns`，只保留当前敌人的冷却。"接触任何新物体即重置先前 stale 冷却"——这样 A→B→A 路径下回到 A 能正常再次反弹。
- **顶墙一致化**：顶部墙壁反弹同样 `hitCooldowns.clear()`，与左/右/底墙保持一致（之前漏写）。

## 测试计划
- [ ] 高速 bounce 子弹（多层 kinetic_surge / 高伤害）多次反弹不再穿模
- [ ] 在两个相邻敌人之间快速来回反弹，每次接触都正确反弹与造成伤害
- [ ] 普通单次反弹、墙壁反弹、polygon/arc 形状敌人反弹无回归
- [ ] pierce 子弹穿透行为不变（pierce 分支未受影响）

https://claude.ai/code/session_01WN4g6PhU4B5SWAucaw9GPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN4g6PhU4B5SWAucaw9GPj)_