### PR TITLE
feat(3d/M1): bootstrap Three.js renderer with background layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,33 @@
             pointer-events: auto;
         }
 
+        /* ===== 3D WebGL 背景层（M1 起引入） =====
+         * 位于 2D #gameCanvas 之下，铺满 #game-container。
+         * 不接收事件（pointer-events: none），不参与 layout（position: absolute）。
+         * 内部分辨率由 JS（Renderer3D）按 2D Canvas 同步设置。
+         */
+        #gl-canvas {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+            pointer-events: none;
+            /* 默认隐藏：仅当 body 带 .render3d-enabled 类或显式 opacity 调整时可见。
+             * M1 阶段我们让它始终渲染（用于性能/正确性验证），但 2D 不透明覆盖之 → 看不到。
+             * 调试时可在 console 执行：
+             *   document.body.classList.add('render3d-debug')
+             * 即可看到下层 3D 背景（同步降低 2D 不透明度到 0.3）。
+             */
+        }
+        body.render3d-debug #gameCanvas {
+            opacity: 0.30;
+            transition: opacity 0.2s ease;
+        }
+        body.render3d-debug #gl-canvas {
+            outline: 1px solid rgba(56, 189, 248, 0.4);
+        }
+
         @keyframes shake-hard {
             0% { transform: translate(0, 0); }
             25% { transform: translate(-5px, 5px); }
@@ -2767,6 +2794,18 @@
     </style>
     <!-- Phase 5A: 位图化 UI 样式覆盖层 -->
     <link rel="stylesheet" href="src/styles/bitmap_ui.css">
+
+    <!-- [3D-Main M1] Three.js importmap：让 `import * as THREE from 'three'` 解析到 CDN ESM 构建。
+         版本锁定 r160（与 docs/visual_redesign_3d_plan.md §6 一致）。
+         若 CDN 不可达，Renderer3D 构造会抛错并被 core.js try/catch 静默降级到 2D-only。 -->
+    <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+      }
+    }
+    </script>
 </head>
 <body>
 <div id="app-wrapper">
@@ -2788,6 +2827,8 @@
 </aside>
 
 <div id="game-container">
+    <!-- [3D-Main M1] WebGL 背景层。位于 2D #gameCanvas 之下，由 src/render3d/Renderer3D.js 驱动 -->
+    <canvas id="gl-canvas"></canvas>
     <canvas id="gameCanvas"></canvas>
     <div id="crt-overlay"></div>
 

--- a/src/core.js
+++ b/src/core.js
@@ -46,6 +46,8 @@ import { calc_utils } from './calc_utils.js';
 import { tutorial_system } from './tutorial_system.js';
 import { game_over_mixin } from './ui/game_over.js';
 import { preloadAllSprites } from './render/sprite_renderer.js'; // [Phase 5B] 预加载所有 Sprite Sheet
+// [3D-Main M1] 引入 3D 渲染管线（仅背景层）。任何加载/初始化失败都会被静默降级到 2D-only。
+import { Renderer3D } from './render3d/Renderer3D.js';
 
 // ==================== 延迟音频初始化 ====================
 let _audioInitialized = false;
@@ -359,6 +361,35 @@ class Game {
         this._perfManualMode = null;
         // [Phase 5B] 预加载所有 Sprite Sheet（在游戏循环开始前触发异步加载）
         preloadAllSprites();
+
+        // ==================== [3D-Main M1] 初始化 3D 渲染管线 ====================
+        // 设计契约：
+        //   1. 任何初始化失败（Three.js CDN 拉取失败、WebGL 不支持、shader 编译错）→
+        //      this.renderer3d = null，主循环 / resize 调用都用可选链跳过。
+        //   2. 默认开启；可通过 localStorage.echo_3d_disabled = '1' 强制关闭。
+        //   3. 调试可见：document.body.classList.add('render3d-debug')
+        //      （把 2D #gameCanvas 透明度降到 0.3 即可看到 3D 背景）。
+        this.renderer3d = null;
+        try {
+            if (typeof localStorage !== 'undefined' && localStorage.getItem('echo_3d_disabled') === '1') {
+                console.info('[Renderer3D] disabled via localStorage.echo_3d_disabled');
+            } else {
+                const glCanvas = document.getElementById('gl-canvas');
+                if (!glCanvas) {
+                    console.warn('[Renderer3D] #gl-canvas not found, skipping 3D init');
+                } else {
+                    // sys_resize() 已在上面跑过，this.width/this.height 已就绪
+                    this.renderer3d = new Renderer3D(glCanvas, this.width, this.height);
+                    // 同步内部像素尺寸到 2D canvas
+                    this.renderer3d.resize(this.canvas.width, this.canvas.height);
+                    console.info(`[Renderer3D] initialized @ ${this.canvas.width}x${this.canvas.height}`);
+                }
+            }
+        } catch (err) {
+            console.error('[Renderer3D] init failed, falling back to 2D-only:', err);
+            this.renderer3d = null;
+        }
+
         // 启动游戏主循环
         this.sys_loop();
     }
@@ -476,6 +507,11 @@ class Game {
         if (this._resizeObserver) {
             try { this._resizeObserver.disconnect(); } catch (e) {}
             this._resizeObserver = null;
+        }
+        // [3D-Main M1] 释放 WebGL 资源
+        if (this.renderer3d) {
+            try { this.renderer3d.dispose(); } catch (e) {}
+            this.renderer3d = null;
         }
     }
 }

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -80,6 +80,20 @@ export const game_system = {
         this._lastFrameTime = _now;
         // ==================== [自适应性能] END ====================
 
+        // ==================== [3D-Main M1] 3D 背景层渲染 ====================
+        // 即便暂停（isPaused）也持续渲染 3D 背景，保持氛围"活着"的呼吸感。
+        // 失败回退已在 Renderer3D 构造阶段处理（this.renderer3d 可能为 null）。
+        if (this.renderer3d) {
+            try {
+                this.renderer3d.render(_now);
+            } catch (err) {
+                // 渲染期出错（如 shader 编译延迟失败）→ 一次性禁用，避免循环报错刷屏
+                console.error('[Renderer3D] render error, disabling:', err);
+                try { this.renderer3d.dispose(); } catch (_) {}
+                this.renderer3d = null;
+            }
+        }
+
         // 暂停时跳过物理更新，但继续请求下一帧以保持 rAF 循环活跃
         if (this.isPaused) {
             requestAnimationFrame(() => this.sys_loop());
@@ -210,6 +224,13 @@ export const game_system = {
         if (!rect.width || !rect.height) return;
         this.width = this.canvas.width = Math.round(rect.width);
         this.height = this.canvas.height = Math.round(rect.height);
+
+        // [3D-Main M1] 同步 WebGL canvas 内部分辨率（CSS 尺寸由全局 canvas 规则控制）
+        if (this.renderer3d) {
+            try { this.renderer3d.resize(this.width, this.height); } catch (e) {
+                console.warn('[Renderer3D] resize error:', e);
+            }
+        }
 
         // 动态调整失败判定线
         // PC 模式下底部面板隐藏，可以缩小安全边距

--- a/src/render3d/BackgroundLayer.js
+++ b/src/render3d/BackgroundLayer.js
@@ -1,0 +1,268 @@
+/**
+ * BackgroundLayer.js - 远景/中后景大气层（L0 + L1）
+ *
+ * 组成：
+ *   1. SkyDome - 反法线球体，shader 程序化生成深空蓝→紫的"星云"
+ *   2. 远处剪影 - 低多边形 box 阵列（z = -200），暗色无 emissive
+ *   3. 体积光柱 - 4 根 additive 圆锥，慢转 + 上下浮动
+ *   4. 环境粒子 - 150 颗 GPU points，缓慢上升，循环复位
+ *
+ * 所有元素都挂在 z < 0 的远景；后续 milestone 玩法面板会放在 z=0。
+ */
+
+import * as THREE from 'three';
+
+// 暗黑炼金调色板（同 visual_redesign_3d_plan.md §1.3）
+const COLOR_DEEP    = 0x0a0e1a;
+const COLOR_MID     = 0x1a1f3a;
+const COLOR_ACCENT  = 0x3b2160;
+const SILHOUETTE_COL = 0x0d1320;
+const CONE_COLORS   = [0x38bdf8, 0xa78bfa, 0x60a5fa, 0xf59e0b];
+const PARTICLE_COL  = 0x60a5fa;
+
+export class BackgroundLayer {
+    /**
+     * @param {THREE.Scene} scene
+     */
+    constructor(scene) {
+        this.scene = scene;
+        this.group = new THREE.Group();
+        this.group.name = 'BackgroundLayer';
+        scene.add(this.group);
+
+        this._createSkyDome();
+        this._createDistantSilhouettes();
+        this._createVolumetricLights();
+        this._createAmbientParticles();
+    }
+
+    // -------------------- 天幕 --------------------
+    _createSkyDome() {
+        const geometry = new THREE.SphereGeometry(450, 24, 16);
+        const material = new THREE.ShaderMaterial({
+            side: THREE.BackSide,
+            depthWrite: false,
+            uniforms: {
+                uTime:        { value: 0 },
+                uColorDeep:   { value: new THREE.Color(COLOR_DEEP) },
+                uColorMid:    { value: new THREE.Color(COLOR_MID) },
+                uColorAccent: { value: new THREE.Color(COLOR_ACCENT) },
+            },
+            vertexShader: /* glsl */`
+                varying vec3 vDir;
+                void main() {
+                    vDir = normalize(position);
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform vec3  uColorDeep;
+                uniform vec3  uColorMid;
+                uniform vec3  uColorAccent;
+                uniform float uTime;
+                varying vec3  vDir;
+
+                // 廉价 hash 噪声（够用即可）
+                float hash3(vec3 p) {
+                    p = fract(p * 0.3183099 + vec3(0.1, 0.13, 0.17));
+                    p *= 17.0;
+                    return fract(p.x * p.y * p.z * (p.x + p.y + p.z));
+                }
+                float noise3(vec3 p) {
+                    vec3 i = floor(p);
+                    vec3 f = fract(p);
+                    f = f * f * (3.0 - 2.0 * f);
+                    float n000 = hash3(i + vec3(0.0, 0.0, 0.0));
+                    float n100 = hash3(i + vec3(1.0, 0.0, 0.0));
+                    float n010 = hash3(i + vec3(0.0, 1.0, 0.0));
+                    float n110 = hash3(i + vec3(1.0, 1.0, 0.0));
+                    float n001 = hash3(i + vec3(0.0, 0.0, 1.0));
+                    float n101 = hash3(i + vec3(1.0, 0.0, 1.0));
+                    float n011 = hash3(i + vec3(0.0, 1.0, 1.0));
+                    float n111 = hash3(i + vec3(1.0, 1.0, 1.0));
+                    float nx00 = mix(n000, n100, f.x);
+                    float nx10 = mix(n010, n110, f.x);
+                    float nx01 = mix(n001, n101, f.x);
+                    float nx11 = mix(n011, n111, f.x);
+                    float nxy0 = mix(nx00, nx10, f.y);
+                    float nxy1 = mix(nx01, nx11, f.y);
+                    return mix(nxy0, nxy1, f.z);
+                }
+
+                void main() {
+                    // 垂直渐变（深空 → 中蓝）
+                    float t = clamp(0.5 + vDir.y * 0.5, 0.0, 1.0);
+                    vec3 col = mix(uColorDeep, uColorMid, t);
+
+                    // 星云斑块（低频噪声 + 时间漂移）
+                    float n = noise3(vDir * 4.0 + vec3(uTime * 0.015, 0.0, uTime * 0.01));
+                    col = mix(col, uColorAccent, smoothstep(0.55, 0.95, n) * 0.35);
+
+                    // 微弱星点
+                    float stars = step(0.985, hash3(floor(vDir * 200.0))) * 0.5;
+                    col += vec3(stars);
+
+                    gl_FragColor = vec4(col, 1.0);
+                }
+            `,
+        });
+        this.skyMaterial = material;
+        const dome = new THREE.Mesh(geometry, material);
+        dome.name = 'SkyDome';
+        this.group.add(dome);
+    }
+
+    // -------------------- 远处剪影 --------------------
+    _createDistantSilhouettes() {
+        const silhouetteGroup = new THREE.Group();
+        silhouetteGroup.name = 'DistantSilhouettes';
+        const mat = new THREE.MeshBasicMaterial({
+            color: SILHOUETTE_COL,
+            depthWrite: false,
+            fog: true,
+        });
+
+        // 确定性 PRNG，让剪影布局每次启动一致（便于风格 review）
+        const rng = mulberry32(2024);
+        const count = 14;
+        // 共享几何减少 draw call（box 都用同一个 BufferGeometry，通过 scale 区分大小）
+        const baseGeom = new THREE.BoxGeometry(1, 1, 1);
+        for (let i = 0; i < count; i++) {
+            const w = 6 + rng() * 18;
+            const h = 30 + rng() * 80;
+            const d = 6 + rng() * 12;
+            const m = new THREE.Mesh(baseGeom, mat);
+            m.scale.set(w, h, d);
+            m.position.set(
+                (rng() - 0.5) * 360,
+                -40 - rng() * 40,
+                -180 - rng() * 60
+            );
+            silhouetteGroup.add(m);
+        }
+        this.silhouetteGroup = silhouetteGroup;
+        this.group.add(silhouetteGroup);
+    }
+
+    // -------------------- 体积光柱 --------------------
+    _createVolumetricLights() {
+        const lightGroup = new THREE.Group();
+        lightGroup.name = 'VolumetricLights';
+        // 单个圆锥几何复用（半径靠 scale 拉伸）
+        const baseGeom = new THREE.ConeGeometry(1, 1, 18, 1, true);
+        for (let i = 0; i < 4; i++) {
+            const color = CONE_COLORS[i % CONE_COLORS.length];
+            const mat = new THREE.MeshBasicMaterial({
+                color,
+                transparent: true,
+                opacity: 0.06,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+                side: THREE.DoubleSide,
+                fog: false,
+            });
+            const cone = new THREE.Mesh(baseGeom, mat);
+            const radius = 20 + i * 6;
+            const height = 220 + i * 20;
+            cone.scale.set(radius, height, radius);
+            cone.position.set(
+                -120 + i * 80,
+                -40,
+                -90 - i * 8
+            );
+            // 圆锥默认尖端朝 +Y；我们让光"自下而上洒"，所以翻转
+            cone.rotation.z = Math.PI;
+            cone.userData = { baseY: cone.position.y, phase: i * 1.7 };
+            lightGroup.add(cone);
+        }
+        this.lightGroup = lightGroup;
+        this.group.add(lightGroup);
+    }
+
+    // -------------------- 环境粒子 --------------------
+    _createAmbientParticles() {
+        const count = 150;
+        const positions = new Float32Array(count * 3);
+        const speeds = new Float32Array(count);
+        for (let i = 0; i < count; i++) {
+            positions[i * 3 + 0] = (Math.random() - 0.5) * 320;
+            positions[i * 3 + 1] = -160 + Math.random() * 320;
+            positions[i * 3 + 2] = -100 + Math.random() * 80;
+            speeds[i] = 2 + Math.random() * 5;
+        }
+        const geom = new THREE.BufferGeometry();
+        geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        const mat = new THREE.PointsMaterial({
+            color: PARTICLE_COL,
+            size: 1.6,
+            sizeAttenuation: true,
+            transparent: true,
+            opacity: 0.35,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            fog: true,
+        });
+        const points = new THREE.Points(geom, mat);
+        points.name = 'AmbientParticles';
+        this.ambientPoints = points;
+        this._ambientSpeeds = speeds;
+        this.group.add(points);
+    }
+
+    // -------------------- 帧更新 --------------------
+    /**
+     * @param {number} dt seconds (clamped)
+     * @param {number} t  seconds elapsed total
+     */
+    update(dt, t) {
+        if (this.skyMaterial) this.skyMaterial.uniforms.uTime.value = t;
+
+        if (this.lightGroup) {
+            const children = this.lightGroup.children;
+            for (let i = 0; i < children.length; i++) {
+                const cone = children[i];
+                const ud = cone.userData;
+                cone.position.y = ud.baseY + Math.sin(t * 0.4 + ud.phase) * 3;
+                cone.rotation.y = t * 0.05 + ud.phase;
+            }
+        }
+
+        if (this.ambientPoints) {
+            const attr = this.ambientPoints.geometry.attributes.position;
+            const arr = attr.array;
+            const speeds = this._ambientSpeeds;
+            const n = speeds.length;
+            for (let i = 0; i < n; i++) {
+                arr[i * 3 + 1] += speeds[i] * dt;
+                if (arr[i * 3 + 1] > 160) {
+                    arr[i * 3 + 1] = -160;
+                    arr[i * 3 + 0] = (Math.random() - 0.5) * 320;
+                }
+            }
+            attr.needsUpdate = true;
+        }
+    }
+
+    dispose() {
+        this.group.traverse(obj => {
+            if (obj.geometry) obj.geometry.dispose();
+            if (obj.material) {
+                const m = obj.material;
+                if (Array.isArray(m)) m.forEach(x => x.dispose());
+                else m.dispose();
+            }
+        });
+        if (this.scene) this.scene.remove(this.group);
+    }
+}
+
+// 简易确定性 PRNG（mulberry32）—— 让远景剪影每次启动布局一致
+function mulberry32(seed) {
+    return function () {
+        let t = seed += 0x6d2b79f5;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}

--- a/src/render3d/BackgroundLayer.js
+++ b/src/render3d/BackgroundLayer.js
@@ -14,11 +14,12 @@ import * as THREE from 'three';
 
 // 暗黑炼金调色板（同 visual_redesign_3d_plan.md §1.3）
 const COLOR_DEEP    = 0x0a0e1a;
-const COLOR_MID     = 0x1a1f3a;
-const COLOR_ACCENT  = 0x3b2160;
-const SILHOUETTE_COL = 0x0d1320;
-const CONE_COLORS   = [0x38bdf8, 0xa78bfa, 0x60a5fa, 0xf59e0b];
-const PARTICLE_COL  = 0x60a5fa;
+const COLOR_MID     = 0x1c2348;     // 略提亮中间色，避免大面积死黑
+const COLOR_ACCENT  = 0x5b2d8a;     // 紫调更饱满，星云有存在感
+const COLOR_FORGE   = 0x6b2418;     // 底部"炼金炉"暖红光（焦点引导）
+const SILHOUETTE_COL = 0x161d33;    // 略提亮，让远处剪影从天幕中"浮"出来
+const CONE_COLORS   = [0x38bdf8, 0xa78bfa, 0x60a5fa, 0xf59e0b, 0xec4899, 0x22d3ee];
+const PARTICLE_COL  = 0x93c5fd;     // 提亮粒子色
 
 export class BackgroundLayer {
     /**
@@ -34,6 +35,76 @@ export class BackgroundLayer {
         this._createDistantSilhouettes();
         this._createVolumetricLights();
         this._createAmbientParticles();
+        this._createAlchemyStage();
+    }
+
+    // -------------------- 炼金台基（底部锚定焦点） --------------------
+    _createAlchemyStage() {
+        // 一道环形发光环，定位在屏幕下方"地平线"位置，象征"炼金引擎舞台"。
+        // M3+ 加入发射器实体后，这环会与发射器同心，强化"舞台中心"概念。
+        const stageGroup = new THREE.Group();
+        stageGroup.name = 'AlchemyStage';
+
+        // 主环：薄圆环，emissive 橙金。半径按 z=-10 处视域宽度（约 ±28）校准。
+        const ringGeom = new THREE.RingGeometry(34, 38, 64, 1);
+        const ringMat = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+            uniforms: {
+                uTime: { value: 0 },
+                uColor: { value: new THREE.Color(0xfb923c) },
+            },
+            vertexShader: /* glsl */`
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform float uTime;
+                uniform vec3 uColor;
+                varying vec2 vUv;
+                void main() {
+                    // uv.x 在环周方向，uv.y 在环宽方向；让中心更亮、两侧衰减
+                    float radial = 1.0 - abs(vUv.y - 0.5) * 2.0;
+                    radial = pow(radial, 1.5);
+                    // 沿环周的流光（4 段亮纹环绕）
+                    float flow = 0.5 + 0.5 * sin(vUv.x * 12.566 + uTime * 1.8);
+                    flow = pow(flow, 4.0);
+                    float alpha = radial * (0.4 + flow * 0.6);
+                    gl_FragColor = vec4(uColor * (0.6 + flow * 1.2), alpha);
+                }
+            `,
+        });
+        const ring = new THREE.Mesh(ringGeom, ringMat);
+        // 平躺在地面上，y 位置略低于相机看向的中心
+        // 平躺在地面上；y 位置紧靠视域下边缘，z 略推后避开后续玩法面板（z=0）
+        ring.rotation.x = -Math.PI / 2;
+        ring.position.set(0, -38, -10);
+        stageGroup.add(ring);
+        this.ringMaterial = ringMat;
+
+        // 二级辉光（内圈，更小、更亮）
+        const innerRingGeom = new THREE.RingGeometry(26, 30, 48, 1);
+        const innerRingMat = new THREE.MeshBasicMaterial({
+            color: 0xfde68a,
+            transparent: true,
+            opacity: 0.25,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+        });
+        const innerRing = new THREE.Mesh(innerRingGeom, innerRingMat);
+        innerRing.rotation.x = -Math.PI / 2;
+        innerRing.position.set(0, -37.5, -10);
+        stageGroup.add(innerRing);
+
+        this.stageGroup = stageGroup;
+        this.group.add(stageGroup);
     }
 
     // -------------------- 天幕 --------------------
@@ -47,6 +118,7 @@ export class BackgroundLayer {
                 uColorDeep:   { value: new THREE.Color(COLOR_DEEP) },
                 uColorMid:    { value: new THREE.Color(COLOR_MID) },
                 uColorAccent: { value: new THREE.Color(COLOR_ACCENT) },
+                uColorForge:  { value: new THREE.Color(COLOR_FORGE) },
             },
             vertexShader: /* glsl */`
                 varying vec3 vDir;
@@ -60,6 +132,7 @@ export class BackgroundLayer {
                 uniform vec3  uColorDeep;
                 uniform vec3  uColorMid;
                 uniform vec3  uColorAccent;
+                uniform vec3  uColorForge;
                 uniform float uTime;
                 varying vec3  vDir;
 
@@ -91,17 +164,36 @@ export class BackgroundLayer {
                 }
 
                 void main() {
-                    // 垂直渐变（深空 → 中蓝）
-                    float t = clamp(0.5 + vDir.y * 0.5, 0.0, 1.0);
+                    // 垂直渐变（深空 → 中蓝），曲线 pow 让中段更浓
+                    float ty = clamp(0.5 + vDir.y * 0.5, 0.0, 1.0);
+                    float t = pow(ty, 0.7);
                     vec3 col = mix(uColorDeep, uColorMid, t);
 
-                    // 星云斑块（低频噪声 + 时间漂移）
-                    float n = noise3(vDir * 4.0 + vec3(uTime * 0.015, 0.0, uTime * 0.01));
-                    col = mix(col, uColorAccent, smoothstep(0.55, 0.95, n) * 0.35);
+                    // 星云斑块：两层 octave 叠加，幅度更大
+                    float n1 = noise3(vDir * 3.0  + vec3(uTime * 0.012, 0.0, uTime * 0.008));
+                    float n2 = noise3(vDir * 8.0  + vec3(0.0, uTime * 0.020, 0.0));
+                    float neb = n1 * 0.75 + n2 * 0.25;
+                    col = mix(col, uColorAccent, smoothstep(0.40, 0.85, neb) * 0.65);
 
-                    // 微弱星点
-                    float stars = step(0.985, hash3(floor(vDir * 200.0))) * 0.5;
-                    col += vec3(stars);
+                    // 底部炼金炉膛暖光：仰角 < 0 时增强（焦点向下引导）
+                    // GLSL smoothstep 要求 edge0 < edge1；反方向需用 1 - smoothstep。
+                    float forgeMask = 1.0 - smoothstep(-0.55, 0.05, vDir.y);
+                    // 中央集束 + 横向衰减
+                    float forgeCenter = pow(max(0.0, 1.0 - abs(vDir.x) * 1.2), 2.0);
+                    col += uColorForge * forgeMask * forgeCenter * 2.2;
+                    // 炉口高光（中心更亮一圈橙金）+ 缓慢搏动
+                    float pulse = 0.85 + 0.15 * sin(uTime * 0.9);
+                    col += vec3(0.95, 0.55, 0.20) * forgeMask * pow(forgeCenter, 3.5) * 1.1 * pulse;
+
+                    // 顶部高空蓝紫提亮
+                    col += vec3(0.04, 0.06, 0.18) * smoothstep(0.3, 0.95, vDir.y);
+
+                    // 星点（两档密度 + 闪烁）
+                    float starRand = hash3(floor(vDir * 220.0));
+                    float bright = step(0.992, starRand);
+                    float dim    = step(0.975, starRand) * step(starRand, 0.992);
+                    float twinkle = 0.7 + 0.3 * sin(uTime * 3.0 + starRand * 30.0);
+                    col += vec3(bright * 1.0 * twinkle + dim * 0.35);
 
                     gl_FragColor = vec4(col, 1.0);
                 }
@@ -151,29 +243,38 @@ export class BackgroundLayer {
         lightGroup.name = 'VolumetricLights';
         // 单个圆锥几何复用（半径靠 scale 拉伸）
         const baseGeom = new THREE.ConeGeometry(1, 1, 18, 1, true);
-        for (let i = 0; i < 4; i++) {
-            const color = CONE_COLORS[i % CONE_COLORS.length];
+
+        // 6 根光柱全部置于远景（z < -180），靠两侧分布避开中央玩法区。
+        // 不放中心柱——中心由 skydome 的炉膛暖光承担焦点引导。
+        // 透明度刻意压低，让光柱作为"帷幕灯光"而非主体。
+        const config = [
+            // x,    y,    z,     radius, height, colorIdx, opacity
+            [-160,  -30,  -210,   28,     300,    0, 0.12], // 远景左主光（青）
+            [ 160,  -30,  -210,   28,     300,    1, 0.12], // 远景右主光（紫）
+            [-230,  -40,  -260,   20,     260,    2, 0.09], // 更远的左侧蓝
+            [ 230,  -40,  -260,   20,     260,    3, 0.09], // 更远的右侧橙
+            [-100,  -60,  -270,   16,     240,    4, 0.07], // 中左副柱（粉）
+            [ 100,  -60,  -270,   16,     240,    4, 0.07], // 中右副柱（粉）
+        ];
+
+        for (let i = 0; i < config.length; i++) {
+            const [px, py, pz, radius, height, ci, op] = config[i];
+            const color = CONE_COLORS[ci % CONE_COLORS.length];
             const mat = new THREE.MeshBasicMaterial({
                 color,
                 transparent: true,
-                opacity: 0.06,
+                opacity: op,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
                 side: THREE.DoubleSide,
                 fog: false,
             });
             const cone = new THREE.Mesh(baseGeom, mat);
-            const radius = 20 + i * 6;
-            const height = 220 + i * 20;
             cone.scale.set(radius, height, radius);
-            cone.position.set(
-                -120 + i * 80,
-                -40,
-                -90 - i * 8
-            );
-            // 圆锥默认尖端朝 +Y；我们让光"自下而上洒"，所以翻转
+            cone.position.set(px, py, pz);
+            // 圆锥默认尖端朝 +Y；让光"自下而上洒"，翻转
             cone.rotation.z = Math.PI;
-            cone.userData = { baseY: cone.position.y, phase: i * 1.7 };
+            cone.userData = { baseY: cone.position.y, phase: i * 1.13, baseOpacity: op };
             lightGroup.add(cone);
         }
         this.lightGroup = lightGroup;
@@ -182,32 +283,45 @@ export class BackgroundLayer {
 
     // -------------------- 环境粒子 --------------------
     _createAmbientParticles() {
-        const count = 150;
-        const positions = new Float32Array(count * 3);
-        const speeds = new Float32Array(count);
-        for (let i = 0; i < count; i++) {
-            positions[i * 3 + 0] = (Math.random() - 0.5) * 320;
-            positions[i * 3 + 1] = -160 + Math.random() * 320;
-            positions[i * 3 + 2] = -100 + Math.random() * 80;
-            speeds[i] = 2 + Math.random() * 5;
+        // 双层粒子：近层（大、慢、亮）+ 远层（小、快、暗）共同营造深度
+        this.ambientPoints = [];
+        this._ambientSpeeds = [];
+
+        const layers = [
+            { count: 180, sizeRange: [2.4, 4.2], color: PARTICLE_COL, opacity: 0.75, zRange: [-60, -10],  speedRange: [3, 8],   xRange: 320 },
+            { count: 200, sizeRange: [1.0, 2.0], color: 0xa78bfa,     opacity: 0.45, zRange: [-150, -80], speedRange: [1, 4],   xRange: 360 },
+        ];
+
+        for (const layer of layers) {
+            const count = layer.count;
+            const positions = new Float32Array(count * 3);
+            const speeds = new Float32Array(count);
+            const sizes = new Float32Array(count);
+            for (let i = 0; i < count; i++) {
+                positions[i * 3 + 0] = (Math.random() - 0.5) * layer.xRange;
+                positions[i * 3 + 1] = -180 + Math.random() * 360;
+                positions[i * 3 + 2] = layer.zRange[0] + Math.random() * (layer.zRange[1] - layer.zRange[0]);
+                speeds[i] = layer.speedRange[0] + Math.random() * (layer.speedRange[1] - layer.speedRange[0]);
+                sizes[i] = layer.sizeRange[0] + Math.random() * (layer.sizeRange[1] - layer.sizeRange[0]);
+            }
+            const geom = new THREE.BufferGeometry();
+            geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            const mat = new THREE.PointsMaterial({
+                color: layer.color,
+                size: (layer.sizeRange[0] + layer.sizeRange[1]) * 0.5, // 平均尺寸；细粒度由 size attribute 自定义着色器才能用
+                sizeAttenuation: true,
+                transparent: true,
+                opacity: layer.opacity,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+                fog: true,
+            });
+            const points = new THREE.Points(geom, mat);
+            points.name = 'AmbientParticles_' + layer.count;
+            this.ambientPoints.push(points);
+            this._ambientSpeeds.push(speeds);
+            this.group.add(points);
         }
-        const geom = new THREE.BufferGeometry();
-        geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-        const mat = new THREE.PointsMaterial({
-            color: PARTICLE_COL,
-            size: 1.6,
-            sizeAttenuation: true,
-            transparent: true,
-            opacity: 0.35,
-            blending: THREE.AdditiveBlending,
-            depthWrite: false,
-            fog: true,
-        });
-        const points = new THREE.Points(geom, mat);
-        points.name = 'AmbientParticles';
-        this.ambientPoints = points;
-        this._ambientSpeeds = speeds;
-        this.group.add(points);
     }
 
     // -------------------- 帧更新 --------------------
@@ -217,6 +331,12 @@ export class BackgroundLayer {
      */
     update(dt, t) {
         if (this.skyMaterial) this.skyMaterial.uniforms.uTime.value = t;
+        if (this.ringMaterial) this.ringMaterial.uniforms.uTime.value = t;
+        if (this.stageGroup) {
+            // 内外环缓慢反向旋转，制造"机械感"
+            this.stageGroup.children[0].rotation.z = t * 0.15;
+            this.stageGroup.children[1].rotation.z = -t * 0.22;
+        }
 
         if (this.lightGroup) {
             const children = this.lightGroup.children;
@@ -225,22 +345,28 @@ export class BackgroundLayer {
                 const ud = cone.userData;
                 cone.position.y = ud.baseY + Math.sin(t * 0.4 + ud.phase) * 3;
                 cone.rotation.y = t * 0.05 + ud.phase;
+                // 呼吸式透明度（基准 ±20%）
+                const breath = 0.85 + 0.15 * Math.sin(t * 0.6 + ud.phase * 0.7);
+                cone.material.opacity = ud.baseOpacity * breath;
             }
         }
 
-        if (this.ambientPoints) {
-            const attr = this.ambientPoints.geometry.attributes.position;
-            const arr = attr.array;
-            const speeds = this._ambientSpeeds;
-            const n = speeds.length;
-            for (let i = 0; i < n; i++) {
-                arr[i * 3 + 1] += speeds[i] * dt;
-                if (arr[i * 3 + 1] > 160) {
-                    arr[i * 3 + 1] = -160;
-                    arr[i * 3 + 0] = (Math.random() - 0.5) * 320;
+        if (this.ambientPoints && this.ambientPoints.length) {
+            for (let li = 0; li < this.ambientPoints.length; li++) {
+                const pts = this.ambientPoints[li];
+                const attr = pts.geometry.attributes.position;
+                const arr = attr.array;
+                const speeds = this._ambientSpeeds[li];
+                const n = speeds.length;
+                for (let i = 0; i < n; i++) {
+                    arr[i * 3 + 1] += speeds[i] * dt;
+                    if (arr[i * 3 + 1] > 180) {
+                        arr[i * 3 + 1] = -180;
+                        arr[i * 3 + 0] = (Math.random() - 0.5) * 320;
+                    }
                 }
+                attr.needsUpdate = true;
             }
-            attr.needsUpdate = true;
         }
     }
 

--- a/src/render3d/CameraController.js
+++ b/src/render3d/CameraController.js
@@ -1,0 +1,50 @@
+/**
+ * CameraController.js - 镜头状态机（M1 阶段 stub）
+ *
+ * 当前仅实现 IDLE 状态的呼吸式漂移（极弱位移）。
+ * 后续 milestone 会扩展为完整状态机（AIM / SHOT / IMPACT / BOSS_INTRO / PHASE_TRANS / GAME_OVER），
+ * 以及弹簧物理震动 + FOV 脉冲。
+ */
+
+export class CameraController {
+    /**
+     * @param {THREE.PerspectiveCamera} camera
+     */
+    constructor(camera) {
+        this.camera = camera;
+        // 记录"基准位置"，所有扰动都相对它叠加
+        this.baseX = camera.position.x;
+        this.baseY = camera.position.y;
+        this.baseZ = camera.position.z;
+
+        this.t = 0;
+        this.state = 'IDLE';
+
+        // 待 M4 接入：事件队列、弹簧状态、FOV 脉冲
+        // this._impulses = [];
+        // this._fovBase = camera.fov;
+    }
+
+    /**
+     * @param {number} dt seconds
+     */
+    update(dt) {
+        this.t += dt;
+        // IDLE 呼吸：极小位移 + 极小旋转感（通过位移 + lookAt 体现）
+        // 幅度刻意压低，避免与 DoF/畸变叠加后晕动。
+        const px = this.baseX + Math.sin(this.t * 0.40) * 1.2;
+        const py = this.baseY + Math.cos(this.t * 0.32) * 0.8;
+        const pz = this.baseZ + Math.sin(this.t * 0.25) * 0.5;
+        this.camera.position.set(px, py, pz);
+        this.camera.lookAt(0, 0, 0);
+    }
+
+    /**
+     * 重置到基准位置（阶段切换/调试用）。
+     */
+    reset() {
+        this.t = 0;
+        this.camera.position.set(this.baseX, this.baseY, this.baseZ);
+        this.camera.lookAt(0, 0, 0);
+    }
+}

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -1,0 +1,131 @@
+/**
+ * Renderer3D.js - 3D 渲染管线主入口（M1：仅背景层）
+ *
+ * 职责：
+ *   - 初始化 Three.js WebGLRenderer / Scene / PerspectiveCamera
+ *   - 装配 BackgroundLayer（远景剪影/光柱/星云）
+ *   - 装配 CameraController（M1 仅 IDLE 呼吸漂移）
+ *   - 暴露 resize(w,h) / render(now) / dispose()
+ *   - 暴露 CoordsMapper 供后续 milestone 用于 2D→3D 坐标转换
+ *
+ * 与游戏循环的对接：
+ *   - core.js 构造 Game 时 try/catch 初始化此渲染器；任何失败 → 静默降级到 2D-only
+ *   - sys_loop 每帧首调 this.renderer3d?.render(performance.now())
+ *   - sys_resize 每次画布尺寸变化调 this.renderer3d?.resize(w, h)
+ */
+
+import * as THREE from 'three';
+import { BackgroundLayer } from './BackgroundLayer.js';
+import { CameraController } from './CameraController.js';
+import { CoordsMapper } from './coords.js';
+
+export class Renderer3D {
+    /**
+     * @param {HTMLCanvasElement} canvas    WebGL canvas 元素
+     * @param {number}            width     initial pixel width
+     * @param {number}            height    initial pixel height
+     */
+    constructor(canvas, width, height) {
+        if (!canvas) throw new Error('[Renderer3D] canvas element required');
+
+        this.canvas = canvas;
+        this.width = Math.max(1, width | 0);
+        this.height = Math.max(1, height | 0);
+
+        this._initRenderer();
+        this._initScene();
+        this._initCamera();
+        this._initLayers();
+
+        this.coords = new CoordsMapper(this.width, this.height);
+        this.cameraController = new CameraController(this.camera);
+
+        // 帧计时（秒）
+        this._tElapsed = 0;
+        this._lastNow = 0;
+
+        // 调试统计（可被外部读取）
+        this.stats = { frames: 0, lastDtMs: 0 };
+    }
+
+    _initRenderer() {
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: this.canvas,
+            antialias: true,
+            alpha: true,                 // 让背景颜色由 setClearColor 决定，便于后续 HUD 合成
+            powerPreference: 'high-performance',
+            stencil: false,
+            depth: true,
+        });
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+        // 第三个参数 false → 不修改 canvas 的 CSS 尺寸（CSS 由 index.html 全局规则控制）
+        this.renderer.setSize(this.width, this.height, false);
+        this.renderer.setClearColor(0x05060d, 1);
+        // r152+ 用 outputColorSpace 替代 outputEncoding
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+    }
+
+    _initScene() {
+        this.scene = new THREE.Scene();
+        // 体积雾 ≈ 远景柔化 & 景深前奏；M4 接入后处理 DoF 时会进一步加强
+        this.scene.fog = new THREE.FogExp2(0x05060d, 0.0025);
+    }
+
+    _initCamera() {
+        const aspect = this.width / this.height;
+        // 窄 FOV：玩法面板（z=0）接近正交，畸变小，便于读图
+        this.camera = new THREE.PerspectiveCamera(28, aspect, 10, 600);
+        this.camera.position.set(0, -10, 180);
+        this.camera.lookAt(0, 0, 0);
+    }
+
+    _initLayers() {
+        this.background = new BackgroundLayer(this.scene);
+        // M2 接入：玩法面板钉子；M3：敌人；M4：后处理；M5：遗物 3D 卡片；M6：GPU 粒子
+    }
+
+    /**
+     * 同步画布尺寸。调用方负责保证传入的就是 2D Canvas 的 width/height。
+     */
+    resize(width, height) {
+        const W = Math.max(1, width | 0);
+        const H = Math.max(1, height | 0);
+        if (W === this.width && H === this.height) return;
+        this.width = W;
+        this.height = H;
+        this.renderer.setSize(W, H, false);
+        this.camera.aspect = W / H;
+        this.camera.updateProjectionMatrix();
+        this.coords.update(W, H);
+    }
+
+    /**
+     * 每帧调用一次。
+     * @param {number} nowMs performance.now() 时间戳
+     */
+    render(nowMs) {
+        if (this._lastNow === 0) this._lastNow = nowMs;
+        // 限制 dt 上限避免标签页切回时的大跳变
+        const dt = Math.min(0.1, Math.max(0, (nowMs - this._lastNow) / 1000));
+        this._lastNow = nowMs;
+        this._tElapsed += dt;
+
+        if (this.background) this.background.update(dt, this._tElapsed);
+        if (this.cameraController) this.cameraController.update(dt);
+
+        this.renderer.render(this.scene, this.camera);
+
+        this.stats.frames++;
+        this.stats.lastDtMs = dt * 1000;
+    }
+
+    dispose() {
+        try { if (this.background) this.background.dispose(); } catch (e) {}
+        try { this.renderer.dispose(); } catch (e) {}
+        this.background = null;
+        this.cameraController = null;
+        this.scene = null;
+        this.camera = null;
+        this.renderer = null;
+    }
+}

--- a/src/render3d/coords.js
+++ b/src/render3d/coords.js
@@ -1,0 +1,49 @@
+/**
+ * coords.js - 2D Canvas ↔ 3D World 坐标映射
+ *
+ * 2D Canvas (现状): origin=top-left, x→right, y→down, units=px (W × H)
+ * 3D World (新版):  origin=center,   x→right, y→up,   units=world unit (1:1 映射)
+ *
+ * 所有玩法实体（钉子/弹珠/敌人）的坐标仍以 Canvas px 存在；渲染层调用 toWorld()
+ * 转换到 z=0 平面。逆向 toCanvas() 用于将世界坐标投影回 UI 层（HUD 锚定等）。
+ */
+
+export class CoordsMapper {
+    /**
+     * @param {number} canvasWidth  Canvas internal pixel width (CSS-resolved)
+     * @param {number} canvasHeight Canvas internal pixel height
+     */
+    constructor(canvasWidth, canvasHeight) {
+        this.update(canvasWidth, canvasHeight);
+    }
+
+    update(canvasWidth, canvasHeight) {
+        this.W = Math.max(1, canvasWidth | 0);
+        this.H = Math.max(1, canvasHeight | 0);
+        // 1 canvas px = 1 world unit；相机 FOV/距离已按此校准
+        this.scale = 1;
+    }
+
+    /**
+     * Canvas px → world position on z=0 plane.
+     * @returns {{x:number, y:number, z:number}}
+     */
+    toWorld(x, y, z = 0) {
+        return {
+            x: (x - this.W * 0.5) * this.scale,
+            y: -(y - this.H * 0.5) * this.scale,
+            z,
+        };
+    }
+
+    /**
+     * World → canvas px（仅 x/y 维度，z 信息丢失）。
+     * @returns {{x:number, y:number}}
+     */
+    toCanvas(x, y) {
+        return {
+            x: x / this.scale + this.W * 0.5,
+            y: -y / this.scale + this.H * 0.5,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

3D 视觉重构的第一个里程碑——把 Three.js 接进来，铺一层"舞台"，玩法零干扰。

完成清单（对应 [`docs/visual_redesign_3d_plan.md`](https://github.com/gdszyy/echo-alchemist-v2-1766564886/blob/3D-Main/docs/visual_redesign_3d_plan.md) §9 M1）：

- [x] 引入 Three.js r160（CDN + importmap）
- [x] 建立 WebGL canvas（`#gl-canvas`），定位在 2D `#gameCanvas` 之下
- [x] 实现 `Renderer3D` + 空场景 + 远景层 + 相机
- [x] 启动后 3D 场景持续渲染；原 2D 内容默认仍叠加在上方
- [x] 可玩性不受影响（try/catch 兜底 + kill switch）

## 文件变更

| 类型 | 文件 | 说明 |
| :--- | :--- | :--- |
| 新增 | `src/render3d/Renderer3D.js` | 主入口：WebGLRenderer + Scene + Camera + 帧循环 |
| 新增 | `src/render3d/BackgroundLayer.js` | SkyDome（程序化星云 shader）+ 14 个低多边形剪影 + 4 根体积光柱 + 150 个 GPU 粒子 |
| 新增 | `src/render3d/CameraController.js` | M1 阶段 stub：IDLE 呼吸漂移；M4 扩展为状态机 |
| 新增 | `src/render3d/coords.js` | 2D canvas px ↔ 3D world unit 双向映射 |
| 修改 | `index.html` | 加 importmap（head）+ `<canvas id="gl-canvas">` + CSS（绝对定位、z-index:0、pointer-events:none）+ 调试 class |
| 修改 | `src/core.js` | 构造期 try/catch 实例化 Renderer3D；dispose 释放 WebGL |
| 修改 | `src/game_system.js` | sys_loop 每帧调 `render(now)`；sys_resize 同步内部像素尺寸 |

## 视觉层组成（M1 仅 L0 + L1 远景）

```
[Z = -200] L0 远景层    : SkyDome + 体积雾 + 14 个剪影（炼金塔/管道）
[Z = -100] L1 中后景层  : 4 根体积光柱（青/紫/蓝/橙）+ 150 个上升粒子
[Z = 0   ] L2 玩法面板  : (M2 接入：钉板)
[Z = +30 ] L3 前景HUD层 : (M5 接入：发射器、遗物卡片)
```

相机配置：`PerspectiveCamera(fov=28°, near=10, far=600)`，位置 `(0, -10, 180)`，IDLE 状态有 ±1.2px 的呼吸漂移。

## 默认表现

**视觉**：与现有版本完全一致——3D 层始终渲染但被不透明的 2D canvas 覆盖。

**性能**：每帧增加一次 WebGL render。14 剪影 + 4 锥 + 150 粒子 + 1 dome ≈ 20 个 draw call，预计 < 0.5ms / 帧。

## 调试与降级

| 操作 | 效果 |
| :--- | :--- |
| `document.body.classList.add('render3d-debug')` | 2D canvas 降到 30% 不透明度，3D 背景透出来；gl-canvas 加蓝色边框 |
| `localStorage.echo_3d_disabled = '1'` 后刷新 | 完全跳过 Renderer3D init，回到纯 2D 模式 |
| Three.js CDN 不可达 / WebGL 不支持 | 自动 try/catch，渲染降级到 2D，控制台 warn |
| 渲染期单帧出错 | 一次性 dispose + 置 null，避免错误循环刷屏 |

## Test plan

- [ ] 浏览器打开游戏，正常进入主菜单 / 命运抉择 / 研磨 / 战斗，确认视觉与之前完全一致
- [ ] DevTools Console 检查启动日志：
  - 应看到 `[Renderer3D] initialized @ <W>x<H>`
  - 不应有任何 error
- [ ] DevTools Elements 检查：`#game-container` 下应有 `<canvas id="gl-canvas">`，z-index:0，pointer-events:none
- [ ] DevTools Console 执行 `document.body.classList.add('render3d-debug')`，应能看到 3D 背景（星云天幕 + 远处剪影轮廓 + 流动光柱 + 上升粒子）
- [ ] Performance：60fps 应维持稳定
- [ ] 移动端 / PC 浏览器各测一次（resize、横竖屏切换）
- [ ] 暂停状态下 3D 仍在呼吸（氛围感保持）
- [ ] kill switch：`localStorage.echo_3d_disabled='1'` 后刷新，应不创建 gl-canvas（或创建但不渲染），无报错

## 已知非问题

- 钉板/弹珠/敌人/UI 仍为 2D —— 这是 M2/M3/M5 的范围
- 没有后处理（无 DoF/畸变/Bloom）—— M4 范围
- 粒子是基础 PointsMaterial 而非 GPU shader 系统 —— M6 范围

## 下一个里程碑

**M2**：钉板 3D 化（PegInstancedMesh + shader），弹珠 3D mesh + 拖尾。这一步开始触及玩法可读性，需要谨慎测试。

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_