### PR TITLE
Fix enemy hit flash + enforce bullet hold cap of 3

### DIFF
--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -70,7 +70,8 @@ class Enemy {
         this.type = type;
         this.affixes = affixes;
         // [架构] elite/boss 由 spawn_system.js 通过 e.type 直接赋值，不再从 affixes 隐式转换
-        this.hitTimer = 0; 
+        this.hitTimer = 0;
+        this._hitFlashTimer = 0;
         this.dropTargetY = y; 
         this.justSpawned = true; 
         this.temp = 0; 
@@ -371,6 +372,7 @@ class Enemy {
             // 保持在入场起始位置（屏幕外），不执行任何移动逻辑
             this.pos.y = this._entranceStartY;
             if (this.hitTimer > 0) this.hitTimer -= timeScale;
+            if (this._hitFlashTimer > 0) this._hitFlashTimer -= timeScale;
             if (this.shieldHitTimer > 0) this.shieldHitTimer -= timeScale;
             if (this._hitImpact > 0) this._hitImpact *= Math.pow(CONFIG.enemyRender.hitImpactDecay, timeScale);
             return;
@@ -399,6 +401,7 @@ class Enemy {
             if (this.entranceTimer <= 0) this.entranceTimer = 0;
             // 入场动画期间不进行其他移动逻辑
             if (this.hitTimer > 0) this.hitTimer -= timeScale;
+            if (this._hitFlashTimer > 0) this._hitFlashTimer -= timeScale;
             if (this.shieldHitTimer > 0) this.shieldHitTimer -= timeScale;
             if (this._hitImpact > 0) this._hitImpact *= Math.pow(CONFIG.enemyRender.hitImpactDecay, timeScale);
             return;
@@ -411,6 +414,7 @@ class Enemy {
         }
         
         if (this.hitTimer > 0) this.hitTimer -= timeScale;
+        if (this._hitFlashTimer > 0) this._hitFlashTimer -= timeScale;
         if (this.shieldHitTimer > 0) this.shieldHitTimer -= timeScale;
         // === A3: 受击形变弹性衰减 ===
         if (this._hitImpact > 0) this._hitImpact *= Math.pow(CONFIG.enemyRender.hitImpactDecay, timeScale);
@@ -1343,6 +1347,7 @@ class Enemy {
 
     playBurnTickEffect(game, dmg) {
         this.hitTimer = 15;
+        this._hitFlashTimer = 4;
         for(let i=0; i<8; i++) game.spawn_createParticle(this.pos.x, this.pos.y, '#f97316', 'spark');
         for(let i=0; i<3; i++) game.spawn_createParticle(this.pos.x, this.pos.y, 'rgba(0,0,0,0.6)', 'smoke');
         game.spawn_createFloatingText(this.pos.x, this.pos.y, `🔥-${dmg}`, '#fbbf24');
@@ -2739,9 +2744,9 @@ class Enemy {
             ctx.fillText(Math.ceil(this.displayHp), 0, -h/2 + 3);
         }
         
-        // 受击闪白
-        if (this.hitTimer > 0) {
-            ctx.fillStyle = `rgba(255, 255, 255, ${this.hitTimer / 10 * 0.6})`;
+        // 受击闪白 - 使用独立的短时计时器，确保只闪一下而非持续白色
+        if (this._hitFlashTimer > 0) {
+            ctx.fillStyle = `rgba(255, 255, 255, ${(this._hitFlashTimer / 4) * 0.8})`;
             ctx.fillRect(-w/2, -h/2, w, h);
         }
 
@@ -4365,8 +4370,9 @@ class Enemy {
         }
 
           // 4. 执行扣血
-        this.hp -= actualDamage; 
-        this.hitTimer = 10; 
+        this.hp -= actualDamage;
+        this.hitTimer = 10;
+        this._hitFlashTimer = 4;
         this.whiteBarTimer = 45;
         // === A3: 记录受击形变强度 ===
         if (this.maxHp > 0) {

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -864,6 +864,11 @@ phase_gathering_getRandomPegType() {
             this.ammoQueue = [...this._carryOverAmmo, ...this.ammoQueue];
             this._carryOverAmmo = null;
         }
+        // 子弹持有上限：基础 3 颗，特殊遗物可通过 bulletCapBonus 增加
+        const _bulletCap = (CONFIG.gameplay.selectionReq || 3) + (this.bulletCapBonus || 0);
+        if (this.ammoQueue.length > _bulletCap) {
+            this.ammoQueue = this.ammoQueue.slice(0, _bulletCap);
+        }
         // [perfect-clear-upgrade] 重置「本回合是否已触发蓄能升级」标志
         this._chargeUpgradeApplied = false;
         // [in-wall-clear-lottery] 重置「本回合是否已触发围墙清空抽奖」标志

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -328,6 +328,7 @@ export const game_system = {
         this.doubleAssimilationBoostRounds = {};
         this.pendingSelectionMode = null;
         this.selectionMode = 'standard';
+        this.bulletCapBonus = 0;
         this.selectionRequiredCount = CONFIG.gameplay.selectionReq || 3;
         this.selectionInjectedRune = null;
         this.selectionPreviewState = null;
@@ -629,7 +630,7 @@ export const game_system = {
         // 确保 phase_switchPhase 内部触发的 ui_updateUI 能读到正确状态，
         // 避免渲染出旧的命运选择界面（如上一次的 chaos_essence / pure_essence 卡片）。
         this.selectionMode = mode;
-        this.selectionRequiredCount = Math.max(1, pendingMode?.requiredCount || CONFIG.gameplay.selectionReq || 3);
+        this.selectionRequiredCount = Math.max(1, pendingMode?.requiredCount || (CONFIG.gameplay.selectionReq || 3) + (this.bulletCapBonus || 0));
         this.fateMomentContext = this.selectionMode === 'standard'
             ? null
             : {
@@ -891,7 +892,7 @@ export const game_system = {
             phase: this.phase,
         });
         this.selectionMode = mode;
-        this.selectionRequiredCount = Math.max(1, pendingMode?.requiredCount || CONFIG.gameplay.selectionReq || 3);
+        this.selectionRequiredCount = Math.max(1, pendingMode?.requiredCount || (CONFIG.gameplay.selectionReq || 3) + (this.bulletCapBonus || 0));
         this.fateMomentContext = {
             type: mode,
             source: pendingMode?.source || 'unknown',
@@ -977,7 +978,7 @@ export const game_system = {
         this.marbleQueue = [];
         this.activeMarbleIndex = 0;
         this.selectionMode = 'standard';
-        this.selectionRequiredCount = CONFIG.gameplay.selectionReq || 3;
+        this.selectionRequiredCount = (CONFIG.gameplay.selectionReq || 3) + (this.bulletCapBonus || 0);
         this.selectionInjectedRune = null;
         this.selectionPreviewState = null;
         this.fateMomentContext = null;
@@ -1070,7 +1071,7 @@ export const game_system = {
             this.fateMomentContext = null;
             this.pendingSelectionMode = null;
             this.selectionMode = 'standard';
-            this.selectionRequiredCount = (typeof CONFIG !== 'undefined' && CONFIG.gameplay.selectionReq) || 3;
+            this.selectionRequiredCount = ((typeof CONFIG !== 'undefined' && CONFIG.gameplay.selectionReq) || 3) + (this.bulletCapBonus || 0);
             this.selectionInjectedRune = null;
             this.selectionPreviewState = null;
             this.marbleQueue = [];
@@ -2376,6 +2377,7 @@ export const game_system = {
                 pendingSelectionMode: this.pendingSelectionMode ? { ...this.pendingSelectionMode } : null,
                 selectionMode: this.selectionMode || 'standard',
                 selectionRequiredCount: this.selectionRequiredCount || (CONFIG.gameplay.selectionReq || 3),
+                bulletCapBonus: this.bulletCapBonus || 0,
                 selectionInjectedRune: this.selectionInjectedRune ? { ...this.selectionInjectedRune } : null,
                 selectionPreviewState: this.selectionPreviewState ? { ...this.selectionPreviewState } : null,
                 relicOverlayReturnState: this.relicOverlayReturnState ? { ...this.relicOverlayReturnState } : null,
@@ -2492,7 +2494,8 @@ export const game_system = {
             this.doubleAssimilationBoostRounds = { ...(state.doubleAssimilationBoostRounds || state.assimilationBoostRounds || {}) };
             this.pendingSelectionMode = state.pendingSelectionMode ? { ...state.pendingSelectionMode } : null;
             this.selectionMode = state.selectionMode || 'standard';
-            this.selectionRequiredCount = state.selectionRequiredCount || (CONFIG.gameplay.selectionReq || 3);
+            this.bulletCapBonus = state.bulletCapBonus || 0;
+            this.selectionRequiredCount = state.selectionRequiredCount || ((CONFIG.gameplay.selectionReq || 3) + (this.bulletCapBonus || 0));
             this.selectionInjectedRune = state.selectionInjectedRune ? { ...state.selectionInjectedRune } : null;
             this.selectionPreviewState = state.selectionPreviewState ? { ...state.selectionPreviewState } : null;
             this.relicOverlayReturnState = state.relicOverlayReturnState ? { ...state.relicOverlayReturnState } : null;

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -243,6 +243,13 @@ export const shop_system = {
                 this.sys_queueRoundStartReward({ type: 'chaos_essence', source: 'relic', sourceRelicId: relic.id, sourceRelicName: relic.name, round: this.round });
             }
         }
+        else if (relic.effect === 'bullet_cap_up') {
+            const amount = (typeof relic.amount === 'number' && relic.amount > 0) ? relic.amount : 1;
+            this.bulletCapBonus = (this.bulletCapBonus || 0) + amount;
+            const newCap = (CONFIG.gameplay.selectionReq || 3) + this.bulletCapBonus;
+            this.selectionRequiredCount = newCap;
+            if (window.showToast) showToast(`子彈持有上限 +${amount}（當前 ${newCap}）`);
+        }
         // ==================== [v2 钉板模块化] 新遗物分支 ====================
         else if (relic.effect === 'module_slot_up') {
             const cfg = (typeof CONFIG !== 'undefined' && CONFIG.gameplay) || {};

--- a/src/ui_system.js
+++ b/src/ui_system.js
@@ -1499,7 +1499,7 @@ export const ui_system = {
         this.replaceAmmoContext = null;
 
         this.selectionMode = 'standard';
-        this.selectionRequiredCount = (typeof CONFIG !== 'undefined' && CONFIG.gameplay.selectionReq) || 3;
+        this.selectionRequiredCount = ((typeof CONFIG !== 'undefined' && CONFIG.gameplay.selectionReq) || 3) + (this.bulletCapBonus || 0);
         this.selectionInjectedRune = null;
         this.selectionPreviewState = null;
         this.fateMomentContext = null;


### PR DESCRIPTION
## Summary

### 1. 敌人受击闪白修复
- 受击白色覆盖层改由独立的 `_hitFlashTimer`（4 帧，约 67ms）驱动，不再使用 `hitTimer`（10~15 帧）
- 连发武器高频命中时，每次受击只产生短促的白色脉冲，不再持续保持纯白色
- `hitTimer` 原有功能（抖动、动画状态、呼吸效果抑制）完全不变

### 2. 子弹持有上限强制为 3
- 新增 `bulletCapBonus`（默认 0）到游戏状态，遗物效果 `bullet_cap_up` 可累加此值
- 在 `phase_startCombatPhase` 组装完 `ammoQueue` 后，强制裁切到 `bulletCap = selectionReq + bulletCapBonus`，防止完美清场/围墙清空的 `_carryOverAmmo` 携带把总数撑超 3
- 所有重置 `selectionRequiredCount` 为"标准值"的地方均纳入 `bulletCapBonus`，确保遗物加成持久生效
- 在存档序列化/反序列化中保存和还原 `bulletCapBonus`

## Test plan

- [ ] 慢速武器命中敌人：每次受击出现短暂白色闪光后恢复正常
- [ ] 连发武器高频命中：看到重复的短促闪白，而不是持续纯白
- [ ] 普通回合结束时剩余子弹 < 3：下回合 ammoQueue 不超过 3
- [ ] 完美清场触发 carryover（剩余 2 颗）：下回合仍只有 3 颗，多余的被裁切
- [ ] 存档/读档后 bulletCapBonus 正确还原
- [ ] 无回归：受击抖动、动画状态、呼吸效果正常

https://claude.ai/code/session_019ZU236EBfUwjfVaeATDPeb