### PR TITLE
feat(3d/M5): procedural relic cards + rune hex meshes + glass HUD CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2794,6 +2794,8 @@
     </style>
     <!-- Phase 5A: 位图化 UI 样式覆盖层 -->
     <link rel="stylesheet" href="src/styles/bitmap_ui.css">
+    <!-- [3D-Main M5] 全息玻璃风 HUD 覆盖（opt-in: body.glass-ui-enabled）-->
+    <link rel="stylesheet" href="src/styles/glass_ui.css">
 
     <!-- [3D-Main M1] Three.js importmap：让 `import * as THREE from 'three'` 解析到 CDN ESM 构建。
          版本锁定 r160（与 docs/visual_redesign_3d_plan.md §6 一致）。

--- a/index.html
+++ b/index.html
@@ -151,6 +151,33 @@
             pointer-events: auto;
         }
 
+        /* ===== 3D WebGL 背景层（M1 起引入） =====
+         * 位于 2D #gameCanvas 之下，铺满 #game-container。
+         * 不接收事件（pointer-events: none），不参与 layout（position: absolute）。
+         * 内部分辨率由 JS（Renderer3D）按 2D Canvas 同步设置。
+         */
+        #gl-canvas {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+            pointer-events: none;
+            /* 默认隐藏：仅当 body 带 .render3d-enabled 类或显式 opacity 调整时可见。
+             * M1 阶段我们让它始终渲染（用于性能/正确性验证），但 2D 不透明覆盖之 → 看不到。
+             * 调试时可在 console 执行：
+             *   document.body.classList.add('render3d-debug')
+             * 即可看到下层 3D 背景（同步降低 2D 不透明度到 0.3）。
+             */
+        }
+        body.render3d-debug #gameCanvas {
+            opacity: 0.30;
+            transition: opacity 0.2s ease;
+        }
+        body.render3d-debug #gl-canvas {
+            outline: 1px solid rgba(56, 189, 248, 0.4);
+        }
+
         @keyframes shake-hard {
             0% { transform: translate(0, 0); }
             25% { transform: translate(-5px, 5px); }
@@ -2767,6 +2794,18 @@
     </style>
     <!-- Phase 5A: 位图化 UI 样式覆盖层 -->
     <link rel="stylesheet" href="src/styles/bitmap_ui.css">
+
+    <!-- [3D-Main M1] Three.js importmap：让 `import * as THREE from 'three'` 解析到 CDN ESM 构建。
+         版本锁定 r160（与 docs/visual_redesign_3d_plan.md §6 一致）。
+         若 CDN 不可达，Renderer3D 构造会抛错并被 core.js try/catch 静默降级到 2D-only。 -->
+    <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+      }
+    }
+    </script>
 </head>
 <body>
 <div id="app-wrapper">
@@ -2788,6 +2827,8 @@
 </aside>
 
 <div id="game-container">
+    <!-- [3D-Main M1] WebGL 背景层。位于 2D #gameCanvas 之下，由 src/render3d/Renderer3D.js 驱动 -->
+    <canvas id="gl-canvas"></canvas>
     <canvas id="gameCanvas"></canvas>
     <div id="crt-overlay"></div>
 

--- a/src/config.js
+++ b/src/config.js
@@ -756,8 +756,10 @@ const CONFIG = {
         moduleAreaBottomMargin: 80,    // 模块区域底部留白
         moduleSpacingX: 4,             // 模块横向间距 px
         moduleSpacingY: 4,             // 模块纵向间距 px
-        // 钉板左右两侧到画布墙的留白（每侧 1.5 个弹珠直径 = 1.5 × 2 × 7.7 ≈ 23 px）
-        moduleAreaSideMargin: 23,
+        // 钉板左右两侧到画布墙的留白
+        // [3D-Main M2] 23 → 32：钉子半径增大到 11 px（视觉）后，原 23 px 留白让最左/最右钉子与
+        //   左右能量墙的发光区视觉重叠。32 = 11(peg radius) + 10(marble doubled radius) + 11(buffer)
+        moduleAreaSideMargin: 32,
         // ==================== [v2 局内商店 + 符文碎片经济] ====================
         runShopInterval: 2,            // 每 N 场战斗弹出一次局内商店
         runShopRefreshCost: 10,        // 刷新一次商店消耗碎片

--- a/src/core.js
+++ b/src/core.js
@@ -46,6 +46,8 @@ import { calc_utils } from './calc_utils.js';
 import { tutorial_system } from './tutorial_system.js';
 import { game_over_mixin } from './ui/game_over.js';
 import { preloadAllSprites } from './render/sprite_renderer.js'; // [Phase 5B] 预加载所有 Sprite Sheet
+// [3D-Main M1] 引入 3D 渲染管线（仅背景层）。任何加载/初始化失败都会被静默降级到 2D-only。
+import { Renderer3D } from './render3d/Renderer3D.js';
 
 // ==================== 延迟音频初始化 ====================
 let _audioInitialized = false;
@@ -359,6 +361,35 @@ class Game {
         this._perfManualMode = null;
         // [Phase 5B] 预加载所有 Sprite Sheet（在游戏循环开始前触发异步加载）
         preloadAllSprites();
+
+        // ==================== [3D-Main M1] 初始化 3D 渲染管线 ====================
+        // 设计契约：
+        //   1. 任何初始化失败（Three.js CDN 拉取失败、WebGL 不支持、shader 编译错）→
+        //      this.renderer3d = null，主循环 / resize 调用都用可选链跳过。
+        //   2. 默认开启；可通过 localStorage.echo_3d_disabled = '1' 强制关闭。
+        //   3. 调试可见：document.body.classList.add('render3d-debug')
+        //      （把 2D #gameCanvas 透明度降到 0.3 即可看到 3D 背景）。
+        this.renderer3d = null;
+        try {
+            if (typeof localStorage !== 'undefined' && localStorage.getItem('echo_3d_disabled') === '1') {
+                console.info('[Renderer3D] disabled via localStorage.echo_3d_disabled');
+            } else {
+                const glCanvas = document.getElementById('gl-canvas');
+                if (!glCanvas) {
+                    console.warn('[Renderer3D] #gl-canvas not found, skipping 3D init');
+                } else {
+                    // sys_resize() 已在上面跑过，this.width/this.height 已就绪
+                    this.renderer3d = new Renderer3D(glCanvas, this.width, this.height);
+                    // 同步内部像素尺寸到 2D canvas
+                    this.renderer3d.resize(this.canvas.width, this.canvas.height);
+                    console.info(`[Renderer3D] initialized @ ${this.canvas.width}x${this.canvas.height}`);
+                }
+            }
+        } catch (err) {
+            console.error('[Renderer3D] init failed, falling back to 2D-only:', err);
+            this.renderer3d = null;
+        }
+
         // 启动游戏主循环
         this.sys_loop();
     }
@@ -476,6 +507,11 @@ class Game {
         if (this._resizeObserver) {
             try { this._resizeObserver.disconnect(); } catch (e) {}
             this._resizeObserver = null;
+        }
+        // [3D-Main M1] 释放 WebGL 资源
+        if (this.renderer3d) {
+            try { this.renderer3d.dispose(); } catch (e) {}
+            this.renderer3d = null;
         }
     }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -379,7 +379,11 @@ class Game {
                     console.warn('[Renderer3D] #gl-canvas not found, skipping 3D init');
                 } else {
                     // sys_resize() 已在上面跑过，this.width/this.height 已就绪
-                    this.renderer3d = new Renderer3D(glCanvas, this.width, this.height);
+                    this.renderer3d = new Renderer3D(glCanvas, this.width, this.height, {
+                        // [M4.5] 把 eventBus 注入到 3D 层，让 damage/kill/boss/phase 事件
+                        // 自动驱动相机震动 + 后处理 boost
+                        eventBus: this.eventBus,
+                    });
                     // 同步内部像素尺寸到 2D canvas
                     this.renderer3d.resize(this.canvas.width, this.canvas.height);
                     console.info(`[Renderer3D] initialized @ ${this.canvas.width}x${this.canvas.height}`);

--- a/src/entities.js
+++ b/src/entities.js
@@ -524,7 +524,8 @@ class GhostPeg {
      */
     constructor(x, y, type, level) {
         this.pos = new Vec2(x, y);
-        this.radius = 6;
+        // [3D-Main M2] 与 Peg.radius 同步：6 → 8
+        this.radius = 8;
         this.type = type;
         this.level = level || 1;
         this.life = 180;       // 存活 180 帧（约 3 秒）
@@ -814,8 +815,9 @@ class TriangleSideWheel {
 
 class Peg {
     constructor(x, y, type = 'normal') {
-        this.pos = new Vec2(x, y); 
-        this.radius = 6; 
+        this.pos = new Vec2(x, y);
+        // [3D-Main M2] 6 → 8，配合视觉钉子变大；MIN_PEG_SPACING 同步更新
+        this.radius = 8;
         this.type = type; 
         this.lit = false; 
         this.litTimer = 0; 
@@ -2426,7 +2428,7 @@ class DropBall {
                     if (_segLenSq > 0) {
                         _t = ((this.pos.x - slot.x) * _sx + (this.pos.y - slot.y) * _sy) / _segLenSq;
                         // 钉子半径 / 线段长度 = 端点排除区间宽度
-                        const _pegR = 6; // Peg.radius
+                        const _pegR = 8; // Peg.radius (3D-Main M2: 6 → 8)
                         const _segLen = Math.sqrt(_segLenSq);
                         const _tMargin = _pegR / _segLen;
                         // 只有投影落在两端钉子之间的内部区间时才触发

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -68,7 +68,14 @@ export const game_phase = {
         } else {
             console.log('[phase_switchPhase] ' + oldPhase + ' -> ' + newPhase);
         }
-        
+
+        // [3D-Main M2] 通知 3D 渲染层阶段变化（控制钉子/墙的可见性）
+        if (this.renderer3d && this.renderer3d.proxy) {
+            try { this.renderer3d.proxy.setPhase(newPhase); } catch (e) {
+                console.warn('[Renderer3D] proxy.setPhase error:', e);
+            }
+        }
+
         // 事件总线广播阶段切换
         eventBus.emit(EVENT_TYPES.PHASE_CHANGED, { from: oldPhase, to: newPhase });
         
@@ -2822,17 +2829,25 @@ phase_gathering_getRandomPegType() {
             this.phase_gathering_initPachinko();
         }
 
-        this.pegs.forEach((p, idx) => { 
+        this.pegs.forEach((p, idx) => {
             p.update(); // 更新冷却和动画
-            p.draw(this.ctx, pegRadius); 
+            p.draw(this.ctx, pegRadius);
             p.resetLight();
-            
+
             // 调试日志：检查是否有槽位叠加在当前钉子上
             const hasSlot = this.specialSlots.some(s => s.pegIndex === idx);
             if (hasSlot && Math.random() < 0.01) {
                 console.log(`[DEBUG] Rendering peg ${idx} with overlaid special slot at (${p.pos.x.toFixed(1)}, ${p.pos.y.toFixed(1)})`);
             }
         });
+
+        // [3D-Main M2] 把当前钉子数组同步到 3D InstancedMesh（每帧一次）
+        // 1 帧后 Renderer3D.render() 才会取到新数据，但 60fps 下不可察觉
+        if (this.renderer3d && this.renderer3d.proxy) {
+            try { this.renderer3d.proxy.syncPegs(this.pegs, pegRadius); } catch (e) {
+                console.warn('[Renderer3D] syncPegs error:', e);
+            }
+        }
 
         
         lightSources.forEach(ball => {

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -2102,6 +2102,13 @@ phase_gathering_getRandomPegType() {
                 }
             });
 
+            // [3D-Main M3] 把当前 enemies[] 同步到 3D EnemyMeshPool（每帧一次）
+            if (this.renderer3d && this.renderer3d.proxy) {
+                try { this.renderer3d.proxy.syncEnemies(this.enemies); } catch (e) {
+                    console.warn('[Renderer3D] syncEnemies error:', e);
+                }
+            }
+
             // [猎人本能] 绘制持续标记特效：找到血量最低的活跃敌人并渲染动态瞄准十字准星
             if (this.ownedRelics && this.ownedRelics.includes('hunter_instinct')) {
                 let hunterTarget = null;

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -2813,7 +2813,8 @@ phase_gathering_getRandomPegType() {
         });
         // 繪製釘子
         // [修复] 增加保底半径，防止 this.width 为 0 时钉子消失
-        const pegRadius = Math.max(4, Math.min(8, (this.width || 400) / 60));
+        // [3D-Main M2] 半径区间 [4,8] → [6,11]、除数 60 → 45（视觉 +33%，与 PEG_RADIUS 物理 6→8 同步）
+        const pegRadius = Math.max(6, Math.min(11, (this.width || 400) / 45));
         
         // [防御性检查] 如果钉子数组为空，尝试自动恢复
         if (this.pegs.length === 0) {

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -80,6 +80,20 @@ export const game_system = {
         this._lastFrameTime = _now;
         // ==================== [自适应性能] END ====================
 
+        // ==================== [3D-Main M1] 3D 背景层渲染 ====================
+        // 即便暂停（isPaused）也持续渲染 3D 背景，保持氛围"活着"的呼吸感。
+        // 失败回退已在 Renderer3D 构造阶段处理（this.renderer3d 可能为 null）。
+        if (this.renderer3d) {
+            try {
+                this.renderer3d.render(_now);
+            } catch (err) {
+                // 渲染期出错（如 shader 编译延迟失败）→ 一次性禁用，避免循环报错刷屏
+                console.error('[Renderer3D] render error, disabling:', err);
+                try { this.renderer3d.dispose(); } catch (_) {}
+                this.renderer3d = null;
+            }
+        }
+
         // 暂停时跳过物理更新，但继续请求下一帧以保持 rAF 循环活跃
         if (this.isPaused) {
             requestAnimationFrame(() => this.sys_loop());
@@ -210,6 +224,13 @@ export const game_system = {
         if (!rect.width || !rect.height) return;
         this.width = this.canvas.width = Math.round(rect.width);
         this.height = this.canvas.height = Math.round(rect.height);
+
+        // [3D-Main M1] 同步 WebGL canvas 内部分辨率（CSS 尺寸由全局 canvas 规则控制）
+        if (this.renderer3d) {
+            try { this.renderer3d.resize(this.width, this.height); } catch (e) {
+                console.warn('[Renderer3D] resize error:', e);
+            }
+        }
 
         // 动态调整失败判定线
         // PC 模式下底部面板隐藏，可以缩小安全边距

--- a/src/pinboard_modules.js
+++ b/src/pinboard_modules.js
@@ -25,10 +25,11 @@ import { Peg, SpecialSlot } from './entities.js';
 const RANDOMIZABLE_PEG_TYPES = ['bounce', 'pierce', 'scatter', 'damage', 'cryo', 'pyro', 'wind'];
 
 // 倍化弹珠半径 = marbleRadius(7.7) + maxSizeBonus(2.5)
-const PEG_RADIUS = 6;               // 与 entities.js Peg.radius 一致
+// [3D-Main M2] 钉子半径从 6 → 8（+33%），配合 3D 钉子视觉变大
+const PEG_RADIUS = 8;               // 与 entities.js Peg.radius 一致
 const DOUBLED_MARBLE_RADIUS = 10.2; // marbleRadius(7.7) + maxSizeBonus(2.5)
 // 最小中心到中心间距 = 两侧钉子半径 + 倍化弹珠直径，确保倍化弹珠能通过
-const MIN_PEG_SPACING = 2 * PEG_RADIUS + 2 * DOUBLED_MARBLE_RADIUS; // = 32.4 px
+const MIN_PEG_SPACING = 2 * PEG_RADIUS + 2 * DOUBLED_MARBLE_RADIUS; // = 36.4 px (was 32.4)
 
 /**
  * 按当前局内属性权重随机生成 peg 类型。
@@ -135,11 +136,12 @@ export const MODULE_DEFS = {
         id: 'std_stagger',
         name: '標準交錯',
         icon: '▦',
-        desc: '3×3 普通釘子，標準交錯排列。',
+        desc: '2×3 普通釘子，標準交錯排列。',
         rarity: 'common',
         price: 0,
+        // [3D-Main M2] 3×3 → 2×3：钉子总数 -33%（配合 3D 渲染钉子变大，密度降低以保证可读性）
         build(ox, oy, w, h) {
-            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 2, 3, 'normal');
             return { pegs, specialSlots: [] };
         },
     },
@@ -147,11 +149,12 @@ export const MODULE_DEFS = {
         id: 'dense_stagger',
         name: '密集交錯',
         icon: '▩',
-        desc: '4×3 密集普通釘子，弹珠碰撞次數多。',
+        desc: '3×3 密集普通釘子，弹珠碰撞次數多。',
         rarity: 'common',
         price: 0,
+        // [3D-Main M2] 4×3 → 3×3：-25%
         build(ox, oy, w, h) {
-            const pegs = generateStaggeredPegs(ox, oy, w, h, 4, 3, 'normal');
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
             return { pegs, specialSlots: [] };
         },
     },
@@ -163,7 +166,8 @@ export const MODULE_DEFS = {
         rarity: 'common',
         price: 0,
         build(ox, oy, w, h) {
-            const pegs = generateStaggeredPegs(ox, oy, w, h, 3, 3, 'normal');
+            // [3D-Main M2] 3×3 → 2×3：-33%
+            const pegs = generateStaggeredPegs(ox, oy, w, h, 2, 3, 'normal');
             if (pegs.length > 0) {
                 let bestIdx = 0;
                 let bestDist = Infinity;

--- a/src/render3d/BackgroundLayer.js
+++ b/src/render3d/BackgroundLayer.js
@@ -1,0 +1,268 @@
+/**
+ * BackgroundLayer.js - 远景/中后景大气层（L0 + L1）
+ *
+ * 组成：
+ *   1. SkyDome - 反法线球体，shader 程序化生成深空蓝→紫的"星云"
+ *   2. 远处剪影 - 低多边形 box 阵列（z = -200），暗色无 emissive
+ *   3. 体积光柱 - 4 根 additive 圆锥，慢转 + 上下浮动
+ *   4. 环境粒子 - 150 颗 GPU points，缓慢上升，循环复位
+ *
+ * 所有元素都挂在 z < 0 的远景；后续 milestone 玩法面板会放在 z=0。
+ */
+
+import * as THREE from 'three';
+
+// 暗黑炼金调色板（同 visual_redesign_3d_plan.md §1.3）
+const COLOR_DEEP    = 0x0a0e1a;
+const COLOR_MID     = 0x1a1f3a;
+const COLOR_ACCENT  = 0x3b2160;
+const SILHOUETTE_COL = 0x0d1320;
+const CONE_COLORS   = [0x38bdf8, 0xa78bfa, 0x60a5fa, 0xf59e0b];
+const PARTICLE_COL  = 0x60a5fa;
+
+export class BackgroundLayer {
+    /**
+     * @param {THREE.Scene} scene
+     */
+    constructor(scene) {
+        this.scene = scene;
+        this.group = new THREE.Group();
+        this.group.name = 'BackgroundLayer';
+        scene.add(this.group);
+
+        this._createSkyDome();
+        this._createDistantSilhouettes();
+        this._createVolumetricLights();
+        this._createAmbientParticles();
+    }
+
+    // -------------------- 天幕 --------------------
+    _createSkyDome() {
+        const geometry = new THREE.SphereGeometry(450, 24, 16);
+        const material = new THREE.ShaderMaterial({
+            side: THREE.BackSide,
+            depthWrite: false,
+            uniforms: {
+                uTime:        { value: 0 },
+                uColorDeep:   { value: new THREE.Color(COLOR_DEEP) },
+                uColorMid:    { value: new THREE.Color(COLOR_MID) },
+                uColorAccent: { value: new THREE.Color(COLOR_ACCENT) },
+            },
+            vertexShader: /* glsl */`
+                varying vec3 vDir;
+                void main() {
+                    vDir = normalize(position);
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform vec3  uColorDeep;
+                uniform vec3  uColorMid;
+                uniform vec3  uColorAccent;
+                uniform float uTime;
+                varying vec3  vDir;
+
+                // 廉价 hash 噪声（够用即可）
+                float hash3(vec3 p) {
+                    p = fract(p * 0.3183099 + vec3(0.1, 0.13, 0.17));
+                    p *= 17.0;
+                    return fract(p.x * p.y * p.z * (p.x + p.y + p.z));
+                }
+                float noise3(vec3 p) {
+                    vec3 i = floor(p);
+                    vec3 f = fract(p);
+                    f = f * f * (3.0 - 2.0 * f);
+                    float n000 = hash3(i + vec3(0.0, 0.0, 0.0));
+                    float n100 = hash3(i + vec3(1.0, 0.0, 0.0));
+                    float n010 = hash3(i + vec3(0.0, 1.0, 0.0));
+                    float n110 = hash3(i + vec3(1.0, 1.0, 0.0));
+                    float n001 = hash3(i + vec3(0.0, 0.0, 1.0));
+                    float n101 = hash3(i + vec3(1.0, 0.0, 1.0));
+                    float n011 = hash3(i + vec3(0.0, 1.0, 1.0));
+                    float n111 = hash3(i + vec3(1.0, 1.0, 1.0));
+                    float nx00 = mix(n000, n100, f.x);
+                    float nx10 = mix(n010, n110, f.x);
+                    float nx01 = mix(n001, n101, f.x);
+                    float nx11 = mix(n011, n111, f.x);
+                    float nxy0 = mix(nx00, nx10, f.y);
+                    float nxy1 = mix(nx01, nx11, f.y);
+                    return mix(nxy0, nxy1, f.z);
+                }
+
+                void main() {
+                    // 垂直渐变（深空 → 中蓝）
+                    float t = clamp(0.5 + vDir.y * 0.5, 0.0, 1.0);
+                    vec3 col = mix(uColorDeep, uColorMid, t);
+
+                    // 星云斑块（低频噪声 + 时间漂移）
+                    float n = noise3(vDir * 4.0 + vec3(uTime * 0.015, 0.0, uTime * 0.01));
+                    col = mix(col, uColorAccent, smoothstep(0.55, 0.95, n) * 0.35);
+
+                    // 微弱星点
+                    float stars = step(0.985, hash3(floor(vDir * 200.0))) * 0.5;
+                    col += vec3(stars);
+
+                    gl_FragColor = vec4(col, 1.0);
+                }
+            `,
+        });
+        this.skyMaterial = material;
+        const dome = new THREE.Mesh(geometry, material);
+        dome.name = 'SkyDome';
+        this.group.add(dome);
+    }
+
+    // -------------------- 远处剪影 --------------------
+    _createDistantSilhouettes() {
+        const silhouetteGroup = new THREE.Group();
+        silhouetteGroup.name = 'DistantSilhouettes';
+        const mat = new THREE.MeshBasicMaterial({
+            color: SILHOUETTE_COL,
+            depthWrite: false,
+            fog: true,
+        });
+
+        // 确定性 PRNG，让剪影布局每次启动一致（便于风格 review）
+        const rng = mulberry32(2024);
+        const count = 14;
+        // 共享几何减少 draw call（box 都用同一个 BufferGeometry，通过 scale 区分大小）
+        const baseGeom = new THREE.BoxGeometry(1, 1, 1);
+        for (let i = 0; i < count; i++) {
+            const w = 6 + rng() * 18;
+            const h = 30 + rng() * 80;
+            const d = 6 + rng() * 12;
+            const m = new THREE.Mesh(baseGeom, mat);
+            m.scale.set(w, h, d);
+            m.position.set(
+                (rng() - 0.5) * 360,
+                -40 - rng() * 40,
+                -180 - rng() * 60
+            );
+            silhouetteGroup.add(m);
+        }
+        this.silhouetteGroup = silhouetteGroup;
+        this.group.add(silhouetteGroup);
+    }
+
+    // -------------------- 体积光柱 --------------------
+    _createVolumetricLights() {
+        const lightGroup = new THREE.Group();
+        lightGroup.name = 'VolumetricLights';
+        // 单个圆锥几何复用（半径靠 scale 拉伸）
+        const baseGeom = new THREE.ConeGeometry(1, 1, 18, 1, true);
+        for (let i = 0; i < 4; i++) {
+            const color = CONE_COLORS[i % CONE_COLORS.length];
+            const mat = new THREE.MeshBasicMaterial({
+                color,
+                transparent: true,
+                opacity: 0.06,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+                side: THREE.DoubleSide,
+                fog: false,
+            });
+            const cone = new THREE.Mesh(baseGeom, mat);
+            const radius = 20 + i * 6;
+            const height = 220 + i * 20;
+            cone.scale.set(radius, height, radius);
+            cone.position.set(
+                -120 + i * 80,
+                -40,
+                -90 - i * 8
+            );
+            // 圆锥默认尖端朝 +Y；我们让光"自下而上洒"，所以翻转
+            cone.rotation.z = Math.PI;
+            cone.userData = { baseY: cone.position.y, phase: i * 1.7 };
+            lightGroup.add(cone);
+        }
+        this.lightGroup = lightGroup;
+        this.group.add(lightGroup);
+    }
+
+    // -------------------- 环境粒子 --------------------
+    _createAmbientParticles() {
+        const count = 150;
+        const positions = new Float32Array(count * 3);
+        const speeds = new Float32Array(count);
+        for (let i = 0; i < count; i++) {
+            positions[i * 3 + 0] = (Math.random() - 0.5) * 320;
+            positions[i * 3 + 1] = -160 + Math.random() * 320;
+            positions[i * 3 + 2] = -100 + Math.random() * 80;
+            speeds[i] = 2 + Math.random() * 5;
+        }
+        const geom = new THREE.BufferGeometry();
+        geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        const mat = new THREE.PointsMaterial({
+            color: PARTICLE_COL,
+            size: 1.6,
+            sizeAttenuation: true,
+            transparent: true,
+            opacity: 0.35,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            fog: true,
+        });
+        const points = new THREE.Points(geom, mat);
+        points.name = 'AmbientParticles';
+        this.ambientPoints = points;
+        this._ambientSpeeds = speeds;
+        this.group.add(points);
+    }
+
+    // -------------------- 帧更新 --------------------
+    /**
+     * @param {number} dt seconds (clamped)
+     * @param {number} t  seconds elapsed total
+     */
+    update(dt, t) {
+        if (this.skyMaterial) this.skyMaterial.uniforms.uTime.value = t;
+
+        if (this.lightGroup) {
+            const children = this.lightGroup.children;
+            for (let i = 0; i < children.length; i++) {
+                const cone = children[i];
+                const ud = cone.userData;
+                cone.position.y = ud.baseY + Math.sin(t * 0.4 + ud.phase) * 3;
+                cone.rotation.y = t * 0.05 + ud.phase;
+            }
+        }
+
+        if (this.ambientPoints) {
+            const attr = this.ambientPoints.geometry.attributes.position;
+            const arr = attr.array;
+            const speeds = this._ambientSpeeds;
+            const n = speeds.length;
+            for (let i = 0; i < n; i++) {
+                arr[i * 3 + 1] += speeds[i] * dt;
+                if (arr[i * 3 + 1] > 160) {
+                    arr[i * 3 + 1] = -160;
+                    arr[i * 3 + 0] = (Math.random() - 0.5) * 320;
+                }
+            }
+            attr.needsUpdate = true;
+        }
+    }
+
+    dispose() {
+        this.group.traverse(obj => {
+            if (obj.geometry) obj.geometry.dispose();
+            if (obj.material) {
+                const m = obj.material;
+                if (Array.isArray(m)) m.forEach(x => x.dispose());
+                else m.dispose();
+            }
+        });
+        if (this.scene) this.scene.remove(this.group);
+    }
+}
+
+// 简易确定性 PRNG（mulberry32）—— 让远景剪影每次启动布局一致
+function mulberry32(seed) {
+    return function () {
+        let t = seed += 0x6d2b79f5;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}

--- a/src/render3d/BackgroundLayer.js
+++ b/src/render3d/BackgroundLayer.js
@@ -14,11 +14,12 @@ import * as THREE from 'three';
 
 // 暗黑炼金调色板（同 visual_redesign_3d_plan.md §1.3）
 const COLOR_DEEP    = 0x0a0e1a;
-const COLOR_MID     = 0x1a1f3a;
-const COLOR_ACCENT  = 0x3b2160;
-const SILHOUETTE_COL = 0x0d1320;
-const CONE_COLORS   = [0x38bdf8, 0xa78bfa, 0x60a5fa, 0xf59e0b];
-const PARTICLE_COL  = 0x60a5fa;
+const COLOR_MID     = 0x1c2348;     // 略提亮中间色，避免大面积死黑
+const COLOR_ACCENT  = 0x5b2d8a;     // 紫调更饱满，星云有存在感
+const COLOR_FORGE   = 0x6b2418;     // 底部"炼金炉"暖红光（焦点引导）
+const SILHOUETTE_COL = 0x161d33;    // 略提亮，让远处剪影从天幕中"浮"出来
+const CONE_COLORS   = [0x38bdf8, 0xa78bfa, 0x60a5fa, 0xf59e0b, 0xec4899, 0x22d3ee];
+const PARTICLE_COL  = 0x93c5fd;     // 提亮粒子色
 
 export class BackgroundLayer {
     /**
@@ -34,6 +35,76 @@ export class BackgroundLayer {
         this._createDistantSilhouettes();
         this._createVolumetricLights();
         this._createAmbientParticles();
+        this._createAlchemyStage();
+    }
+
+    // -------------------- 炼金台基（底部锚定焦点） --------------------
+    _createAlchemyStage() {
+        // 一道环形发光环，定位在屏幕下方"地平线"位置，象征"炼金引擎舞台"。
+        // M3+ 加入发射器实体后，这环会与发射器同心，强化"舞台中心"概念。
+        const stageGroup = new THREE.Group();
+        stageGroup.name = 'AlchemyStage';
+
+        // 主环：薄圆环，emissive 橙金。半径按 z=-10 处视域宽度（约 ±28）校准。
+        const ringGeom = new THREE.RingGeometry(34, 38, 64, 1);
+        const ringMat = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+            uniforms: {
+                uTime: { value: 0 },
+                uColor: { value: new THREE.Color(0xfb923c) },
+            },
+            vertexShader: /* glsl */`
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform float uTime;
+                uniform vec3 uColor;
+                varying vec2 vUv;
+                void main() {
+                    // uv.x 在环周方向，uv.y 在环宽方向；让中心更亮、两侧衰减
+                    float radial = 1.0 - abs(vUv.y - 0.5) * 2.0;
+                    radial = pow(radial, 1.5);
+                    // 沿环周的流光（4 段亮纹环绕）
+                    float flow = 0.5 + 0.5 * sin(vUv.x * 12.566 + uTime * 1.8);
+                    flow = pow(flow, 4.0);
+                    float alpha = radial * (0.4 + flow * 0.6);
+                    gl_FragColor = vec4(uColor * (0.6 + flow * 1.2), alpha);
+                }
+            `,
+        });
+        const ring = new THREE.Mesh(ringGeom, ringMat);
+        // 平躺在地面上，y 位置略低于相机看向的中心
+        // 平躺在地面上；y 位置紧靠视域下边缘，z 略推后避开后续玩法面板（z=0）
+        ring.rotation.x = -Math.PI / 2;
+        ring.position.set(0, -38, -10);
+        stageGroup.add(ring);
+        this.ringMaterial = ringMat;
+
+        // 二级辉光（内圈，更小、更亮）
+        const innerRingGeom = new THREE.RingGeometry(26, 30, 48, 1);
+        const innerRingMat = new THREE.MeshBasicMaterial({
+            color: 0xfde68a,
+            transparent: true,
+            opacity: 0.25,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+        });
+        const innerRing = new THREE.Mesh(innerRingGeom, innerRingMat);
+        innerRing.rotation.x = -Math.PI / 2;
+        innerRing.position.set(0, -37.5, -10);
+        stageGroup.add(innerRing);
+
+        this.stageGroup = stageGroup;
+        this.group.add(stageGroup);
     }
 
     // -------------------- 天幕 --------------------
@@ -47,6 +118,7 @@ export class BackgroundLayer {
                 uColorDeep:   { value: new THREE.Color(COLOR_DEEP) },
                 uColorMid:    { value: new THREE.Color(COLOR_MID) },
                 uColorAccent: { value: new THREE.Color(COLOR_ACCENT) },
+                uColorForge:  { value: new THREE.Color(COLOR_FORGE) },
             },
             vertexShader: /* glsl */`
                 varying vec3 vDir;
@@ -60,6 +132,7 @@ export class BackgroundLayer {
                 uniform vec3  uColorDeep;
                 uniform vec3  uColorMid;
                 uniform vec3  uColorAccent;
+                uniform vec3  uColorForge;
                 uniform float uTime;
                 varying vec3  vDir;
 
@@ -91,17 +164,36 @@ export class BackgroundLayer {
                 }
 
                 void main() {
-                    // 垂直渐变（深空 → 中蓝）
-                    float t = clamp(0.5 + vDir.y * 0.5, 0.0, 1.0);
+                    // 垂直渐变（深空 → 中蓝），曲线 pow 让中段更浓
+                    float ty = clamp(0.5 + vDir.y * 0.5, 0.0, 1.0);
+                    float t = pow(ty, 0.7);
                     vec3 col = mix(uColorDeep, uColorMid, t);
 
-                    // 星云斑块（低频噪声 + 时间漂移）
-                    float n = noise3(vDir * 4.0 + vec3(uTime * 0.015, 0.0, uTime * 0.01));
-                    col = mix(col, uColorAccent, smoothstep(0.55, 0.95, n) * 0.35);
+                    // 星云斑块：两层 octave 叠加，幅度更大
+                    float n1 = noise3(vDir * 3.0  + vec3(uTime * 0.012, 0.0, uTime * 0.008));
+                    float n2 = noise3(vDir * 8.0  + vec3(0.0, uTime * 0.020, 0.0));
+                    float neb = n1 * 0.75 + n2 * 0.25;
+                    col = mix(col, uColorAccent, smoothstep(0.40, 0.85, neb) * 0.65);
 
-                    // 微弱星点
-                    float stars = step(0.985, hash3(floor(vDir * 200.0))) * 0.5;
-                    col += vec3(stars);
+                    // 底部炼金炉膛暖光：仰角 < 0 时增强（焦点向下引导）
+                    // GLSL smoothstep 要求 edge0 < edge1；反方向需用 1 - smoothstep。
+                    float forgeMask = 1.0 - smoothstep(-0.55, 0.05, vDir.y);
+                    // 中央集束 + 横向衰减
+                    float forgeCenter = pow(max(0.0, 1.0 - abs(vDir.x) * 1.2), 2.0);
+                    col += uColorForge * forgeMask * forgeCenter * 2.2;
+                    // 炉口高光（中心更亮一圈橙金）+ 缓慢搏动
+                    float pulse = 0.85 + 0.15 * sin(uTime * 0.9);
+                    col += vec3(0.95, 0.55, 0.20) * forgeMask * pow(forgeCenter, 3.5) * 1.1 * pulse;
+
+                    // 顶部高空蓝紫提亮
+                    col += vec3(0.04, 0.06, 0.18) * smoothstep(0.3, 0.95, vDir.y);
+
+                    // 星点（两档密度 + 闪烁）
+                    float starRand = hash3(floor(vDir * 220.0));
+                    float bright = step(0.992, starRand);
+                    float dim    = step(0.975, starRand) * step(starRand, 0.992);
+                    float twinkle = 0.7 + 0.3 * sin(uTime * 3.0 + starRand * 30.0);
+                    col += vec3(bright * 1.0 * twinkle + dim * 0.35);
 
                     gl_FragColor = vec4(col, 1.0);
                 }
@@ -151,29 +243,38 @@ export class BackgroundLayer {
         lightGroup.name = 'VolumetricLights';
         // 单个圆锥几何复用（半径靠 scale 拉伸）
         const baseGeom = new THREE.ConeGeometry(1, 1, 18, 1, true);
-        for (let i = 0; i < 4; i++) {
-            const color = CONE_COLORS[i % CONE_COLORS.length];
+
+        // 6 根光柱全部置于远景（z < -180），靠两侧分布避开中央玩法区。
+        // 不放中心柱——中心由 skydome 的炉膛暖光承担焦点引导。
+        // 透明度刻意压低，让光柱作为"帷幕灯光"而非主体。
+        const config = [
+            // x,    y,    z,     radius, height, colorIdx, opacity
+            [-160,  -30,  -210,   28,     300,    0, 0.12], // 远景左主光（青）
+            [ 160,  -30,  -210,   28,     300,    1, 0.12], // 远景右主光（紫）
+            [-230,  -40,  -260,   20,     260,    2, 0.09], // 更远的左侧蓝
+            [ 230,  -40,  -260,   20,     260,    3, 0.09], // 更远的右侧橙
+            [-100,  -60,  -270,   16,     240,    4, 0.07], // 中左副柱（粉）
+            [ 100,  -60,  -270,   16,     240,    4, 0.07], // 中右副柱（粉）
+        ];
+
+        for (let i = 0; i < config.length; i++) {
+            const [px, py, pz, radius, height, ci, op] = config[i];
+            const color = CONE_COLORS[ci % CONE_COLORS.length];
             const mat = new THREE.MeshBasicMaterial({
                 color,
                 transparent: true,
-                opacity: 0.06,
+                opacity: op,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
                 side: THREE.DoubleSide,
                 fog: false,
             });
             const cone = new THREE.Mesh(baseGeom, mat);
-            const radius = 20 + i * 6;
-            const height = 220 + i * 20;
             cone.scale.set(radius, height, radius);
-            cone.position.set(
-                -120 + i * 80,
-                -40,
-                -90 - i * 8
-            );
-            // 圆锥默认尖端朝 +Y；我们让光"自下而上洒"，所以翻转
+            cone.position.set(px, py, pz);
+            // 圆锥默认尖端朝 +Y；让光"自下而上洒"，翻转
             cone.rotation.z = Math.PI;
-            cone.userData = { baseY: cone.position.y, phase: i * 1.7 };
+            cone.userData = { baseY: cone.position.y, phase: i * 1.13, baseOpacity: op };
             lightGroup.add(cone);
         }
         this.lightGroup = lightGroup;
@@ -182,32 +283,45 @@ export class BackgroundLayer {
 
     // -------------------- 环境粒子 --------------------
     _createAmbientParticles() {
-        const count = 150;
-        const positions = new Float32Array(count * 3);
-        const speeds = new Float32Array(count);
-        for (let i = 0; i < count; i++) {
-            positions[i * 3 + 0] = (Math.random() - 0.5) * 320;
-            positions[i * 3 + 1] = -160 + Math.random() * 320;
-            positions[i * 3 + 2] = -100 + Math.random() * 80;
-            speeds[i] = 2 + Math.random() * 5;
+        // 双层粒子：近层（大、慢、亮）+ 远层（小、快、暗）共同营造深度
+        this.ambientPoints = [];
+        this._ambientSpeeds = [];
+
+        const layers = [
+            { count: 180, sizeRange: [2.4, 4.2], color: PARTICLE_COL, opacity: 0.75, zRange: [-60, -10],  speedRange: [3, 8],   xRange: 320 },
+            { count: 200, sizeRange: [1.0, 2.0], color: 0xa78bfa,     opacity: 0.45, zRange: [-150, -80], speedRange: [1, 4],   xRange: 360 },
+        ];
+
+        for (const layer of layers) {
+            const count = layer.count;
+            const positions = new Float32Array(count * 3);
+            const speeds = new Float32Array(count);
+            const sizes = new Float32Array(count);
+            for (let i = 0; i < count; i++) {
+                positions[i * 3 + 0] = (Math.random() - 0.5) * layer.xRange;
+                positions[i * 3 + 1] = -180 + Math.random() * 360;
+                positions[i * 3 + 2] = layer.zRange[0] + Math.random() * (layer.zRange[1] - layer.zRange[0]);
+                speeds[i] = layer.speedRange[0] + Math.random() * (layer.speedRange[1] - layer.speedRange[0]);
+                sizes[i] = layer.sizeRange[0] + Math.random() * (layer.sizeRange[1] - layer.sizeRange[0]);
+            }
+            const geom = new THREE.BufferGeometry();
+            geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            const mat = new THREE.PointsMaterial({
+                color: layer.color,
+                size: (layer.sizeRange[0] + layer.sizeRange[1]) * 0.5, // 平均尺寸；细粒度由 size attribute 自定义着色器才能用
+                sizeAttenuation: true,
+                transparent: true,
+                opacity: layer.opacity,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+                fog: true,
+            });
+            const points = new THREE.Points(geom, mat);
+            points.name = 'AmbientParticles_' + layer.count;
+            this.ambientPoints.push(points);
+            this._ambientSpeeds.push(speeds);
+            this.group.add(points);
         }
-        const geom = new THREE.BufferGeometry();
-        geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-        const mat = new THREE.PointsMaterial({
-            color: PARTICLE_COL,
-            size: 1.6,
-            sizeAttenuation: true,
-            transparent: true,
-            opacity: 0.35,
-            blending: THREE.AdditiveBlending,
-            depthWrite: false,
-            fog: true,
-        });
-        const points = new THREE.Points(geom, mat);
-        points.name = 'AmbientParticles';
-        this.ambientPoints = points;
-        this._ambientSpeeds = speeds;
-        this.group.add(points);
     }
 
     // -------------------- 帧更新 --------------------
@@ -217,6 +331,12 @@ export class BackgroundLayer {
      */
     update(dt, t) {
         if (this.skyMaterial) this.skyMaterial.uniforms.uTime.value = t;
+        if (this.ringMaterial) this.ringMaterial.uniforms.uTime.value = t;
+        if (this.stageGroup) {
+            // 内外环缓慢反向旋转，制造"机械感"
+            this.stageGroup.children[0].rotation.z = t * 0.15;
+            this.stageGroup.children[1].rotation.z = -t * 0.22;
+        }
 
         if (this.lightGroup) {
             const children = this.lightGroup.children;
@@ -225,22 +345,28 @@ export class BackgroundLayer {
                 const ud = cone.userData;
                 cone.position.y = ud.baseY + Math.sin(t * 0.4 + ud.phase) * 3;
                 cone.rotation.y = t * 0.05 + ud.phase;
+                // 呼吸式透明度（基准 ±20%）
+                const breath = 0.85 + 0.15 * Math.sin(t * 0.6 + ud.phase * 0.7);
+                cone.material.opacity = ud.baseOpacity * breath;
             }
         }
 
-        if (this.ambientPoints) {
-            const attr = this.ambientPoints.geometry.attributes.position;
-            const arr = attr.array;
-            const speeds = this._ambientSpeeds;
-            const n = speeds.length;
-            for (let i = 0; i < n; i++) {
-                arr[i * 3 + 1] += speeds[i] * dt;
-                if (arr[i * 3 + 1] > 160) {
-                    arr[i * 3 + 1] = -160;
-                    arr[i * 3 + 0] = (Math.random() - 0.5) * 320;
+        if (this.ambientPoints && this.ambientPoints.length) {
+            for (let li = 0; li < this.ambientPoints.length; li++) {
+                const pts = this.ambientPoints[li];
+                const attr = pts.geometry.attributes.position;
+                const arr = attr.array;
+                const speeds = this._ambientSpeeds[li];
+                const n = speeds.length;
+                for (let i = 0; i < n; i++) {
+                    arr[i * 3 + 1] += speeds[i] * dt;
+                    if (arr[i * 3 + 1] > 180) {
+                        arr[i * 3 + 1] = -180;
+                        arr[i * 3 + 0] = (Math.random() - 0.5) * 320;
+                    }
                 }
+                attr.needsUpdate = true;
             }
-            attr.needsUpdate = true;
         }
     }
 

--- a/src/render3d/CameraController.js
+++ b/src/render3d/CameraController.js
@@ -1,10 +1,29 @@
 /**
- * CameraController.js - 镜头状态机（M1 阶段 stub）
+ * CameraController.js - 动态镜头状态机（M4.5）
  *
- * 当前仅实现 IDLE 状态的呼吸式漂移（极弱位移）。
- * 后续 milestone 会扩展为完整状态机（AIM / SHOT / IMPACT / BOSS_INTRO / PHASE_TRANS / GAME_OVER），
- * 以及弹簧物理震动 + FOV 脉冲。
+ * 设计：
+ *   不用枚举式状态机（容易僵），而是用"加性扰动 + 弹簧物理"实现：
+ *     基准位置(basePos) + 呼吸漂移(idle) + 弹簧震动(shake) + 瞄准位移(aim)
+ *   事件触发（impact / boss intro / player hit）往弹簧上注入冲量，
+ *   弹簧自然衰减回平衡位置，得到"被打了一下"的有机感。
+ *
+ *   同时把 FOV、镜头畸变、色散、bloom 的"瞬时增量"暴露给 PostFX，
+ *   让 Renderer3D 每帧合并到后处理 uniform。
+ *
+ * 公开 API：
+ *   triggerImpact(intensity, dirX, dirY)     —— 暴击 / 大命中
+ *   triggerEnemyKilled(intensity, hitX, hitY) —— 清场反馈（柔和）
+ *   triggerPlayerHit(intensity)              —— 玩家被击中（猛烈 + 色散）
+ *   triggerBossIntro()                       —— Boss 入场（FOV 拉近 + 重击）
+ *   triggerPhaseTransition()                 —— 阶段切换（柔性滑动）
+ *   setAim(normX, normY)                     —— 瞄准位移（-1..+1 归一化）
+ *   reset()                                  —— 完全归零（debug）
+ *   getPostFXState()                         —— Renderer3D 读，合并到 PostFX uniforms
  */
+
+import * as THREE from 'three';
+
+const TWO_PI = Math.PI * 2;
 
 export class CameraController {
     /**
@@ -12,39 +31,232 @@ export class CameraController {
      */
     constructor(camera) {
         this.camera = camera;
-        // 记录"基准位置"，所有扰动都相对它叠加
-        this.baseX = camera.position.x;
-        this.baseY = camera.position.y;
-        this.baseZ = camera.position.z;
+        this.basePos = camera.position.clone();
+        this.baseFov = camera.fov;
 
+        // 时间
         this.t = 0;
-        this.state = 'IDLE';
 
-        // 待 M4 接入：事件队列、弹簧状态、FOV 脉冲
-        // this._impulses = [];
-        // this._fovBase = camera.fov;
+        // ---- 弹簧式震动（位移 + 速度） ----
+        this.shakeOffset = new THREE.Vector3();
+        this.shakeVel    = new THREE.Vector3();
+        this._impulsesQueued = [];   // 帧内累积的冲量
+
+        // ---- FOV 弹簧（脉冲式 zoom-in/out） ----
+        this.fovOffset = 0;
+        this.fovVel    = 0;
+
+        // ---- 瞄准位移（lerp） ----
+        this.aimOffset = new THREE.Vector2();
+        this.aimTarget = new THREE.Vector2();
+
+        // ---- 给 PostFX 的瞬时 boost（自然衰减） ----
+        this.distortionBoost = 0;   // 桶形 K 的增量
+        this.chromaticBoost  = 0;   // 色散增量
+        this.bloomBoost      = 0;   // bloom strength 增量
+        this.exposureBoost   = 0;   // tonemap exposure 增量（罕用）
+
+        // ---- 弹簧常数 ----
+        this.K_SHAKE = 90;   // 越大恢复越快
+        this.C_SHAKE = 9;    // 阻尼
+        this.K_FOV   = 38;
+        this.C_FOV   = 9;
+
+        // ---- 衰减率（per sec） ----
+        this.DECAY_DISTORTION = 4.0;
+        this.DECAY_CHROMATIC  = 4.5;
+        this.DECAY_BLOOM      = 2.2;
+        this.DECAY_EXPOSURE   = 3.0;
+
+        // ---- 状态读取（仅 debug 用） ----
+        this.lastEvent = 'IDLE';
     }
 
-    /**
-     * @param {number} dt seconds
-     */
     update(dt) {
-        this.t += dt;
-        // IDLE 呼吸：极小位移 + 极小旋转感（通过位移 + lookAt 体现）
-        // 幅度刻意压低，避免与 DoF/畸变叠加后晕动。
-        const px = this.baseX + Math.sin(this.t * 0.40) * 1.2;
-        const py = this.baseY + Math.cos(this.t * 0.32) * 0.8;
-        const pz = this.baseZ + Math.sin(this.t * 0.25) * 0.5;
-        this.camera.position.set(px, py, pz);
+        // 物理稳定性：限制 dt
+        const h = Math.min(0.05, Math.max(0, dt));
+        this.t += h;
+
+        // ---- 1. 注入帧内冲量到速度 ----
+        for (let i = 0; i < this._impulsesQueued.length; i++) {
+            const imp = this._impulsesQueued[i];
+            this.shakeVel.x += imp.x;
+            this.shakeVel.y += imp.y;
+            this.shakeVel.z += imp.z;
+        }
+        this._impulsesQueued.length = 0;
+
+        // ---- 2. 位置弹簧物理 ----
+        // a = -k*x - c*v
+        const ax = -this.K_SHAKE * this.shakeOffset.x - this.C_SHAKE * this.shakeVel.x;
+        const ay = -this.K_SHAKE * this.shakeOffset.y - this.C_SHAKE * this.shakeVel.y;
+        const az = -this.K_SHAKE * this.shakeOffset.z - this.C_SHAKE * this.shakeVel.z;
+        this.shakeVel.x += ax * h;
+        this.shakeVel.y += ay * h;
+        this.shakeVel.z += az * h;
+        this.shakeOffset.x += this.shakeVel.x * h;
+        this.shakeOffset.y += this.shakeVel.y * h;
+        this.shakeOffset.z += this.shakeVel.z * h;
+
+        // ---- 3. FOV 弹簧 ----
+        const af = -this.K_FOV * this.fovOffset - this.C_FOV * this.fovVel;
+        this.fovVel += af * h;
+        this.fovOffset += this.fovVel * h;
+
+        // ---- 4. 瞄准平滑 ----
+        const aimAlpha = Math.min(1, h * 6);
+        this.aimOffset.x += (this.aimTarget.x - this.aimOffset.x) * aimAlpha;
+        this.aimOffset.y += (this.aimTarget.y - this.aimOffset.y) * aimAlpha;
+
+        // ---- 5. 呼吸漂移（始终在线） ----
+        const idleX = Math.sin(this.t * 0.40) * 1.2;
+        const idleY = Math.cos(this.t * 0.32) * 0.8;
+        const idleZ = Math.sin(this.t * 0.25) * 0.5;
+
+        // ---- 6. 应用到相机 ----
+        this.camera.position.set(
+            this.basePos.x + idleX + this.shakeOffset.x + this.aimOffset.x * 5.0,
+            this.basePos.y + idleY + this.shakeOffset.y + this.aimOffset.y * 5.0,
+            this.basePos.z + idleZ + this.shakeOffset.z
+        );
         this.camera.lookAt(0, 0, 0);
+
+        // FOV 变化要重算 projection matrix（开销小）
+        if (Math.abs(this.fovOffset) > 0.005) {
+            this.camera.fov = this.baseFov + this.fovOffset;
+            this.camera.updateProjectionMatrix();
+        } else if (this.camera.fov !== this.baseFov) {
+            this.camera.fov = this.baseFov;
+            this.camera.updateProjectionMatrix();
+        }
+
+        // ---- 7. PostFX boost 衰减 ----
+        this.distortionBoost = Math.max(0, this.distortionBoost - this.DECAY_DISTORTION * h);
+        this.chromaticBoost  = Math.max(0, this.chromaticBoost  - this.DECAY_CHROMATIC  * h);
+        this.bloomBoost      = Math.max(0, this.bloomBoost      - this.DECAY_BLOOM      * h);
+        this.exposureBoost   = Math.max(0, this.exposureBoost   - this.DECAY_EXPOSURE   * h);
+    }
+
+    // ============================================================
+    //   事件 API
+    // ============================================================
+
+    /**
+     * 普通击中 / 暴击。强度 0.3 = 轻击，1.0 = 强击，2.0 = 终结。
+     * @param {number} intensity
+     * @param {number} [dirX=0]  冲量方向偏置（屏幕空间，可选）
+     * @param {number} [dirY=0]
+     */
+    triggerImpact(intensity = 1.0, dirX = 0, dirY = 0) {
+        this.lastEvent = 'IMPACT';
+        const i = Math.max(0, intensity);
+        // 随机方向 + 偏置方向叠加
+        const a = Math.random() * TWO_PI;
+        const rand = i * 7.0;
+        this._impulsesQueued.push({
+            x: Math.cos(a) * rand + dirX * i * 4.0,
+            y: Math.sin(a) * rand + dirY * i * 4.0,
+            z: (Math.random() - 0.5) * i * 2.0,
+        });
+        // 微 FOV 拉远（"被击中"压缩感）
+        this.fovVel -= i * 6.0;
+        // PostFX 短促波动
+        this.distortionBoost = Math.max(this.distortionBoost, i * 0.035);
+        this.chromaticBoost  = Math.max(this.chromaticBoost,  i * 0.010);
+        this.bloomBoost      = Math.max(this.bloomBoost,      i * 0.30);
     }
 
     /**
-     * 重置到基准位置（阶段切换/调试用）。
+     * 敌人被击杀 / 清场。比普通击中弱一档，更"庆祝"——bloom 多一点。
      */
+    triggerEnemyKilled(intensity = 0.4) {
+        this.lastEvent = 'KILLED';
+        const i = Math.max(0, intensity);
+        this._impulsesQueued.push({
+            x: (Math.random() - 0.5) * i * 5.0,
+            y: (Math.random() - 0.5) * i * 5.0,
+            z: 0,
+        });
+        this.bloomBoost = Math.max(this.bloomBoost, i * 0.45);
+        this.exposureBoost = Math.max(this.exposureBoost, i * 0.06);
+    }
+
+    /**
+     * 玩家被攻击：强横向震动 + 显著色散（"被打蒙"）+ 瞬间 FOV 拉近。
+     */
+    triggerPlayerHit(intensity = 1.0) {
+        this.lastEvent = 'HIT_PLAYER';
+        const i = Math.max(0, intensity);
+        this._impulsesQueued.push({
+            x: (Math.random() - 0.5) * i * 18.0,
+            y: -i * 5.0,
+            z: 0,
+        });
+        this.fovVel += i * 5.0;  // 突然拉近 → 压迫
+        this.chromaticBoost  = Math.max(this.chromaticBoost,  i * 0.022);
+        this.distortionBoost = Math.max(this.distortionBoost, i * 0.05);
+    }
+
+    /**
+     * Boss 入场：缓慢拉近 + 重低音震动 + bloom 浪漫化。
+     */
+    triggerBossIntro() {
+        this.lastEvent = 'BOSS_INTRO';
+        // FOV 缓慢拉近（fovVel 给正值，fovOffset 慢慢上升后被弹簧拉回）
+        // 实际效果想要"持续拉近一段时间"，所以同时设置 offset
+        this.fovOffset = -3.0;   // 立即拉近 3°
+        this.fovVel = 0;
+        this._impulsesQueued.push({ x: 0, y: 8, z: 0 });
+        this.bloomBoost = Math.max(this.bloomBoost, 0.7);
+        this.distortionBoost = Math.max(this.distortionBoost, 0.04);
+    }
+
+    /**
+     * 阶段切换：柔和的位置滑动（不靠弹簧，靠 base 漂移）。
+     * 这一版用最简单实现：触发轻微 z 弹簧（"摄影机退一步"），无 PostFX 干扰。
+     */
+    triggerPhaseTransition() {
+        this.lastEvent = 'PHASE_TRANS';
+        this._impulsesQueued.push({ x: 0, y: 0, z: -4 });
+        this.bloomBoost = Math.max(this.bloomBoost, 0.15);
+    }
+
+    /**
+     * 瞄准位移目标。归一化坐标 [-1, +1]。 update 内 lerp。
+     */
+    setAim(normX, normY) {
+        this.aimTarget.x = Math.max(-1, Math.min(1, normX));
+        this.aimTarget.y = Math.max(-1, Math.min(1, normY));
+    }
+
+    /**
+     * 给 PostFX 用：当前帧应叠加到后处理 uniform 的瞬时增量。
+     * Renderer3D 在 render 前调一次，合并到 baseline。
+     */
+    getPostFXState() {
+        return {
+            distortion: this.distortionBoost,
+            chromatic:  this.chromaticBoost,
+            bloom:      this.bloomBoost,
+            exposure:   this.exposureBoost,
+        };
+    }
+
+    /** 完全归零（debug / 切场景用） */
     reset() {
-        this.t = 0;
-        this.camera.position.set(this.baseX, this.baseY, this.baseZ);
-        this.camera.lookAt(0, 0, 0);
+        this.shakeOffset.set(0, 0, 0);
+        this.shakeVel.set(0, 0, 0);
+        this.fovOffset = 0;
+        this.fovVel = 0;
+        this.aimOffset.set(0, 0);
+        this.aimTarget.set(0, 0);
+        this.distortionBoost = 0;
+        this.chromaticBoost = 0;
+        this.bloomBoost = 0;
+        this.exposureBoost = 0;
+        this.lastEvent = 'IDLE';
+        this.camera.fov = this.baseFov;
+        this.camera.updateProjectionMatrix();
+        this.camera.position.copy(this.basePos);
     }
 }

--- a/src/render3d/CameraController.js
+++ b/src/render3d/CameraController.js
@@ -1,0 +1,50 @@
+/**
+ * CameraController.js - 镜头状态机（M1 阶段 stub）
+ *
+ * 当前仅实现 IDLE 状态的呼吸式漂移（极弱位移）。
+ * 后续 milestone 会扩展为完整状态机（AIM / SHOT / IMPACT / BOSS_INTRO / PHASE_TRANS / GAME_OVER），
+ * 以及弹簧物理震动 + FOV 脉冲。
+ */
+
+export class CameraController {
+    /**
+     * @param {THREE.PerspectiveCamera} camera
+     */
+    constructor(camera) {
+        this.camera = camera;
+        // 记录"基准位置"，所有扰动都相对它叠加
+        this.baseX = camera.position.x;
+        this.baseY = camera.position.y;
+        this.baseZ = camera.position.z;
+
+        this.t = 0;
+        this.state = 'IDLE';
+
+        // 待 M4 接入：事件队列、弹簧状态、FOV 脉冲
+        // this._impulses = [];
+        // this._fovBase = camera.fov;
+    }
+
+    /**
+     * @param {number} dt seconds
+     */
+    update(dt) {
+        this.t += dt;
+        // IDLE 呼吸：极小位移 + 极小旋转感（通过位移 + lookAt 体现）
+        // 幅度刻意压低，避免与 DoF/畸变叠加后晕动。
+        const px = this.baseX + Math.sin(this.t * 0.40) * 1.2;
+        const py = this.baseY + Math.cos(this.t * 0.32) * 0.8;
+        const pz = this.baseZ + Math.sin(this.t * 0.25) * 0.5;
+        this.camera.position.set(px, py, pz);
+        this.camera.lookAt(0, 0, 0);
+    }
+
+    /**
+     * 重置到基准位置（阶段切换/调试用）。
+     */
+    reset() {
+        this.t = 0;
+        this.camera.position.set(this.baseX, this.baseY, this.baseZ);
+        this.camera.lookAt(0, 0, 0);
+    }
+}

--- a/src/render3d/EnemyMeshFactory.js
+++ b/src/render3d/EnemyMeshFactory.js
@@ -1,0 +1,178 @@
+/**
+ * EnemyMeshFactory.js - 程序化生成不同 archetype 的敌人 3D 几何（M3）
+ *
+ * 9 个 archetype（参考 enemy_v2_metadata）+ 默认 residue：
+ *
+ *   bastion     (3×1)  长六棱柱（横躺）   — "装甲横梁"
+ *   maw         (2×2)  双锥对夹           — "深渊胃囊"
+ *   deflector   (2×1)  斜楔（梯形棱柱）   — "棱盾兽"
+ *   echoSpire   (1×2)  双层金字塔         — "共振尖塔"
+ *   prism       (1×3)  细长三棱柱         — "折光棱柱"
+ *   hive        (2×3)  二十面体           — "孵化巢"
+ *   siege       (3×2)  方块+顶部炮塔      — "攻城履带"
+ *   gravityWell (3×3)  球体+扁圆环框架    — "引力炉心"
+ *   residue     (1×1)  方块（默认）       — 普通敌人
+ *
+ * 每个工厂函数返回 { geometry, color } —— Mesh 由外层 EnemyMeshPool 负责装配，
+ * 共用同一份 ShaderMaterial（uniform 上传 type/tier 控制颜色）。
+ */
+
+import * as THREE from 'three';
+
+// 调色板（暗黑炼金金属感）
+const METAL_BASE  = 0x1f2937;   // slate-800
+const TIER_NORMAL = 0x475569;   // slate-500 (normal 敌人主色)
+const TIER_ELITE  = 0x22d3ee;   // cyan-400 (精英)
+const TIER_BOSS   = 0xf59e0b;   // amber-500 (boss)
+
+/**
+ * 主入口：根据 archetype 名返回 BufferGeometry。
+ * 所有几何已经预对齐：中心在 (0,0,0)，朝向沿 +z 略前倾（让玩家看到正面）。
+ * 缩放交给调用方根据 enemy.width / enemy.height 处理。
+ */
+export function createGeometryFor(archetype) {
+    switch (archetype) {
+        case 'bastion':     return _bastion();
+        case 'maw':         return _maw();
+        case 'deflector':   return _deflector();
+        case 'echoSpire':   return _echoSpire();
+        case 'echo_spire':  return _echoSpire();  // 兼容下划线写法
+        case 'prism':       return _prism();
+        case 'hive':        return _hive();
+        case 'siege':       return _siege();
+        case 'gravityWell': return _gravityWell();
+        case 'gravity_core':return _gravityWell();
+        case 'residue':     return _residue();
+        default:            return _residue();
+    }
+}
+
+/**
+ * 按敌人 type ('normal' | 'elite' | 'boss') 返回 emissive 色（用在 shader uniform）。
+ */
+export function getTierColor(type) {
+    if (type === 'boss')  return TIER_BOSS;
+    if (type === 'elite') return TIER_ELITE;
+    return TIER_NORMAL;
+}
+
+export const METAL_BASE_COLOR = METAL_BASE;
+
+// ============================================================
+// 几何工厂（每个返回一个 BufferGeometry，单位长方体大小 = (1, 1, 1)，
+// 由 EnemyMeshPool 用 scale 拉伸到 (enemy.width, enemy.height, depth)）
+// ============================================================
+
+function _bastion() {
+    // 横躺六棱柱：长(x) > 厚(y) ≈ 深(z)
+    // 默认 CylinderGeometry 沿 y 轴，我们旋转 90° 让它沿 x 轴方向
+    const g = new THREE.CylinderGeometry(0.5, 0.5, 1, 6, 1);
+    g.rotateZ(Math.PI / 2);  // 棱柱躺平：长轴 → x
+    return g;
+}
+
+function _maw() {
+    // 上下两个对顶圆锥（jaw 开合的暗示）
+    const top = new THREE.ConeGeometry(0.5, 0.5, 5, 1);
+    top.translate(0, 0.25, 0);
+    const bot = new THREE.ConeGeometry(0.5, 0.5, 5, 1);
+    bot.rotateZ(Math.PI);     // 倒置
+    bot.translate(0, -0.25, 0);
+    const merged = _mergeBuffer([top, bot]);
+    return merged;
+}
+
+function _deflector() {
+    // 斜楔：基于 BoxGeometry 把顶面四个 vertex 朝 +x 推
+    const g = new THREE.BoxGeometry(1, 1, 1);
+    const pos = g.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+        if (pos.getY(i) > 0) pos.setX(i, pos.getX(i) + 0.35);
+    }
+    pos.needsUpdate = true;
+    g.computeVertexNormals();
+    return g;
+}
+
+function _echoSpire() {
+    // 双层金字塔（底层四棱锥，顶层小一些）
+    const lower = new THREE.ConeGeometry(0.5, 0.55, 4, 1);
+    lower.translate(0, -0.225, 0);
+    const upper = new THREE.ConeGeometry(0.3, 0.45, 4, 1);
+    upper.translate(0, 0.275, 0);
+    return _mergeBuffer([lower, upper]);
+}
+
+function _prism() {
+    // 细长三棱柱（沿 y 轴）
+    const g = new THREE.CylinderGeometry(0.45, 0.45, 1, 3, 1);
+    // 略微沿 z 倾斜，给 fresnel 更复杂的表现
+    g.rotateX(Math.PI / 28);
+    return g;
+}
+
+function _hive() {
+    // 二十面体（蜂巢质感）
+    return new THREE.IcosahedronGeometry(0.55, 0);
+}
+
+function _siege() {
+    // 方块基座 + 顶部小球（炮塔）
+    const base = new THREE.BoxGeometry(1, 0.7, 1);
+    base.translate(0, -0.15, 0);
+    const turret = new THREE.SphereGeometry(0.32, 12, 8);
+    turret.translate(0, 0.35, 0.0);
+    return _mergeBuffer([base, turret]);
+}
+
+function _gravityWell() {
+    // 中央球 + 一个扁平 Torus（笼状框架）
+    const sphere = new THREE.SphereGeometry(0.30, 16, 12);
+    const torus = new THREE.TorusGeometry(0.45, 0.05, 8, 24);
+    torus.rotateX(Math.PI / 2);  // 立成"光环"
+    return _mergeBuffer([sphere, torus]);
+}
+
+function _residue() {
+    // 默认方块（圆角化通过 segments 实现 cheaper）
+    const g = new THREE.BoxGeometry(0.9, 0.9, 0.9);
+    return g;
+}
+
+// ============================================================
+// 合并多个 BufferGeometry 为一个（轻量替代 BufferGeometryUtils.mergeGeometries）
+// 当前用法都是简单合并，不需要 indexed 转换
+// ============================================================
+function _mergeBuffer(geoms) {
+    let totalPos = 0;
+    let totalIdx = 0;
+    for (const g of geoms) {
+        totalPos += g.attributes.position.count;
+        if (g.index) totalIdx += g.index.count;
+    }
+    const positions = new Float32Array(totalPos * 3);
+    const normals   = new Float32Array(totalPos * 3);
+    const indices   = totalIdx > 0 ? new Uint32Array(totalIdx) : null;
+
+    let pOff = 0, iOff = 0, vOff = 0;
+    for (const g of geoms) {
+        const p = g.attributes.position.array;
+        const n = g.attributes.normal ? g.attributes.normal.array : null;
+        positions.set(p, pOff * 3);
+        if (n) normals.set(n, pOff * 3);
+        if (indices && g.index) {
+            const ix = g.index.array;
+            for (let i = 0; i < ix.length; i++) indices[iOff + i] = ix[i] + vOff;
+            iOff += ix.length;
+        }
+        pOff += g.attributes.position.count;
+        vOff = pOff;
+        g.dispose();
+    }
+    const merged = new THREE.BufferGeometry();
+    merged.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    merged.setAttribute('normal',   new THREE.BufferAttribute(normals, 3));
+    if (indices) merged.setIndex(new THREE.BufferAttribute(indices, 1));
+    merged.computeVertexNormals();
+    return merged;
+}

--- a/src/render3d/EnemyMeshPool.js
+++ b/src/render3d/EnemyMeshPool.js
@@ -1,0 +1,345 @@
+/**
+ * EnemyMeshPool.js - 敌人 3D 网格的"按需创建 + 池缓存"管理器（M3）
+ *
+ * 设计：
+ *   - 敌人数不多（< 32 同时存在），每个敌人对应一个 THREE.Group：
+ *       Group {
+ *         Mesh<core geometry, ShaderMaterial>   // archetype 主体
+ *         Mesh<shield plane> (if affix shield)
+ *         Mesh<regen orbs>   (if affix regen)
+ *       }
+ *   - 用 Map<enemyId, Group> 跟踪。enemy 没有显式 id → 第一次见到时给它打 `__id3d` 标记
+ *   - sync 流程：
+ *       1. 标记池中所有 Group 为 stale
+ *       2. 遍历当前 enemies[]，每个 active 敌人：
+ *          a. 池中已存在 → 复用，update position/scale，标记 fresh
+ *          b. 不存在 → 用 EnemyMeshFactory 创建并加入 scene + 池
+ *       3. 把仍 stale 的 Group dispose + 从 scene 移除
+ *
+ * 材质共享：所有敌人共用一份 ShaderMaterial（不同 emissive 颜色靠 instanceColor 形式
+ *           注入 uniform 不太方便 → 改为每敌一个材质 clone；性能影响极小因为敌人少）
+ */
+
+import * as THREE from 'three';
+import { createGeometryFor, getTierColor, METAL_BASE_COLOR } from './EnemyMeshFactory.js';
+
+let _idSeq = 0;
+function _ensureId(enemy) {
+    if (!enemy.__id3d) enemy.__id3d = ++_idSeq;
+    return enemy.__id3d;
+}
+
+const ENEMY_DEPTH = 18;       // z 厚度（world units），让敌人在 z=0 平面上立体感
+const DEFAULT_FOOTPRINT = 60; // px → 默认敌人尺寸（实际从 enemy.width/height 读）
+
+// 共享主体 shader（每敌实例化时 clone material 设置 uniform）
+const VERT_SRC = /* glsl */`
+    varying vec3 vNormal;
+    varying vec3 vViewPos;
+    void main() {
+        vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
+        vNormal = normalize(normalMatrix * normal);
+        vViewPos = mvPos.xyz;
+        gl_Position = projectionMatrix * mvPos;
+    }
+`;
+
+const FRAG_SRC = /* glsl */`
+    precision mediump float;
+    uniform vec3  uBase;        // 暗金属色
+    uniform vec3  uTier;        // 阶级色（emissive）
+    uniform float uHit;         // 击中冲量 0..1
+    uniform float uTime;
+    uniform float uPhase;       // 个体相位
+    varying vec3 vNormal;
+    varying vec3 vViewPos;
+
+    void main() {
+        vec3 N = normalize(vNormal);
+        vec3 V = normalize(-vViewPos);
+        float ndotv = max(0.0, dot(N, V));
+
+        float rim = pow(1.0 - ndotv, 2.0);
+        float pulse = 0.65 + 0.35 * sin(uTime * 1.4 + uPhase);
+
+        // 伪光照：用 view-y 模拟从上方斜下的"舞台灯"
+        float fakeLight = 0.5 + 0.5 * max(0.0, N.y * 0.6 + N.z * 0.4);
+
+        vec3 col = uBase * (0.55 + 0.55 * fakeLight);   // 提亮基底，面部可读
+        col += uTier * 0.22;                            // 全身 tier 染色（嵌入金属基）
+        col += uTier * rim * 1.7 * pulse;               // 边缘按 tier 增强 + 呼吸
+        col = mix(col, vec3(1.0), uHit * 0.85);         // 击中瞬白闪
+
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;
+
+function _createBodyMaterial(tierHex, phase) {
+    return new THREE.ShaderMaterial({
+        uniforms: {
+            uBase:  { value: new THREE.Color(METAL_BASE_COLOR) },
+            uTier:  { value: new THREE.Color(tierHex) },
+            uHit:   { value: 0 },
+            uTime:  { value: 0 },
+            uPhase: { value: phase },
+        },
+        vertexShader: VERT_SRC,
+        fragmentShader: FRAG_SRC,
+    });
+}
+
+// ============================================================
+// Affix 装饰：当前 M3 只做最常见的两种（shield / regen），其余 milestone 再补
+// ============================================================
+function _createShieldDecor() {
+    // 六边形蜂巢盾，半透明青蓝，悬浮在敌人正面
+    const ring = new THREE.RingGeometry(0.55, 0.62, 6, 1);
+    const mat = new THREE.MeshBasicMaterial({
+        color: 0x60a5fa,
+        transparent: true,
+        opacity: 0.45,
+        side: THREE.DoubleSide,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+    });
+    const ringMesh = new THREE.Mesh(ring, mat);
+    // 中央填充薄板（更"实体感"）
+    const hex = new THREE.CircleGeometry(0.55, 6);
+    const hexMat = new THREE.MeshBasicMaterial({
+        color: 0x60a5fa,
+        transparent: true,
+        opacity: 0.15,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+    });
+    const hexMesh = new THREE.Mesh(hex, hexMat);
+
+    const grp = new THREE.Group();
+    grp.add(ringMesh, hexMesh);
+    grp.userData = { affix: 'shield', _materials: [mat, hexMat] };
+    return grp;
+}
+
+function _createRegenDecor() {
+    // 3 颗小绿球绕顶部螺旋
+    const grp = new THREE.Group();
+    const mat = new THREE.MeshBasicMaterial({
+        color: 0x4ade80,
+        transparent: true,
+        opacity: 0.85,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+    });
+    const geom = new THREE.SphereGeometry(0.07, 8, 6);
+    for (let i = 0; i < 3; i++) {
+        const m = new THREE.Mesh(geom, mat);
+        m.userData = { angle: (i / 3) * Math.PI * 2, radius: 0.4, ySpeed: 0.4 };
+        grp.add(m);
+    }
+    grp.userData = { affix: 'regen', _material: mat, _geometry: geom };
+    return grp;
+}
+
+// ============================================================
+// Pool
+// ============================================================
+export class EnemyMeshPool {
+    constructor(scene) {
+        this.scene = scene;
+        this.map = new Map();   // id → entry { group, body, archetype, affixSet, fresh }
+        this._tmpV = new THREE.Vector3();
+    }
+
+    /**
+     * 把当前 enemies[] 同步到 3D 场景。
+     * @param {Array} enemies game.enemies
+     * @param {Object} coords CoordsMapper
+     */
+    sync(enemies, coords) {
+        // 1. 标记所有 entry 为 stale
+        for (const entry of this.map.values()) entry.fresh = false;
+
+        // 2. 遍历活跃敌人
+        for (const e of enemies) {
+            if (!e || !e.active) continue;
+            // 入场动画 / 待生成的敌人：屏幕外的暂不渲染（pos.y < 0 多半是顶部入场）
+            // 这里允许 pos.y < 0 也渲染——可表现 boss"从天而降"
+            const id = _ensureId(e);
+            let entry = this.map.get(id);
+            const archetype = e.baseArchetype || 'residue';
+            const wantedAffixes = (e.affixes || []).slice().sort();
+            const affixKey = wantedAffixes.join('|');
+
+            if (!entry) {
+                entry = this._createEntry(e, archetype);
+                this.map.set(id, entry);
+                this.scene.add(entry.group);
+            } else if (entry.archetype !== archetype) {
+                // archetype 罕见变化（一般不会发生）；保守重建
+                this.scene.remove(entry.group);
+                this._disposeEntry(entry);
+                entry = this._createEntry(e, archetype);
+                this.map.set(id, entry);
+                this.scene.add(entry.group);
+            }
+
+            // 同步 affix 装饰
+            if (entry.affixKey !== affixKey) {
+                this._syncAffixes(entry, wantedAffixes);
+                entry.affixKey = affixKey;
+            }
+
+            // 同步位置 + 缩放
+            const w = coords.toWorld(e.pos.x, e.pos.y, 0);
+            entry.group.position.set(w.x, w.y, 0);
+
+            const widthWorld  = (e.width  || DEFAULT_FOOTPRINT) * coords.scale;
+            const heightWorld = (e.height || DEFAULT_FOOTPRINT) * coords.scale;
+            const depthWorld  = Math.min(widthWorld, heightWorld) * 0.65;
+            entry.body.scale.set(widthWorld, heightWorld, depthWorld);
+
+            // tier 颜色可能变化（精英化等）
+            const tierHex = getTierColor(e.type);
+            if (entry.tierHex !== tierHex) {
+                entry.body.material.uniforms.uTier.value.setHex(tierHex);
+                entry.tierHex = tierHex;
+            }
+
+            // 受击冲量：从 enemy._hitImpact 拉取（如果存在）
+            if (e._hitImpact !== undefined) {
+                entry.body.material.uniforms.uHit.value =
+                    Math.max(entry.body.material.uniforms.uHit.value * 0.85, e._hitImpact);
+            }
+
+            entry.fresh = true;
+        }
+
+        // 3. 移除 stale entries
+        for (const [id, entry] of this.map) {
+            if (!entry.fresh) {
+                this.scene.remove(entry.group);
+                this._disposeEntry(entry);
+                this.map.delete(id);
+            }
+        }
+    }
+
+    /** 每帧推进时间 + 装饰动画 */
+    update(dt, t) {
+        for (const entry of this.map.values()) {
+            // 主体 shader 时间
+            entry.body.material.uniforms.uTime.value = t;
+            // 击中冲量衰减
+            const u = entry.body.material.uniforms.uHit;
+            if (u.value > 0.001) u.value *= Math.max(0, 1 - 5.0 * dt);
+
+            // regen 球轨道
+            if (entry.regenGroup) {
+                for (const orb of entry.regenGroup.children) {
+                    const ud = orb.userData;
+                    ud.angle += dt * 1.6;
+                    orb.position.set(
+                        Math.cos(ud.angle) * ud.radius,
+                        0.5 + Math.sin(t * 1.2 + ud.angle * 2) * 0.15,
+                        Math.sin(ud.angle) * ud.radius
+                    );
+                }
+            }
+            // shield 旋转
+            if (entry.shieldGroup) {
+                entry.shieldGroup.rotation.z = t * 0.4;
+            }
+        }
+    }
+
+    clear() {
+        for (const entry of this.map.values()) {
+            this.scene.remove(entry.group);
+            this._disposeEntry(entry);
+        }
+        this.map.clear();
+    }
+
+    // -------- 内部 --------
+    _createEntry(enemy, archetype) {
+        const geom = createGeometryFor(archetype);
+        const tierHex = getTierColor(enemy.type);
+        const phase = ((enemy.__id3d || 0) * 0.37) % (Math.PI * 2);
+        const mat = _createBodyMaterial(tierHex, phase);
+        const body = new THREE.Mesh(geom, mat);
+        body.frustumCulled = false;
+
+        const group = new THREE.Group();
+        group.add(body);
+        group.name = `Enemy_${enemy.__id3d}_${archetype}`;
+
+        return {
+            group,
+            body,
+            archetype,
+            tierHex,
+            affixKey: '',
+            shieldGroup: null,
+            regenGroup: null,
+            fresh: true,
+        };
+    }
+
+    _syncAffixes(entry, affixes) {
+        const set = new Set(affixes);
+
+        // shield
+        if (set.has('shield')) {
+            if (!entry.shieldGroup) {
+                entry.shieldGroup = _createShieldDecor();
+                // 摆在敌人正前方（+z）一点点
+                entry.shieldGroup.position.set(0, 0, 0.55);
+                entry.group.add(entry.shieldGroup);
+            }
+        } else if (entry.shieldGroup) {
+            entry.group.remove(entry.shieldGroup);
+            this._disposeShield(entry.shieldGroup);
+            entry.shieldGroup = null;
+        }
+
+        // regen
+        if (set.has('regen')) {
+            if (!entry.regenGroup) {
+                entry.regenGroup = _createRegenDecor();
+                entry.group.add(entry.regenGroup);
+            }
+        } else if (entry.regenGroup) {
+            entry.group.remove(entry.regenGroup);
+            this._disposeRegen(entry.regenGroup);
+            entry.regenGroup = null;
+        }
+    }
+
+    _disposeEntry(entry) {
+        try {
+            entry.body.geometry.dispose();
+            entry.body.material.dispose();
+        } catch (e) {}
+        if (entry.shieldGroup) this._disposeShield(entry.shieldGroup);
+        if (entry.regenGroup) this._disposeRegen(entry.regenGroup);
+    }
+
+    _disposeShield(grp) {
+        try {
+            for (const m of grp.children) m.geometry.dispose();
+            const mats = grp.userData._materials || [];
+            for (const m of mats) m.dispose();
+        } catch (e) {}
+    }
+
+    _disposeRegen(grp) {
+        try {
+            if (grp.userData._geometry) grp.userData._geometry.dispose();
+            if (grp.userData._material) grp.userData._material.dispose();
+        } catch (e) {}
+    }
+
+    dispose() {
+        this.clear();
+    }
+}

--- a/src/render3d/PegInstancedMesh.js
+++ b/src/render3d/PegInstancedMesh.js
@@ -1,0 +1,220 @@
+/**
+ * PegInstancedMesh.js - 钉子的 3D 实例化网格（M2 核心）
+ *
+ * 全部钉子共享一个 SphereGeometry，通过 InstancedMesh 一次性提交 GPU。
+ * 每个实例携带：
+ *   - 变换矩阵（位置 + 均匀缩放至钉子半径）
+ *   - 颜色（按 type 查表）
+ *   - 相位（错开发光脉动 / 击中表演时间）
+ *
+ * 容量上限 PEG_CAPACITY。当前默认布局 ~72 个钉子，给 256 余量足够。
+ *
+ * 类型颜色 LUT 与游戏内 peg.type 字符串一一对应；未知 type 回退到 normal slate。
+ */
+
+import * as THREE from 'three';
+
+export const PEG_CAPACITY = 256;
+const SEGMENT = 14;
+
+// 与 visual_redesign_3d_plan.md §1.3 调色板对齐
+const PEG_COLORS = {
+    normal:        [0.30, 0.36, 0.44], // slate
+    pink:          [0.94, 0.50, 0.75], // 高弹粉
+    wind:          [0.20, 0.72, 0.60], // 风系青绿
+    flying_sword:  [0.98, 0.55, 0.20], // 剑系橙
+    pyro:          [0.94, 0.27, 0.27], // 火
+    cryo:          [0.38, 0.65, 0.98], // 冰
+    lightning:     [0.98, 0.80, 0.13], // 雷
+    bounce:        [0.64, 0.90, 0.21], // 弹射
+    pierce:        [0.97, 0.45, 0.10], // 穿透
+    scatter:       [0.75, 0.52, 0.99], // 散射
+    damage:        [0.92, 0.92, 0.92], // 增幅
+    laser:         [0.20, 0.85, 0.60], // 激光（一般不生成钉子，留位）
+    venom:         [0.66, 0.30, 0.85], // 毒
+    echo:          [0.55, 0.75, 0.95], // 回响
+    resonance:     [0.95, 0.75, 0.95], // 共振
+    rainbow:       [0.95, 0.55, 0.85], // 彩虹
+    matryoshka:    [0.80, 0.70, 0.50], // 套娃
+    explosive:     [0.99, 0.50, 0.25], // 爆破
+};
+
+export class PegInstancedMesh {
+    constructor() {
+        this.geometry = new THREE.SphereGeometry(1, SEGMENT, SEGMENT);
+
+        // 每实例的"相位"——用于错开脉动，避免所有钉子同步呼吸（视觉死板）。
+        const phases = new Float32Array(PEG_CAPACITY);
+        for (let i = 0; i < PEG_CAPACITY; i++) phases[i] = Math.random() * Math.PI * 2;
+        this.geometry.setAttribute(
+            'instancePhase',
+            new THREE.InstancedBufferAttribute(phases, 1)
+        );
+
+        // 击中冲量：被弹珠撞到瞬间这个值飙到 1.0，每帧衰减；驱动整球 emissive 增强 + 微膨胀。
+        const hitImpulse = new Float32Array(PEG_CAPACITY);
+        this.geometry.setAttribute(
+            'instanceHit',
+            new THREE.InstancedBufferAttribute(hitImpulse, 1)
+        );
+        this._hitImpulseAttr = this.geometry.attributes.instanceHit;
+        this._hitImpulse = hitImpulse;
+
+        this.material = new THREE.ShaderMaterial({
+            transparent: false,
+            uniforms: {
+                uTime: { value: 0 },
+            },
+            vertexShader: /* glsl */`
+                // ShaderMaterial 不会自动 inject 实例属性；手动声明。
+                attribute float instancePhase;
+                attribute float instanceHit;
+
+                varying vec3  vNormal;
+                varying vec3  vColor;
+                varying vec3  vViewPos;
+                varying float vPhase;
+                varying float vHit;
+
+                void main() {
+                    // 击中时整球沿法线轻微膨胀（squash-and-stretch 雏形）
+                    float displ = instanceHit * 0.15;
+                    vec3 displaced = position + normal * displ;
+
+                    vec4 instancePos = instanceMatrix * vec4(displaced, 1.0);
+                    vec4 mvPos = modelViewMatrix * instancePos;
+
+                    // 法线需经过 instanceMatrix 的 3x3 部分（这里只含均匀缩放，所以 normalize 后等价于纯旋转）
+                    vec3 instNormal = mat3(instanceMatrix) * normal;
+                    vNormal  = normalize(normalMatrix * instNormal);
+                    vColor   = instanceColor;
+                    vViewPos = mvPos.xyz;
+                    vPhase   = instancePhase;
+                    vHit     = instanceHit;
+
+                    gl_Position = projectionMatrix * mvPos;
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform float uTime;
+
+                varying vec3  vNormal;
+                varying vec3  vColor;
+                varying vec3  vViewPos;
+                varying float vPhase;
+                varying float vHit;
+
+                void main() {
+                    vec3 N = normalize(vNormal);
+                    vec3 V = normalize(-vViewPos);     // view dir in view space
+
+                    float ndotv = max(0.0, dot(N, V));
+                    float rim   = pow(1.0 - ndotv, 2.2);
+
+                    // 缓慢呼吸 emission，每个钉子相位错开
+                    float pulse = 0.75 + 0.25 * sin(uTime * 1.6 + vPhase);
+
+                    // 基底：颜色 * 0.30（暗调金属感）
+                    vec3 base     = vColor * 0.30;
+                    // 边缘高光：颜色 * rim
+                    vec3 rimLight = vColor * rim * 1.7 * pulse;
+                    // 击中冲量：emissive 全白瞬闪
+                    vec3 hitFlash = vec3(1.0) * vHit * 0.9;
+
+                    vec3 col = base + rimLight + hitFlash;
+                    gl_FragColor = vec4(col, 1.0);
+                }
+            `,
+        });
+
+        this.mesh = new THREE.InstancedMesh(this.geometry, this.material, PEG_CAPACITY);
+        this.mesh.count = 0;            // 起步隐藏所有实例
+        this.mesh.frustumCulled = false; // 整个 mesh 一直可见，让 instanceMatrix 控制位置
+        this.mesh.name = 'PegInstancedMesh';
+
+        // 预分配复用对象（避免每帧 new Matrix4/Color）
+        this._tmpMat = new THREE.Matrix4();
+        this._tmpColor = new THREE.Color();
+        this._pegIndexMap = new Map(); // peg → instance index
+
+        // 击中冲量衰减率（per second）
+        this.hitDecay = 4.0;
+    }
+
+    /**
+     * 把游戏的 2D pegs[] 数组同步成 3D 实例。
+     *
+     * @param {Array}  pegs2D       game.pegs；每个元素需有 pos.x, pos.y, type, level
+     * @param {Object} coords       CoordsMapper 实例（提供 toWorld + scale）
+     * @param {number} pegRadiusPx  视觉钉子半径（canvas px），由 game_phase 计算后传入
+     */
+    sync(pegs2D, coords, pegRadiusPx) {
+        const n = Math.min(pegs2D.length, PEG_CAPACITY);
+        const worldRadius = Math.max(0.05, pegRadiusPx * coords.scale);
+
+        for (let i = 0; i < n; i++) {
+            const p = pegs2D[i];
+            if (!p || !p.pos) continue;
+
+            const w = coords.toWorld(p.pos.x, p.pos.y, 0);
+            this._tmpMat.makeScale(worldRadius, worldRadius, worldRadius);
+            this._tmpMat.setPosition(w.x, w.y, w.z);
+            this.mesh.setMatrixAt(i, this._tmpMat);
+
+            const arr = PEG_COLORS[p.type] || PEG_COLORS.normal;
+            this._tmpColor.setRGB(arr[0], arr[1], arr[2]);
+            this.mesh.setColorAt(i, this._tmpColor);
+        }
+        this.mesh.count = n;
+        this.mesh.instanceMatrix.needsUpdate = true;
+        if (this.mesh.instanceColor) this.mesh.instanceColor.needsUpdate = true;
+    }
+
+    /**
+     * 触发"被弹珠撞到"的视觉反馈。
+     * @param {number} index instance index (0..count-1)
+     * @param {number} [intensity=1.0]
+     */
+    pulse(index, intensity = 1.0) {
+        if (index < 0 || index >= PEG_CAPACITY) return;
+        this._hitImpulse[index] = Math.min(1.0, this._hitImpulse[index] + intensity);
+        this._hitImpulseAttr.needsUpdate = true;
+    }
+
+    /**
+     * 每帧推进时间 + 衰减击中冲量。
+     * @param {number} dt seconds
+     * @param {number} t  seconds elapsed total
+     */
+    update(dt, t) {
+        this.material.uniforms.uTime.value = t;
+
+        // 衰减击中冲量
+        if (this._hitImpulse) {
+            const decay = Math.max(0, 1 - this.hitDecay * dt);
+            let anyChanged = false;
+            for (let i = 0; i < this.mesh.count; i++) {
+                const v = this._hitImpulse[i];
+                if (v > 0.001) {
+                    this._hitImpulse[i] = v * decay;
+                    anyChanged = true;
+                } else if (v !== 0) {
+                    this._hitImpulse[i] = 0;
+                    anyChanged = true;
+                }
+            }
+            if (anyChanged) this._hitImpulseAttr.needsUpdate = true;
+        }
+    }
+
+    /** 显式隐藏所有钉子（切换出 gathering 阶段时调用） */
+    clear() {
+        this.mesh.count = 0;
+    }
+
+    dispose() {
+        this.geometry.dispose();
+        this.material.dispose();
+    }
+}

--- a/src/render3d/PostFX.js
+++ b/src/render3d/PostFX.js
@@ -1,0 +1,249 @@
+/**
+ * PostFX.js - 后处理管线（M4 核心）
+ *
+ * 链路（从最早到最晚）：
+ *   1. RenderPass        把 scene/camera 渲染到第一个 framebuffer
+ *   2. UnrealBloomPass   提取 HDR 高光做模糊 + additive（emissive 自然辉光）
+ *   3. LensDistortionPass 桶形畸变 + RGB 色散（电影感焦点感）
+ *   4. VignetteGrainPass 边角暗角 + 胶片颗粒（沉浸感氛围）
+ *   5. FXAAPass          廉价抗锯齿
+ *   6. OutputPass        ACES Filmic 色调映射 + sRGB 输出
+ *
+ * HDR：WebGL2 设备启用 HalfFloatType 帧缓冲，让 emissive > 1.0 触发 bloom；
+ *      WebGL1 / 不支持时回退到 UnsignedByteType（bloom 仍工作但不"炸"）。
+ *
+ * 任何 import / 构造失败都让 Renderer3D 走 try/catch 兜底，不破坏游戏可玩性。
+ */
+
+import * as THREE from 'three';
+import { EffectComposer }    from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass }        from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass }   from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { ShaderPass }        from 'three/addons/postprocessing/ShaderPass.js';
+import { OutputPass }        from 'three/addons/postprocessing/OutputPass.js';
+import { FXAAShader }        from 'three/addons/shaders/FXAAShader.js';
+
+// ===================================================================
+// 自定义 shader：桶形畸变 + 色散
+// ===================================================================
+const LENS_DISTORTION_SHADER = {
+    name: 'LensDistortionShader',
+    uniforms: {
+        tDiffuse:    { value: null },
+        uDistortion: { value: 0.06 },    // 桶形畸变强度
+        uChromatic:  { value: 0.005 },   // RGB 色散
+        uVignettePower: { value: 0.0 },  // 不在这里做 vignette
+    },
+    vertexShader: /* glsl */`
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: /* glsl */`
+        precision mediump float;
+        uniform sampler2D tDiffuse;
+        uniform float uDistortion;
+        uniform float uChromatic;
+        varying vec2 vUv;
+
+        vec2 barrel(vec2 uv, float k) {
+            vec2 c = uv - 0.5;
+            float r2 = dot(c, c);
+            return uv + c * k * r2;
+        }
+
+        void main() {
+            // 三色通道分别按略不同的畸变量采样，模拟色散
+            vec2 uvR = barrel(vUv, uDistortion + uChromatic);
+            vec2 uvG = barrel(vUv, uDistortion);
+            vec2 uvB = barrel(vUv, uDistortion - uChromatic);
+
+            float r = texture2D(tDiffuse, uvR).r;
+            float g = texture2D(tDiffuse, uvG).g;
+            float b = texture2D(tDiffuse, uvB).b;
+
+            // 畸变后 uv 出界时回退黑色（避免边缘拉伸）
+            vec2 q = abs(uvG - 0.5) * 2.0;
+            float inFrame = step(max(q.x, q.y), 1.0);
+
+            gl_FragColor = vec4(vec3(r, g, b) * inFrame, 1.0);
+        }
+    `,
+};
+
+// ===================================================================
+// 自定义 shader：边角暗角 + 胶片颗粒（合并一个 pass 省 framebuffer）
+// ===================================================================
+const VIGNETTE_GRAIN_SHADER = {
+    name: 'VignetteGrainShader',
+    uniforms: {
+        tDiffuse:          { value: null },
+        uTime:             { value: 0 },
+        uVignetteOffset:   { value: 0.70 },   // 半径外开始变暗
+        uVignetteDarkness: { value: 0.65 },   // 边角最深度
+        uGrainAmount:      { value: 0.045 },  // 颗粒强度
+        uResolution:       { value: new THREE.Vector2(1, 1) },
+    },
+    vertexShader: /* glsl */`
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: /* glsl */`
+        precision mediump float;
+        uniform sampler2D tDiffuse;
+        uniform float uTime;
+        uniform float uVignetteOffset;
+        uniform float uVignetteDarkness;
+        uniform float uGrainAmount;
+        uniform vec2  uResolution;
+        varying vec2 vUv;
+
+        float hash21(vec2 p) {
+            p = fract(p * vec2(123.34, 456.21));
+            p += dot(p, p + 45.32);
+            return fract(p.x * p.y);
+        }
+
+        void main() {
+            vec4 color = texture2D(tDiffuse, vUv);
+
+            // Vignette：以画面中心为圆心，距离 > offset 后线性变暗
+            vec2 c = vUv - 0.5;
+            // 椭圆 vignette（考虑 9:16 纵向画面）
+            c.x *= uResolution.x / max(uResolution.y, 1.0);
+            float r = length(c) * 1.6;
+            float vig = 1.0 - smoothstep(uVignetteOffset, uVignetteOffset + 0.45, r);
+            // vig=1 表示中心保留原色，vig=0 表示边角全黑
+            float vAmt = mix(1.0 - uVignetteDarkness, 1.0, vig);
+            color.rgb *= vAmt;
+
+            // Film grain：基于 uv * res + 时间扰动的伪随机噪点
+            float grain = hash21(vUv * uResolution + uTime * 137.0) - 0.5;
+            color.rgb += grain * uGrainAmount;
+
+            gl_FragColor = vec4(color.rgb, 1.0);
+        }
+    `,
+};
+
+// ===================================================================
+// PostFX 主类
+// ===================================================================
+export class PostFX {
+    /**
+     * @param {THREE.WebGLRenderer} renderer
+     * @param {THREE.Scene}         scene
+     * @param {THREE.Camera}        camera
+     * @param {number}              width
+     * @param {number}              height
+     * @param {Object}              [opts]
+     * @param {boolean}             [opts.hdr=true]     启用 HalfFloat 帧缓冲（WebGL2 支持）
+     * @param {number}              [opts.pixelRatio]   composer 内部分辨率
+     */
+    constructor(renderer, scene, camera, width, height, opts = {}) {
+        this.renderer = renderer;
+        this.width = Math.max(1, width | 0);
+        this.height = Math.max(1, height | 0);
+
+        // 决定 HDR：WebGL2 可用 HalfFloatType；WebGL1 回退
+        const wantHDR = opts.hdr !== false;
+        const isWebGL2 = !!(renderer && renderer.capabilities && renderer.capabilities.isWebGL2);
+        const type = (wantHDR && isWebGL2) ? THREE.HalfFloatType : THREE.UnsignedByteType;
+        this.usingHDR = type === THREE.HalfFloatType;
+
+        // Tonemapping 在 OutputPass 末端处理（OutputPass 使用 renderer.toneMapping）
+        // 启用 ACES Filmic 让 HDR 高光自然 roll-off
+        renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        renderer.toneMappingExposure = 1.0;
+
+        const rt = new THREE.WebGLRenderTarget(this.width, this.height, {
+            type,
+            format: THREE.RGBAFormat,
+            depthBuffer: true,
+            stencilBuffer: false,
+        });
+        this.composer = new EffectComposer(renderer, rt);
+        // composer 默认 setPixelRatio 跟随 renderer
+        this.composer.setPixelRatio(renderer.getPixelRatio());
+
+        // --- Pass 1: render the scene ---
+        this.renderPass = new RenderPass(scene, camera);
+        this.composer.addPass(this.renderPass);
+
+        // --- Pass 2: bloom ---
+        this.bloomPass = new UnrealBloomPass(
+            new THREE.Vector2(this.width, this.height),
+            0.70,   // strength
+            0.45,   // radius
+            0.55    // threshold（LDR 模式下需要较低阈值才能触发）
+        );
+        // HDR 时阈值可以高一些（emissive 自然 > 1）
+        if (this.usingHDR) {
+            this.bloomPass.threshold = 0.85;
+            this.bloomPass.strength = 0.85;
+        }
+        this.composer.addPass(this.bloomPass);
+
+        // --- Pass 3: lens distortion + chromatic aberration ---
+        this.lensPass = new ShaderPass(LENS_DISTORTION_SHADER);
+        this.composer.addPass(this.lensPass);
+
+        // --- Pass 4: vignette + film grain ---
+        this.vignettePass = new ShaderPass(VIGNETTE_GRAIN_SHADER);
+        this.vignettePass.uniforms.uResolution.value.set(this.width, this.height);
+        this.composer.addPass(this.vignettePass);
+
+        // --- Pass 5: FXAA antialiasing ---
+        this.fxaaPass = new ShaderPass(FXAAShader);
+        this.fxaaPass.uniforms.resolution.value.set(1 / this.width, 1 / this.height);
+        this.composer.addPass(this.fxaaPass);
+
+        // --- Pass 6: output (ACES Filmic + sRGB conversion) ---
+        this.outputPass = new OutputPass();
+        this.composer.addPass(this.outputPass);
+
+        this._time = 0;
+    }
+
+    resize(width, height) {
+        const W = Math.max(1, width | 0);
+        const H = Math.max(1, height | 0);
+        if (W === this.width && H === this.height) return;
+        this.width = W;
+        this.height = H;
+        this.composer.setSize(W, H);
+        if (this.bloomPass && this.bloomPass.setSize) this.bloomPass.setSize(W, H);
+        this.vignettePass.uniforms.uResolution.value.set(W, H);
+        this.fxaaPass.uniforms.resolution.value.set(1 / W, 1 / H);
+    }
+
+    /**
+     * @param {number} dt seconds
+     */
+    render(dt) {
+        this._time += dt;
+        this.vignettePass.uniforms.uTime.value = this._time;
+        this.composer.render(dt);
+    }
+
+    /** 调节畸变强度（M4.5 / 动态镜头会用：受击高、平时低） */
+    setDistortion(distortion, chromatic) {
+        if (distortion !== undefined) this.lensPass.uniforms.uDistortion.value = distortion;
+        if (chromatic !== undefined)  this.lensPass.uniforms.uChromatic.value  = chromatic;
+    }
+
+    /** 调节 bloom 强度（剧烈事件时短暂拉高） */
+    setBloomStrength(s) {
+        this.bloomPass.strength = s;
+    }
+
+    dispose() {
+        try { this.composer.dispose(); } catch (e) {}
+        try { if (this.bloomPass) this.bloomPass.dispose(); } catch (e) {}
+    }
+}

--- a/src/render3d/RelicCard.js
+++ b/src/render3d/RelicCard.js
@@ -1,0 +1,454 @@
+/**
+ * RelicCard.js - 遗物的 3D 卡片表达（M5 核心）
+ *
+ * 设计：
+ *   不再使用 PNG sprite。每张遗物卡片完全程序化生成：
+ *
+ *     Card Group {
+ *       FrontPlate       —— 圆角平板，shader 渲染稀有度边框 + 暗色基底
+ *       SigilMesh        —— 中央徽记（程序化 shader，hash(id) → 形状）
+ *       TextPanel        —— Canvas 2D 绘制标题/描述/标签 → CanvasTexture
+ *       RarityRimGlow    —— 卡片四周薄光环（稀有度色，bloom 友好）
+ *     }
+ *
+ * 用法：
+ *   const card = new RelicCard(relic);    // relic = config.RELIC_DB 里一行
+ *   card.group.position.set(...);
+ *   scene.add(card.group);
+ *   ...
+ *   card.dispose();                       // 销毁所有资源
+ *
+ * 整张卡片用 1 个 ShaderMaterial（外加 1 张 CanvasTexture），总 draw call ≤ 3。
+ */
+
+import * as THREE from 'three';
+
+// 稀有度色板（与 visual_redesign_3d_plan.md §1.3 一致）
+const RARITY_COLORS = {
+    common:    { fill: 0xe2e8f0, glow: 0x94a3b8 },
+    rare:      { fill: 0x818cf8, glow: 0x6366f1 },
+    epic:      { fill: 0xd946ef, glow: 0xc026d3 },
+    legendary: { fill: 0xf59e0b, glow: 0xea580c },
+    cursed:    { fill: 0x9f1239, glow: 0xbe123c },
+};
+
+const CARD_WIDTH  = 4.6;
+const CARD_HEIGHT = 6.4;
+const CARD_DEPTH  = 0.35;
+const CARD_RADIUS = 0.45;  // 圆角半径
+
+// ============================================================
+// 字符串哈希 → [0,1) 数字，用作程序化随机种子
+// ============================================================
+function hashStr(s) {
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+    }
+    return (h >>> 0) / 0xffffffff;
+}
+
+// 简易确定性 PRNG（同 BackgroundLayer mulberry32）
+function mulberry32(seed) {
+    return function () {
+        let t = seed += 0x6d2b79f5;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+// ============================================================
+// 圆角矩形 BufferGeometry（构造一次，所有卡片共享）
+// ============================================================
+let _sharedCardGeom = null;
+function getCardGeometry() {
+    if (_sharedCardGeom) return _sharedCardGeom;
+    const shape = new THREE.Shape();
+    const w = CARD_WIDTH, h = CARD_HEIGHT, r = CARD_RADIUS;
+    shape.moveTo(-w / 2 + r, -h / 2);
+    shape.lineTo(w / 2 - r, -h / 2);
+    shape.quadraticCurveTo(w / 2, -h / 2, w / 2, -h / 2 + r);
+    shape.lineTo(w / 2, h / 2 - r);
+    shape.quadraticCurveTo(w / 2, h / 2, w / 2 - r, h / 2);
+    shape.lineTo(-w / 2 + r, h / 2);
+    shape.quadraticCurveTo(-w / 2, h / 2, -w / 2, h / 2 - r);
+    shape.lineTo(-w / 2, -h / 2 + r);
+    shape.quadraticCurveTo(-w / 2, -h / 2, -w / 2 + r, -h / 2);
+
+    _sharedCardGeom = new THREE.ExtrudeGeometry(shape, {
+        depth: CARD_DEPTH,
+        bevelEnabled: true,
+        bevelSize: 0.05,
+        bevelThickness: 0.04,
+        bevelSegments: 2,
+        curveSegments: 8,
+    });
+    _sharedCardGeom.center();
+
+    // ExtrudeGeometry 默认 UV 是 shape 坐标范围（约 [-w/2, +w/2]），不是 [0, 1]。
+    // 手动归一化到 [0, 1] 以便 shader 里的 vignette / edge 计算工作正常。
+    const pos = _sharedCardGeom.attributes.position;
+    const uv = new Float32Array(pos.count * 2);
+    for (let i = 0; i < pos.count; i++) {
+        uv[i * 2 + 0] = (pos.getX(i) + CARD_WIDTH * 0.5) / CARD_WIDTH;
+        uv[i * 2 + 1] = (pos.getY(i) + CARD_HEIGHT * 0.5) / CARD_HEIGHT;
+    }
+    _sharedCardGeom.setAttribute('uv', new THREE.BufferAttribute(uv, 2));
+    return _sharedCardGeom;
+}
+
+// ============================================================
+// 文本面板：Canvas 2D 渲染 → CanvasTexture
+// ============================================================
+function _wrapText(ctx, text, maxWidth) {
+    if (!text) return [''];
+    // 简易"按字符断行"——适合中文
+    const chars = Array.from(text);
+    const lines = [];
+    let cur = '';
+    for (const ch of chars) {
+        const tryLine = cur + ch;
+        if (ctx.measureText(tryLine).width > maxWidth) {
+            if (cur) lines.push(cur);
+            cur = ch;
+        } else {
+            cur = tryLine;
+        }
+    }
+    if (cur) lines.push(cur);
+    return lines;
+}
+
+function createTextTexture(relic) {
+    const W = 512;
+    const H = 768;
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+
+    // 全透明背景（卡片本体已经渲染基底色）
+    ctx.clearRect(0, 0, W, H);
+
+    const rarity = relic.rarity || 'common';
+    const colors = RARITY_COLORS[rarity] || RARITY_COLORS.common;
+    const glowHex = '#' + colors.glow.toString(16).padStart(6, '0');
+    const fillHex = '#' + colors.fill.toString(16).padStart(6, '0');
+
+    // ---- 顶部色带（rarity）----
+    const bandH = 88;
+    const grad = ctx.createLinearGradient(0, 0, W, 0);
+    grad.addColorStop(0, glowHex + '00');
+    grad.addColorStop(0.5, glowHex + 'cc');
+    grad.addColorStop(1, glowHex + '00');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, W, bandH);
+
+    // ---- 标题 ----
+    ctx.fillStyle = '#f8fafc';
+    ctx.font = 'bold 48px "Noto Serif TC", serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.shadowColor = glowHex;
+    ctx.shadowBlur = 16;
+    ctx.fillText(relic.name || '???', W / 2, bandH / 2 + 8);
+    ctx.shadowBlur = 0;
+
+    // ---- 中央徽记位置预留（在 3D 里用 SigilMesh）----
+    const sigilY = bandH + 60;
+    const sigilSize = 220;
+    // 占位标记（透明）—— Sigil 由独立 mesh 覆盖
+    // 这里画一圈纹路装饰
+    ctx.strokeStyle = glowHex + '66';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(W / 2, sigilY + sigilSize / 2, sigilSize / 2 + 18, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.strokeStyle = glowHex + '33';
+    ctx.beginPath();
+    ctx.arc(W / 2, sigilY + sigilSize / 2, sigilSize / 2 + 30, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // ---- 描述文本 ----
+    const descY = sigilY + sigilSize + 60;
+    ctx.fillStyle = '#cbd5e1';
+    ctx.font = '32px "Noto Serif TC", serif';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    const desc = relic.desc || '';
+    const lines = _wrapText(ctx, desc, W - 60);
+    const lineH = 44;
+    for (let i = 0; i < Math.min(lines.length, 6); i++) {
+        ctx.fillText(lines[i], 30, descY + i * lineH);
+    }
+
+    // ---- 底部稀有度标 + tags ----
+    const footY = H - 60;
+    ctx.fillStyle = glowHex;
+    ctx.font = 'bold 26px "Noto Serif TC", serif';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    const rarityLabel = rarity.toUpperCase();
+    ctx.fillText(rarityLabel, 30, footY);
+    if (relic.tags && relic.tags.length) {
+        ctx.fillStyle = '#94a3b8';
+        ctx.font = '24px "Noto Serif TC", serif';
+        ctx.textAlign = 'right';
+        ctx.fillText(relic.tags.slice(0, 2).join(' · '), W - 30, footY);
+    }
+    if (relic.maxStacks && relic.maxStacks > 1) {
+        ctx.fillStyle = '#fbbf24';
+        ctx.font = '20px "Noto Serif TC", serif';
+        ctx.textAlign = 'right';
+        ctx.fillText(`MAX ${relic.maxStacks}`, W - 30, footY - 30);
+    }
+
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    tex.minFilter = THREE.LinearFilter;
+    tex.magFilter = THREE.LinearFilter;
+    tex.needsUpdate = true;
+    return { texture: tex, canvas, sigilSize };
+}
+
+// ============================================================
+// Sigil shader：程序化徽记（hash → 形状）
+// ============================================================
+function _createSigilMaterial(relic) {
+    const seed = hashStr(relic.id || relic.name || '???');
+    const colors = RARITY_COLORS[relic.rarity || 'common'] || RARITY_COLORS.common;
+    const rng = mulberry32(Math.floor(seed * 1e8));
+    const armCount = 3 + Math.floor(rng() * 6);          // 3..8
+    const innerFreq = 2 + Math.floor(rng() * 4);          // 2..5
+    const phase = rng() * Math.PI * 2;
+    const colorHex = colors.glow;
+    return new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        uniforms: {
+            uTime:      { value: 0 },
+            uColor:     { value: new THREE.Color(colorHex) },
+            uColorBri:  { value: new THREE.Color(colors.fill) },
+            uArms:      { value: armCount },
+            uInner:     { value: innerFreq },
+            uPhase:     { value: phase },
+        },
+        vertexShader: /* glsl */`
+            varying vec2 vUv;
+            void main() {
+                vUv = uv;
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: /* glsl */`
+            precision mediump float;
+            uniform float uTime;
+            uniform vec3  uColor;
+            uniform vec3  uColorBri;
+            uniform float uArms;
+            uniform float uInner;
+            uniform float uPhase;
+            varying vec2 vUv;
+
+            void main() {
+                vec2 c = vUv - 0.5;
+                float r = length(c) * 2.0;
+                float ang = atan(c.y, c.x);
+
+                // 离散花瓣（"星花"）
+                float petal = cos(ang * uArms + uPhase) * 0.5 + 0.5;
+                float petalShape = smoothstep(0.6, 0.85, petal) * smoothstep(0.95, 0.5, r);
+
+                // 内圈细纹
+                float ring = sin(r * 32.0 + uTime * 0.6) * 0.5 + 0.5;
+                float ringMask = smoothstep(0.45, 0.30, r) * (0.4 + ring * 0.6);
+
+                // 中心亮点
+                float core = smoothstep(0.12, 0.0, r) * 1.4;
+
+                // 慢速旋转感（让花瓣轻微脉动）
+                float pulse = 0.85 + 0.15 * sin(uTime * 1.2);
+
+                vec3 col = uColor * petalShape * 1.6 * pulse;
+                col += uColor * ringMask * 0.55;
+                col += uColorBri * core;
+
+                // 外环淡出
+                float outerFade = smoothstep(1.0, 0.85, r);
+
+                gl_FragColor = vec4(col * outerFade, (petalShape + ringMask + core) * outerFade);
+            }
+        `,
+    });
+}
+
+// ============================================================
+// RelicCard 主类
+// ============================================================
+export class RelicCard {
+    /**
+     * @param {Object} relic { id, name, desc, rarity, tags, maxStacks }
+     */
+    constructor(relic) {
+        this.relic = relic || {};
+        this.group = new THREE.Group();
+        this.group.name = `RelicCard_${relic.id || 'anon'}`;
+
+        const rarity = relic.rarity || 'common';
+        const colors = RARITY_COLORS[rarity] || RARITY_COLORS.common;
+        this._rarityHex = colors.glow;
+        this._fillHex = colors.fill;
+
+        // ----- 卡牌本体（圆角板 + 边框 shader）-----
+        const cardGeom = getCardGeometry();
+        this.cardMat = new THREE.ShaderMaterial({
+            transparent: true,
+            uniforms: {
+                uTime:     { value: 0 },
+                uRarity:   { value: new THREE.Color(this._rarityHex) },
+                uFill:     { value: new THREE.Color(this._fillHex) },
+            },
+            vertexShader: /* glsl */`
+                varying vec3 vNormal;
+                varying vec3 vWorldPos;
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    vec4 wp = modelMatrix * vec4(position, 1.0);
+                    vWorldPos = wp.xyz;
+                    vNormal = normalize(normalMatrix * normal);
+                    gl_Position = projectionMatrix * viewMatrix * wp;
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform float uTime;
+                uniform vec3  uRarity;
+                uniform vec3  uFill;
+                varying vec3 vNormal;
+                varying vec3 vWorldPos;
+                varying vec2 vUv;
+
+                void main() {
+                    // 朝玩家方向的 fresnel 边光
+                    vec3 viewDir = normalize(cameraPosition - vWorldPos);
+                    float fres = pow(1.0 - max(0.0, dot(vNormal, viewDir)), 2.5);
+
+                    // 深色基底（不抢文字）
+                    vec3 base = vec3(0.04, 0.06, 0.10);
+
+                    // 内部 vignette（中间饱满，边缘掉到 0）
+                    float vx = smoothstep(0.0, 0.15, min(vUv.x, 1.0 - vUv.x));
+                    float vy = smoothstep(0.0, 0.10, min(vUv.y, 1.0 - vUv.y));
+                    float interior = vx * vy;
+
+                    // edgeMask 只在最外圈（vignette 衰减区）激活，避免大面积染色
+                    float edgeMask = 1.0 - interior;
+
+                    // 卡牌基底色：中央接近纯黑，仅边缘有 rarity 染色
+                    vec3 col = base + uRarity * edgeMask * 0.35;
+                    // 加 fresnel 边光（卡牌外缘的 emissive 光环，bloom 会接管）
+                    col += uRarity * fres * 0.9;
+
+                    gl_FragColor = vec4(col, 1.0);
+                }
+            `,
+        });
+        this.cardMesh = new THREE.Mesh(cardGeom, this.cardMat);
+        this.cardMesh.frustumCulled = false;
+        this.group.add(this.cardMesh);
+
+        // ----- 文本面板（CanvasTexture 贴在卡牌正面）-----
+        const { texture, sigilSize } = createTextTexture(this.relic);
+        this._textTexture = texture;
+        const textGeom = new THREE.PlaneGeometry(CARD_WIDTH * 0.92, CARD_HEIGHT * 0.92);
+        const textMat = new THREE.MeshBasicMaterial({
+            map: texture,
+            transparent: true,
+            depthWrite: false,
+        });
+        this._textMat = textMat;
+        this.textMesh = new THREE.Mesh(textGeom, textMat);
+        // 贴在卡牌正面外侧。CARD_DEPTH/2 + bevelThickness(0.06) + 余量 → 至少 0.30
+        this.textMesh.position.set(0, 0, CARD_DEPTH / 2 + 0.12);
+        this.textMesh.renderOrder = 1;
+        this.group.add(this.textMesh);
+
+        // ----- 程序化徽记（在卡牌中央，文字纹理之上）-----
+        const sigilMat = _createSigilMaterial(this.relic);
+        this._sigilMat = sigilMat;
+        // 徽记大小 = sigilSize / canvas_height * CARD_HEIGHT * 0.92
+        const sigilWorldSize = (220 / 768) * (CARD_HEIGHT * 0.92);
+        const sigilGeom = new THREE.PlaneGeometry(sigilWorldSize, sigilWorldSize);
+        this._sigilGeom = sigilGeom;
+        this.sigilMesh = new THREE.Mesh(sigilGeom, sigilMat);
+        // 卡片纹理里 sigilY = 88+60 = 148, sigilSize = 220
+        // 中心 y on canvas = 148 + 110 = 258, canvas H = 768
+        // local y = (0.5 - 258/768) * (CARD_HEIGHT*0.92) ≈ 0.964
+        const sigilY = (0.5 - (88 + 60 + 220 / 2) / 768) * (CARD_HEIGHT * 0.92);
+        this.sigilMesh.position.set(0, sigilY, CARD_DEPTH / 2 + 0.16);
+        this.sigilMesh.renderOrder = 2;
+        this.group.add(this.sigilMesh);
+
+        // ----- 卡牌四周光环（薄椭圆 plane 在卡背后，bloom 友好）-----
+        const glowGeom = new THREE.PlaneGeometry(CARD_WIDTH * 1.35, CARD_HEIGHT * 1.20);
+        const glowMat = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            uniforms: {
+                uColor: { value: new THREE.Color(this._rarityHex) },
+                uTime:  { value: 0 },
+            },
+            vertexShader: /* glsl */`
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform vec3  uColor;
+                uniform float uTime;
+                varying vec2 vUv;
+                void main() {
+                    vec2 c = vUv - 0.5;
+                    float r = length(c) * 2.0;
+                    float halo = smoothstep(1.05, 0.55, r);
+                    float pulse = 0.85 + 0.15 * sin(uTime * 0.8);
+                    gl_FragColor = vec4(uColor * halo * pulse * 0.8, halo * 0.65);
+                }
+            `,
+        });
+        this._glowMat = glowMat;
+        this._glowGeom = glowGeom;
+        this.glowMesh = new THREE.Mesh(glowGeom, glowMat);
+        // 放在卡牌后面一点
+        this.glowMesh.position.set(0, 0, -CARD_DEPTH * 0.6);
+        this.group.add(this.glowMesh);
+    }
+
+    /** 每帧更新 shader 时间（外层 update loop 调） */
+    update(t) {
+        if (this.cardMat) this.cardMat.uniforms.uTime.value = t;
+        if (this._sigilMat) this._sigilMat.uniforms.uTime.value = t;
+        if (this._glowMat) this._glowMat.uniforms.uTime.value = t;
+    }
+
+    /** 完全销毁所有 GPU 资源 */
+    dispose() {
+        // 共享 geometry 不在这里 dispose；只销毁本卡的材质 + 文字纹理
+        if (this.cardMat) this.cardMat.dispose();
+        if (this._textMat) this._textMat.dispose();
+        if (this._sigilMat) this._sigilMat.dispose();
+        if (this._textTexture) this._textTexture.dispose();
+        if (this._sigilGeom) this._sigilGeom.dispose();
+        if (this._glowMat) this._glowMat.dispose();
+        if (this._glowGeom) this._glowGeom.dispose();
+        if (this.textMesh && this.textMesh.geometry) this.textMesh.geometry.dispose();
+    }
+}

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -18,6 +18,7 @@ import * as THREE from 'three';
 import { BackgroundLayer } from './BackgroundLayer.js';
 import { CameraController } from './CameraController.js';
 import { CoordsMapper } from './coords.js';
+import { SceneProxy } from './SceneProxy.js';
 
 export class Renderer3D {
     /**
@@ -35,9 +36,17 @@ export class Renderer3D {
         this._initRenderer();
         this._initScene();
         this._initCamera();
+
+        // CoordsMapper：根据相机 FOV/距离自动算 scale，画布高度占视域 94%
+        const cameraDist = Math.abs(this.camera.position.z);
+        const scale = CoordsMapper.autoScaleFromFov(this.camera.fov, cameraDist, this.height, 0.94);
+        this.coords = new CoordsMapper(this.width, this.height, scale);
+
         this._initLayers();
 
-        this.coords = new CoordsMapper(this.width, this.height);
+        // SceneProxy：玩法 ↔ 3D 桥接（钉子 / 墙 / 后续敌人 / 子弹...）
+        this.proxy = new SceneProxy(this.scene, this.coords);
+
         this.cameraController = new CameraController(this.camera);
 
         // 帧计时（秒）
@@ -96,7 +105,11 @@ export class Renderer3D {
         this.renderer.setSize(W, H, false);
         this.camera.aspect = W / H;
         this.camera.updateProjectionMatrix();
-        this.coords.update(W, H);
+        // 新 H → 重算 scale
+        const cameraDist = Math.abs(this.camera.position.z);
+        const scale = CoordsMapper.autoScaleFromFov(this.camera.fov, cameraDist, H, 0.94);
+        this.coords.update(W, H, scale);
+        if (this.proxy) this.proxy.onResize();
     }
 
     /**
@@ -111,6 +124,7 @@ export class Renderer3D {
         this._tElapsed += dt;
 
         if (this.background) this.background.update(dt, this._tElapsed);
+        if (this.proxy) this.proxy.update(dt, this._tElapsed);
         if (this.cameraController) this.cameraController.update(dt);
 
         this.renderer.render(this.scene, this.camera);
@@ -120,8 +134,10 @@ export class Renderer3D {
     }
 
     dispose() {
+        try { if (this.proxy) this.proxy.dispose(); } catch (e) {}
         try { if (this.background) this.background.dispose(); } catch (e) {}
         try { this.renderer.dispose(); } catch (e) {}
+        this.proxy = null;
         this.background = null;
         this.cameraController = null;
         this.scene = null;

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -1,0 +1,131 @@
+/**
+ * Renderer3D.js - 3D 渲染管线主入口（M1：仅背景层）
+ *
+ * 职责：
+ *   - 初始化 Three.js WebGLRenderer / Scene / PerspectiveCamera
+ *   - 装配 BackgroundLayer（远景剪影/光柱/星云）
+ *   - 装配 CameraController（M1 仅 IDLE 呼吸漂移）
+ *   - 暴露 resize(w,h) / render(now) / dispose()
+ *   - 暴露 CoordsMapper 供后续 milestone 用于 2D→3D 坐标转换
+ *
+ * 与游戏循环的对接：
+ *   - core.js 构造 Game 时 try/catch 初始化此渲染器；任何失败 → 静默降级到 2D-only
+ *   - sys_loop 每帧首调 this.renderer3d?.render(performance.now())
+ *   - sys_resize 每次画布尺寸变化调 this.renderer3d?.resize(w, h)
+ */
+
+import * as THREE from 'three';
+import { BackgroundLayer } from './BackgroundLayer.js';
+import { CameraController } from './CameraController.js';
+import { CoordsMapper } from './coords.js';
+
+export class Renderer3D {
+    /**
+     * @param {HTMLCanvasElement} canvas    WebGL canvas 元素
+     * @param {number}            width     initial pixel width
+     * @param {number}            height    initial pixel height
+     */
+    constructor(canvas, width, height) {
+        if (!canvas) throw new Error('[Renderer3D] canvas element required');
+
+        this.canvas = canvas;
+        this.width = Math.max(1, width | 0);
+        this.height = Math.max(1, height | 0);
+
+        this._initRenderer();
+        this._initScene();
+        this._initCamera();
+        this._initLayers();
+
+        this.coords = new CoordsMapper(this.width, this.height);
+        this.cameraController = new CameraController(this.camera);
+
+        // 帧计时（秒）
+        this._tElapsed = 0;
+        this._lastNow = 0;
+
+        // 调试统计（可被外部读取）
+        this.stats = { frames: 0, lastDtMs: 0 };
+    }
+
+    _initRenderer() {
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: this.canvas,
+            antialias: true,
+            alpha: true,                 // 让背景颜色由 setClearColor 决定，便于后续 HUD 合成
+            powerPreference: 'high-performance',
+            stencil: false,
+            depth: true,
+        });
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+        // 第三个参数 false → 不修改 canvas 的 CSS 尺寸（CSS 由 index.html 全局规则控制）
+        this.renderer.setSize(this.width, this.height, false);
+        this.renderer.setClearColor(0x05060d, 1);
+        // r152+ 用 outputColorSpace 替代 outputEncoding
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+    }
+
+    _initScene() {
+        this.scene = new THREE.Scene();
+        // 体积雾 ≈ 远景柔化 & 景深前奏；M4 接入后处理 DoF 时会进一步加强
+        this.scene.fog = new THREE.FogExp2(0x05060d, 0.0025);
+    }
+
+    _initCamera() {
+        const aspect = this.width / this.height;
+        // 窄 FOV：玩法面板（z=0）接近正交，畸变小，便于读图
+        this.camera = new THREE.PerspectiveCamera(28, aspect, 10, 600);
+        this.camera.position.set(0, -10, 180);
+        this.camera.lookAt(0, 0, 0);
+    }
+
+    _initLayers() {
+        this.background = new BackgroundLayer(this.scene);
+        // M2 接入：玩法面板钉子；M3：敌人；M4：后处理；M5：遗物 3D 卡片；M6：GPU 粒子
+    }
+
+    /**
+     * 同步画布尺寸。调用方负责保证传入的就是 2D Canvas 的 width/height。
+     */
+    resize(width, height) {
+        const W = Math.max(1, width | 0);
+        const H = Math.max(1, height | 0);
+        if (W === this.width && H === this.height) return;
+        this.width = W;
+        this.height = H;
+        this.renderer.setSize(W, H, false);
+        this.camera.aspect = W / H;
+        this.camera.updateProjectionMatrix();
+        this.coords.update(W, H);
+    }
+
+    /**
+     * 每帧调用一次。
+     * @param {number} nowMs performance.now() 时间戳
+     */
+    render(nowMs) {
+        if (this._lastNow === 0) this._lastNow = nowMs;
+        // 限制 dt 上限避免标签页切回时的大跳变
+        const dt = Math.min(0.1, Math.max(0, (nowMs - this._lastNow) / 1000));
+        this._lastNow = nowMs;
+        this._tElapsed += dt;
+
+        if (this.background) this.background.update(dt, this._tElapsed);
+        if (this.cameraController) this.cameraController.update(dt);
+
+        this.renderer.render(this.scene, this.camera);
+
+        this.stats.frames++;
+        this.stats.lastDtMs = dt * 1000;
+    }
+
+    dispose() {
+        try { if (this.background) this.background.dispose(); } catch (e) {}
+        try { this.renderer.dispose(); } catch (e) {}
+        this.background = null;
+        this.cameraController = null;
+        this.scene = null;
+        this.camera = null;
+        this.renderer = null;
+    }
+}

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -27,12 +27,18 @@ export class Renderer3D {
      * @param {number}            width     initial pixel width
      * @param {number}            height    initial pixel height
      */
-    constructor(canvas, width, height) {
+    constructor(canvas, width, height, opts = {}) {
         if (!canvas) throw new Error('[Renderer3D] canvas element required');
 
         this.canvas = canvas;
         this.width = Math.max(1, width | 0);
         this.height = Math.max(1, height | 0);
+        this.opts = opts;
+
+        // 后处理 baseline（与 PostFX 默认值保持一致）—— 用于合并 cameraController 瞬时增量
+        this._fxBaselineDistortion = 0.06;
+        this._fxBaselineChromatic  = 0.005;
+        this._fxBaselineBloom      = 0.85;
 
         this._initRenderer();
         this._initScene();
@@ -55,10 +61,21 @@ export class Renderer3D {
         this.postfx = null;
         try {
             this.postfx = new PostFX(this.renderer, this.scene, this.camera, this.width, this.height);
+            // 校准 baseline（避免与 PostFX 内部默认值不一致）
+            if (this.postfx.usingHDR) {
+                this._fxBaselineBloom = 0.85;
+            } else {
+                this._fxBaselineBloom = 0.70;
+            }
             console.info(`[Renderer3D] PostFX enabled (HDR=${this.postfx.usingHDR})`);
         } catch (err) {
             console.warn('[Renderer3D] PostFX init failed, falling back to direct render:', err);
             this.postfx = null;
+        }
+
+        // [3D-Main M4.5] 订阅 eventBus（若传入），把游戏事件转发到镜头
+        if (opts.eventBus && typeof opts.eventBus.on === 'function') {
+            this._bindEventBus(opts.eventBus);
         }
 
         // 帧计时（秒）
@@ -144,6 +161,18 @@ export class Renderer3D {
         if (this.proxy) this.proxy.update(dt, this._tElapsed);
         if (this.cameraController) this.cameraController.update(dt);
 
+        // [M4.5] 把镜头瞬时增量合并到后处理 uniform
+        if (this.postfx && this.cameraController) {
+            const fx = this.cameraController.getPostFXState();
+            this.postfx.setDistortion(
+                this._fxBaselineDistortion + fx.distortion,
+                this._fxBaselineChromatic  + fx.chromatic
+            );
+            this.postfx.setBloomStrength(this._fxBaselineBloom + fx.bloom);
+            // exposure 通过 renderer.toneMappingExposure 控制（OutputPass 读取）
+            this.renderer.toneMappingExposure = 1.0 + fx.exposure;
+        }
+
         if (this.postfx) {
             this.postfx.render(dt);
         } else {
@@ -154,10 +183,95 @@ export class Renderer3D {
         this.stats.lastDtMs = dt * 1000;
     }
 
+    /**
+     * [M4.5] 触发镜头事件。语义类型由 CameraController 内部处理。
+     * @param {string} type   'IMPACT' | 'KILLED' | 'HIT_PLAYER' | 'BOSS_INTRO' | 'PHASE_TRANS'
+     * @param {Object} [payload]
+     */
+    cameraEvent(type, payload = {}) {
+        if (!this.cameraController) return;
+        try {
+            switch (type) {
+                case 'IMPACT':
+                    this.cameraController.triggerImpact(
+                        payload.intensity ?? 1.0,
+                        payload.dirX ?? 0,
+                        payload.dirY ?? 0
+                    );
+                    break;
+                case 'KILLED':
+                    this.cameraController.triggerEnemyKilled(payload.intensity ?? 0.4);
+                    break;
+                case 'HIT_PLAYER':
+                    this.cameraController.triggerPlayerHit(payload.intensity ?? 1.0);
+                    break;
+                case 'BOSS_INTRO':
+                    this.cameraController.triggerBossIntro();
+                    break;
+                case 'PHASE_TRANS':
+                    this.cameraController.triggerPhaseTransition();
+                    break;
+                case 'AIM':
+                    this.cameraController.setAim(payload.x ?? 0, payload.y ?? 0);
+                    break;
+                default:
+                    // 未知类型不报错，便于上游平滑扩展
+                    break;
+            }
+        } catch (e) {
+            console.warn('[Renderer3D] cameraEvent error:', e);
+        }
+    }
+
+    /**
+     * [M4.5] 订阅 eventBus 把游戏事件转发到镜头。轻量，幂等。
+     * @private
+     */
+    _bindEventBus(bus) {
+        // 暴击 / 强击：使用 damage:dealt 事件，按 damage 量级映射强度
+        const onDamage = (data) => {
+            if (!data) return;
+            const dmg = data.damage || data.amount || 0;
+            if (dmg <= 0) return;
+            // 阈值：< 30 微震，30..120 中震，>= 120 大震
+            let intensity = 0.18;
+            if (dmg >= 120) intensity = 0.85;
+            else if (dmg >= 30) intensity = 0.42;
+            if (data.killed) intensity *= 1.4;
+            this.cameraEvent('IMPACT', { intensity });
+        };
+        const onKill = (data) => {
+            this.cameraEvent('KILLED', { intensity: 0.5 });
+        };
+        const onBossDefeated = () => {
+            this.cameraEvent('IMPACT', { intensity: 1.4 });
+        };
+        const onPhaseChange = (data) => {
+            this.cameraEvent('PHASE_TRANS', {});
+        };
+
+        bus.on('damage:dealt', onDamage);
+        bus.on('enemy:killed', onKill);
+        bus.on('boss:defeated', onBossDefeated);
+        bus.on('phase:change', onPhaseChange);
+
+        // 记录引用以便 dispose 时取消（如果 eventBus 提供 off）
+        this._busHandlers = { onDamage, onKill, onBossDefeated, onPhaseChange };
+        this._bus = bus;
+    }
+
     dispose() {
         try { if (this.postfx) this.postfx.dispose(); } catch (e) {}
         try { if (this.proxy) this.proxy.dispose(); } catch (e) {}
         try { if (this.background) this.background.dispose(); } catch (e) {}
+        try {
+            if (this._bus && this._busHandlers && typeof this._bus.off === 'function') {
+                this._bus.off('damage:dealt',  this._busHandlers.onDamage);
+                this._bus.off('enemy:killed',  this._busHandlers.onKill);
+                this._bus.off('boss:defeated', this._busHandlers.onBossDefeated);
+                this._bus.off('phase:change',  this._busHandlers.onPhaseChange);
+            }
+        } catch (e) {}
         try { this.renderer.dispose(); } catch (e) {}
         this.postfx = null;
         this.proxy = null;
@@ -166,5 +280,7 @@ export class Renderer3D {
         this.scene = null;
         this.camera = null;
         this.renderer = null;
+        this._bus = null;
+        this._busHandlers = null;
     }
 }

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -19,6 +19,7 @@ import { BackgroundLayer } from './BackgroundLayer.js';
 import { CameraController } from './CameraController.js';
 import { CoordsMapper } from './coords.js';
 import { SceneProxy } from './SceneProxy.js';
+import { PostFX } from './PostFX.js';
 
 export class Renderer3D {
     /**
@@ -48,6 +49,17 @@ export class Renderer3D {
         this.proxy = new SceneProxy(this.scene, this.coords);
 
         this.cameraController = new CameraController(this.camera);
+
+        // [3D-Main M4] 后处理管线：bloom / 畸变 / 颗粒 / 暗角 / ACES tonemap
+        // 失败时静默回退到直接 render（this.postfx = null）
+        this.postfx = null;
+        try {
+            this.postfx = new PostFX(this.renderer, this.scene, this.camera, this.width, this.height);
+            console.info(`[Renderer3D] PostFX enabled (HDR=${this.postfx.usingHDR})`);
+        } catch (err) {
+            console.warn('[Renderer3D] PostFX init failed, falling back to direct render:', err);
+            this.postfx = null;
+        }
 
         // 帧计时（秒）
         this._tElapsed = 0;
@@ -110,6 +122,11 @@ export class Renderer3D {
         const scale = CoordsMapper.autoScaleFromFov(this.camera.fov, cameraDist, H, 0.94);
         this.coords.update(W, H, scale);
         if (this.proxy) this.proxy.onResize();
+        if (this.postfx) {
+            try { this.postfx.resize(W, H); } catch (e) {
+                console.warn('[Renderer3D] PostFX resize error:', e);
+            }
+        }
     }
 
     /**
@@ -127,16 +144,22 @@ export class Renderer3D {
         if (this.proxy) this.proxy.update(dt, this._tElapsed);
         if (this.cameraController) this.cameraController.update(dt);
 
-        this.renderer.render(this.scene, this.camera);
+        if (this.postfx) {
+            this.postfx.render(dt);
+        } else {
+            this.renderer.render(this.scene, this.camera);
+        }
 
         this.stats.frames++;
         this.stats.lastDtMs = dt * 1000;
     }
 
     dispose() {
+        try { if (this.postfx) this.postfx.dispose(); } catch (e) {}
         try { if (this.proxy) this.proxy.dispose(); } catch (e) {}
         try { if (this.background) this.background.dispose(); } catch (e) {}
         try { this.renderer.dispose(); } catch (e) {}
+        this.postfx = null;
         this.proxy = null;
         this.background = null;
         this.cameraController = null;

--- a/src/render3d/RuneMesh.js
+++ b/src/render3d/RuneMesh.js
@@ -1,0 +1,223 @@
+/**
+ * RuneMesh.js - 符文的 3D 六边形几何（M5 配套）
+ *
+ * 与遗物卡片同期上线。每个符文 = 一片薄六边形 + 元素专属 shader。
+ * 不再用 emoji icon。
+ *
+ * 当前支持的元素（与 src/rune_config.js RUNE_DB 对齐）：
+ *   pyro / cryo / lightning / bounce / pierce / scatter / laser / wind / flying_sword
+ */
+
+import * as THREE from 'three';
+
+const ELEMENT_COLORS = {
+    pyro:         { core: 0xef4444, accent: 0xfb7185 },
+    cryo:         { core: 0x60a5fa, accent: 0xa5f3fc },
+    lightning:    { core: 0xfacc15, accent: 0xfde68a },
+    bounce:       { core: 0xa3e635, accent: 0xbef264 },
+    pierce:       { core: 0xf97316, accent: 0xfdba74 },
+    scatter:      { core: 0xc084fc, accent: 0xddd6fe },
+    laser:        { core: 0x34d399, accent: 0x6ee7b7 },
+    wind:         { core: 0x14b8a6, accent: 0x5eead4 },
+    flying_sword: { core: 0xfb923c, accent: 0xfed7aa },
+    default:      { core: 0xa78bfa, accent: 0xc4b5fd },
+};
+
+let _hexGeom = null;
+function getHexGeometry() {
+    if (_hexGeom) return _hexGeom;
+    // 六棱柱，俯视薄片：半径 1，高度 0.18（厚度）
+    _hexGeom = new THREE.CylinderGeometry(1, 1, 0.18, 6, 1);
+    return _hexGeom;
+}
+
+export class RuneMesh {
+    /**
+     * @param {string} element 'pyro' | 'cryo' | ... | 'default'
+     * @param {number} [level=1]  符文等级（1..3）。等级越高边缘光越强
+     */
+    constructor(element, level = 1) {
+        this.element = element;
+        this.level = Math.max(1, Math.min(3, level | 0));
+        const cols = ELEMENT_COLORS[element] || ELEMENT_COLORS.default;
+
+        this.material = new THREE.ShaderMaterial({
+            uniforms: {
+                uTime:   { value: 0 },
+                uCore:   { value: new THREE.Color(cols.core) },
+                uAccent: { value: new THREE.Color(cols.accent) },
+                uLevel:  { value: this.level },
+            },
+            vertexShader: /* glsl */`
+                varying vec3 vNormal;
+                varying vec3 vWorldPos;
+                varying vec3 vViewPos;
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+                    vViewPos = mv.xyz;
+                    vec4 wp = modelMatrix * vec4(position, 1.0);
+                    vWorldPos = wp.xyz;
+                    vNormal = normalize(normalMatrix * normal);
+                    gl_Position = projectionMatrix * mv;
+                }
+            `,
+            fragmentShader: this._buildFragShader(element),
+        });
+
+        this.mesh = new THREE.Mesh(getHexGeometry(), this.material);
+        this.mesh.frustumCulled = false;
+        this.mesh.userData = { runeElement: element, runeLevel: this.level };
+    }
+
+    /**
+     * 每个元素一套独立纹饰（pyro 用噪声扭曲、cryo 用裂纹、雷用闪电分叉…）。
+     * 所有 shader 共享相同的顶点+输入；差异在 fragment 主体的 motif 函数里。
+     */
+    _buildFragShader(element) {
+        // 主体 fragment 模板（公共部分）
+        const HEAD = /* glsl */`
+            precision mediump float;
+            uniform float uTime;
+            uniform vec3  uCore;
+            uniform vec3  uAccent;
+            uniform float uLevel;
+            varying vec3 vNormal;
+            varying vec3 vWorldPos;
+            varying vec3 vViewPos;
+            varying vec2 vUv;
+
+            float hash(vec2 p) {
+                p = fract(p * vec2(123.34, 456.21));
+                p += dot(p, p + 45.32);
+                return fract(p.x * p.y);
+            }
+            float noise2(vec2 p) {
+                vec2 i = floor(p);
+                vec2 f = fract(p);
+                f = f*f*(3.0-2.0*f);
+                float a = hash(i);
+                float b = hash(i + vec2(1.0, 0.0));
+                float c = hash(i + vec2(0.0, 1.0));
+                float d = hash(i + vec2(1.0, 1.0));
+                return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+            }
+        `;
+        const TAIL = /* glsl */`
+            vec3 col = uCore * 0.45 + motif * uAccent * 1.7;
+            // 边缘 Fresnel
+            vec3 V = normalize(-vViewPos);
+            float fres = pow(1.0 - max(0.0, dot(normalize(vNormal), V)), 2.0);
+            col += uAccent * fres * (0.7 + 0.3 * uLevel);
+            gl_FragColor = vec4(col, 1.0);
+        `;
+
+        let motifCode;
+        switch (element) {
+            case 'pyro':
+                motifCode = `
+                    float n = noise2(vUv * 6.0 + vec2(uTime * 1.4, uTime * 0.6));
+                    motif = smoothstep(0.45, 0.85, n);
+                    // 向上流动
+                    float rise = smoothstep(0.0, 1.0, vUv.y - uTime * 0.4);
+                    motif *= 0.6 + rise * 0.6;
+                `;
+                break;
+            case 'cryo':
+                motifCode = `
+                    // 裂纹：abs(2*uv-1) 距离 + 噪声扰动
+                    vec2 c = vUv - 0.5;
+                    float angle = atan(c.y, c.x);
+                    float lines = abs(sin(angle * 4.0 + noise2(vUv*4.0)*2.0));
+                    motif = 1.0 - smoothstep(0.15, 0.35, lines * (0.4 + length(c) * 1.6));
+                    motif += step(0.96, noise2(vUv * 22.0 + uTime * 0.05)) * 0.5;
+                `;
+                break;
+            case 'lightning':
+                motifCode = `
+                    // 之字形闪电：基于 y 的高频锯齿 + 噪声扰动
+                    float zig = abs(fract(vUv.y * 8.0 + noise2(vec2(vUv.y * 10.0, uTime * 1.5)) * 0.5) - 0.5);
+                    motif = 1.0 - smoothstep(0.05, 0.10, zig);
+                    motif *= smoothstep(0.85, 0.5, abs(vUv.x - 0.5) * 2.0);
+                    motif += step(0.97, hash(vec2(floor(uTime * 8.0), 0.0))) * 0.3;
+                `;
+                break;
+            case 'bounce':
+                motifCode = `
+                    // 同心环波（弹性涟漪）
+                    float r = length(vUv - 0.5) * 2.0;
+                    motif = sin(r * 12.0 - uTime * 4.0) * 0.5 + 0.5;
+                    motif = pow(motif, 2.5);
+                `;
+                break;
+            case 'pierce':
+                motifCode = `
+                    // 箭头流线（沿 y 向上 + 中央集中）
+                    float band = abs(fract(vUv.y * 6.0 - uTime * 1.2) - 0.5);
+                    motif = smoothstep(0.4, 0.1, band);
+                    motif *= smoothstep(0.6, 0.0, abs(vUv.x - 0.5));
+                `;
+                break;
+            case 'scatter':
+                motifCode = `
+                    // 三方分裂线
+                    vec2 c = vUv - 0.5;
+                    float ang = atan(c.y, c.x);
+                    float spokes = abs(cos(ang * 1.5));
+                    motif = smoothstep(0.85, 1.0, spokes);
+                    motif *= smoothstep(0.5, 0.0, length(c));
+                `;
+                break;
+            case 'laser':
+                motifCode = `
+                    // 一条强光束
+                    float beam = smoothstep(0.08, 0.0, abs(vUv.x - 0.5));
+                    motif = beam;
+                    motif += step(0.5, fract(vUv.y * 2.0 + uTime * 0.3)) * 0.05;
+                `;
+                break;
+            case 'wind':
+                motifCode = `
+                    // 旋风：螺旋
+                    vec2 c = vUv - 0.5;
+                    float ang = atan(c.y, c.x) + length(c) * 6.0 - uTime * 1.4;
+                    motif = sin(ang * 3.0) * 0.5 + 0.5;
+                    motif = pow(motif, 3.0);
+                    motif *= smoothstep(0.5, 0.0, length(c));
+                `;
+                break;
+            case 'flying_sword':
+                motifCode = `
+                    // 刀光：对角斜线 + 噪声尖锐
+                    float diag = abs(vUv.x - vUv.y - sin(uTime * 0.6) * 0.05);
+                    motif = 1.0 - smoothstep(0.05, 0.12, diag);
+                    motif *= 0.7 + 0.3 * noise2(vUv * 8.0 + uTime);
+                `;
+                break;
+            default:
+                motifCode = `
+                    motif = noise2(vUv * 5.0 + uTime * 0.4);
+                `;
+                break;
+        }
+
+        return HEAD + `
+            void main() {
+                float motif = 0.0;
+                ${motifCode}
+                ${TAIL}
+            }
+        `;
+    }
+
+    /** 每帧 update */
+    update(t) {
+        this.material.uniforms.uTime.value = t;
+    }
+
+    dispose() {
+        this.material.dispose();
+        // 共享 _hexGeom 不在这 dispose
+    }
+}

--- a/src/render3d/SceneProxy.js
+++ b/src/render3d/SceneProxy.js
@@ -1,0 +1,99 @@
+/**
+ * SceneProxy.js - 玩法逻辑 ↔ 3D 渲染层 的桥接（M2 起引入）
+ *
+ * 设计原则：
+ *   - 玩法层（game_phase.js / entities.js）不感知 Three.js；只调 proxy 上的语义方法
+ *   - proxy 内部把这些调用翻译成 InstancedMesh / 粒子池 / shader uniform 更新
+ *   - 单帧调用契约：
+ *       1. 物理 update 完成后
+ *       2. 调用一次 syncPegs / syncWalls / syncBalls / ...
+ *       3. Renderer3D 在 RAF 内 render() 时统一拉数据
+ *
+ * 当前 M2 范围：钉子 + 左右墙。后续 milestone 会扩 syncBalls / syncEnemies / spawn* 等。
+ */
+
+import { PegInstancedMesh } from './PegInstancedMesh.js';
+import { WallMesh } from './WallMesh.js';
+
+export class SceneProxy {
+    /**
+     * @param {THREE.Scene} scene
+     * @param {CoordsMapper} coords
+     */
+    constructor(scene, coords) {
+        this.scene = scene;
+        this.coords = coords;
+
+        this.pegs = new PegInstancedMesh();
+        this.scene.add(this.pegs.mesh);
+
+        this.walls = new WallMesh();
+        this.walls.resize(coords);
+        this.scene.add(this.walls.group);
+        this.walls.setVisible(false); // 默认隐藏：阶段不是 gathering/combat/training 时不显示
+
+        // 当前阶段，决定可见性。null 让首次 setPhase 一定触发刷新（避免初始 'meta' early-out）
+        this._phase = null;
+    }
+
+    /**
+     * 同步整个 pegs 数组到 InstancedMesh。
+     * @param {Array}  pegs2D
+     * @param {number} pegRadiusPx
+     */
+    syncPegs(pegs2D, pegRadiusPx) {
+        if (!pegs2D || pegs2D.length === 0) {
+            this.pegs.clear();
+            return;
+        }
+        this.pegs.sync(pegs2D, this.coords, pegRadiusPx);
+    }
+
+    /**
+     * 触发某个钉子的击中表演。
+     * @param {number} pegIndex
+     * @param {number} [intensity=1.0]
+     */
+    pulsePeg(pegIndex, intensity = 1.0) {
+        this.pegs.pulse(pegIndex, intensity);
+    }
+
+    /**
+     * 通知 proxy 当前阶段，控制墙/钉等的可见性。
+     */
+    setPhase(phase) {
+        if (this._phase === phase) return;
+        this._phase = phase;
+        // 墙：研磨 + 战斗 + 试炼都显示；其他阶段隐藏
+        const wallsOn = phase === 'gathering' || phase === 'combat' || phase === 'training';
+        this.walls.setVisible(wallsOn);
+        // 钉子：仅 gathering / training 显示（combat 内没有钉子，由 syncPegs([]) 自然清空）
+        if (phase !== 'gathering' && phase !== 'training') {
+            this.pegs.clear();
+        }
+    }
+
+    /** Canvas resize 时调用（来自 Renderer3D.resize） */
+    onResize() {
+        this.walls.resize(this.coords);
+    }
+
+    /**
+     * Renderer3D 主循环每帧调用。
+     * @param {number} dt seconds
+     * @param {number} t  seconds elapsed total
+     */
+    update(dt, t) {
+        this.pegs.update(dt, t);
+        this.walls.update(t);
+    }
+
+    dispose() {
+        try { this.pegs.dispose(); } catch (e) {}
+        try { this.walls.dispose(); } catch (e) {}
+        if (this.scene) {
+            this.scene.remove(this.pegs.mesh);
+            this.scene.remove(this.walls.group);
+        }
+    }
+}

--- a/src/render3d/SceneProxy.js
+++ b/src/render3d/SceneProxy.js
@@ -14,6 +14,7 @@
 
 import { PegInstancedMesh } from './PegInstancedMesh.js';
 import { WallMesh } from './WallMesh.js';
+import { EnemyMeshPool } from './EnemyMeshPool.js';
 
 export class SceneProxy {
     /**
@@ -31,6 +32,8 @@ export class SceneProxy {
         this.walls.resize(coords);
         this.scene.add(this.walls.group);
         this.walls.setVisible(false); // 默认隐藏：阶段不是 gathering/combat/training 时不显示
+
+        this.enemies = new EnemyMeshPool(this.scene);
 
         // 当前阶段，决定可见性。null 让首次 setPhase 一定触发刷新（避免初始 'meta' early-out）
         this._phase = null;
@@ -59,6 +62,18 @@ export class SceneProxy {
     }
 
     /**
+     * 同步整个 enemies 数组到 3D 池。
+     * @param {Array} enemies game.enemies
+     */
+    syncEnemies(enemies) {
+        if (!enemies || enemies.length === 0) {
+            this.enemies.clear();
+            return;
+        }
+        this.enemies.sync(enemies, this.coords);
+    }
+
+    /**
      * 通知 proxy 当前阶段，控制墙/钉等的可见性。
      */
     setPhase(phase) {
@@ -70,6 +85,10 @@ export class SceneProxy {
         // 钉子：仅 gathering / training 显示（combat 内没有钉子，由 syncPegs([]) 自然清空）
         if (phase !== 'gathering' && phase !== 'training') {
             this.pegs.clear();
+        }
+        // 敌人：仅 combat / training 显示
+        if (phase !== 'combat' && phase !== 'training') {
+            this.enemies.clear();
         }
     }
 
@@ -86,11 +105,13 @@ export class SceneProxy {
     update(dt, t) {
         this.pegs.update(dt, t);
         this.walls.update(t);
+        this.enemies.update(dt, t);
     }
 
     dispose() {
         try { this.pegs.dispose(); } catch (e) {}
         try { this.walls.dispose(); } catch (e) {}
+        try { this.enemies.dispose(); } catch (e) {}
         if (this.scene) {
             this.scene.remove(this.pegs.mesh);
             this.scene.remove(this.walls.group);

--- a/src/render3d/WallMesh.js
+++ b/src/render3d/WallMesh.js
@@ -57,8 +57,9 @@ export class WallMesh {
 
                 void main() {
                     // 朝玩家方向的面给一个 fresnel 边缘
+                    // [3D-Main M2 fix] 指数 1.8 → 3.5，让发光更紧贴边缘，避免蔓延到画布内部覆盖钉子
                     vec3 viewDir = normalize(cameraPosition - vWorldPos);
-                    float fres = pow(1.0 - max(0.0, dot(vNormal, viewDir)), 1.8);
+                    float fres = pow(1.0 - max(0.0, dot(vNormal, viewDir)), 3.5);
 
                     // 垂直流光（沿 v 轴推动）
                     float scroll = fract(vUv.y * 2.0 - uTime * 0.18);
@@ -70,13 +71,13 @@ export class WallMesh {
                     // 基底色（很暗）
                     vec3 col = uColorBase * 0.4;
                     // 边缘 fresnel
-                    col += uColorGlow * fres * 0.85;
+                    col += uColorGlow * fres * 0.9;
                     // 流光条纹
-                    col += uColorGlow * band * 0.75;
+                    col += uColorGlow * band * 0.8;
 
-                    // 整体 alpha：边缘 + 条纹处更不透明，靠中心透
-                    float alpha = (0.18 + fres * 0.6 + band * 0.55) * edgeY;
-                    gl_FragColor = vec4(col, clamp(alpha, 0.0, 0.95));
+                    // 整体 alpha：边缘 + 条纹处更不透明，中央更透；总体也下调让墙更"克制"
+                    float alpha = (0.12 + fres * 0.65 + band * 0.55) * edgeY;
+                    gl_FragColor = vec4(col, clamp(alpha, 0.0, 0.92));
                 }
             `,
         });
@@ -97,24 +98,26 @@ export class WallMesh {
      * 根据当前 canvas 尺寸 + scale 重新摆放两堵墙。
      * @param {Object} coords  CoordsMapper
      * @param {Object} [opts]
-     * @param {number} [opts.thickness=2]   墙厚（world units）
-     * @param {number} [opts.depth=8]       墙深（往 -z 拉出，制造厚度立体感）
-     * @param {number} [opts.heightRatio=1] 墙高占画布高的比例（1=满高）
+     * @param {number} [opts.thickness=1.5]  墙厚（world units，沿 x 横向）
+     * @param {number} [opts.depth=3]        墙深（沿 z 前后；薄一点避免遮挡 z=0 钉子）
+     * @param {number} [opts.outset=1.0]     墙向画布外侧推出的距离（避免与 z=0 钉子视觉重叠）
+     * @param {number} [opts.heightRatio=1]  墙高占画布高的比例（1=满高）
      */
     resize(coords, opts = {}) {
-        const thickness = opts.thickness ?? 2;
-        const depth     = opts.depth     ?? 8;
+        const thickness   = opts.thickness   ?? 1.5;
+        const depth       = opts.depth       ?? 3;
+        const outset      = opts.outset      ?? 1.0;
         const heightRatio = opts.heightRatio ?? 1.0;
 
         const wWorld = coords.W * coords.scale;
         const hWorld = coords.H * coords.scale * heightRatio;
 
-        // 左墙：x = -W/2 - thickness/2（紧贴画布左缘外侧）
+        // 左墙：x = -W/2 - outset - thickness/2（推到画布外缘外侧 outset 单位）
         this.left.scale.set(thickness, hWorld, depth);
-        this.left.position.set(-wWorld * 0.5 - thickness * 0.5, 0, 0);
+        this.left.position.set(-wWorld * 0.5 - outset - thickness * 0.5, 0, 0);
 
         this.right.scale.set(thickness, hWorld, depth);
-        this.right.position.set(wWorld * 0.5 + thickness * 0.5, 0, 0);
+        this.right.position.set(wWorld * 0.5 + outset + thickness * 0.5, 0, 0);
 
         this._configured = true;
     }

--- a/src/render3d/WallMesh.js
+++ b/src/render3d/WallMesh.js
@@ -1,0 +1,136 @@
+/**
+ * WallMesh.js - 左右外墙的 3D 视觉表达（M2 新增）
+ *
+ * 物理意义：弹珠物理已经在 entities.js DropBall.update 里处理了 x 边界反弹（保留 60% 能量）。
+ *           本类只负责"让玩家能看见墙"——把那两道隐形边界做成发光的能量壁。
+ *
+ * 视觉：两块薄 Box，竖立在画布左右边缘（world-x = ±W/2*scale），高度覆盖玩法区。
+ *       材质用自定义 shader：
+ *         - 垂直流光（从上往下扫的能量条纹）
+ *         - 边缘 Fresnel 提亮
+ *         - 击中时短暂闪烁（M3 接入；当前留 uniform 钩子）
+ */
+
+import * as THREE from 'three';
+
+const WALL_COLOR_BASE  = 0x1e293b;  // 钢灰
+const WALL_COLOR_GLOW  = 0x38bdf8;  // 青蓝能量光
+
+export class WallMesh {
+    constructor() {
+        this.group = new THREE.Group();
+        this.group.name = 'WallMesh';
+
+        const geom = new THREE.BoxGeometry(1, 1, 1);
+        this.geometry = geom;
+
+        // 左右共用同一个材质（uniform 共享；可以拿到 uHitL / uHitR 分别播放反馈）
+        this.material = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.NormalBlending,
+            uniforms: {
+                uTime:      { value: 0 },
+                uColorBase: { value: new THREE.Color(WALL_COLOR_BASE) },
+                uColorGlow: { value: new THREE.Color(WALL_COLOR_GLOW) },
+            },
+            vertexShader: /* glsl */`
+                varying vec3 vWorldPos;
+                varying vec3 vNormal;
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    vec4 wp = modelMatrix * vec4(position, 1.0);
+                    vWorldPos = wp.xyz;
+                    vNormal = normalize(normalMatrix * normal);
+                    gl_Position = projectionMatrix * viewMatrix * wp;
+                }
+            `,
+            fragmentShader: /* glsl */`
+                precision mediump float;
+                uniform float uTime;
+                uniform vec3  uColorBase;
+                uniform vec3  uColorGlow;
+                varying vec3 vNormal;
+                varying vec3 vWorldPos;
+                varying vec2 vUv;
+
+                void main() {
+                    // 朝玩家方向的面给一个 fresnel 边缘
+                    vec3 viewDir = normalize(cameraPosition - vWorldPos);
+                    float fres = pow(1.0 - max(0.0, dot(vNormal, viewDir)), 1.8);
+
+                    // 垂直流光（沿 v 轴推动）
+                    float scroll = fract(vUv.y * 2.0 - uTime * 0.18);
+                    float band   = smoothstep(0.45, 0.50, scroll) - smoothstep(0.52, 0.58, scroll);
+
+                    // 顶部 / 底部柔化（避免硬边缘）
+                    float edgeY = smoothstep(0.0, 0.03, vUv.y) * (1.0 - smoothstep(0.97, 1.0, vUv.y));
+
+                    // 基底色（很暗）
+                    vec3 col = uColorBase * 0.4;
+                    // 边缘 fresnel
+                    col += uColorGlow * fres * 0.85;
+                    // 流光条纹
+                    col += uColorGlow * band * 0.75;
+
+                    // 整体 alpha：边缘 + 条纹处更不透明，靠中心透
+                    float alpha = (0.18 + fres * 0.6 + band * 0.55) * edgeY;
+                    gl_FragColor = vec4(col, clamp(alpha, 0.0, 0.95));
+                }
+            `,
+        });
+
+        // 两面墙先建一个空壳，resize() 时调位置与缩放
+        this.left  = new THREE.Mesh(geom, this.material);
+        this.right = new THREE.Mesh(geom, this.material);
+        this.left.name  = 'WallLeft';
+        this.right.name = 'WallRight';
+        this.left.frustumCulled  = false;
+        this.right.frustumCulled = false;
+        this.group.add(this.left, this.right);
+
+        this._configured = false;
+    }
+
+    /**
+     * 根据当前 canvas 尺寸 + scale 重新摆放两堵墙。
+     * @param {Object} coords  CoordsMapper
+     * @param {Object} [opts]
+     * @param {number} [opts.thickness=2]   墙厚（world units）
+     * @param {number} [opts.depth=8]       墙深（往 -z 拉出，制造厚度立体感）
+     * @param {number} [opts.heightRatio=1] 墙高占画布高的比例（1=满高）
+     */
+    resize(coords, opts = {}) {
+        const thickness = opts.thickness ?? 2;
+        const depth     = opts.depth     ?? 8;
+        const heightRatio = opts.heightRatio ?? 1.0;
+
+        const wWorld = coords.W * coords.scale;
+        const hWorld = coords.H * coords.scale * heightRatio;
+
+        // 左墙：x = -W/2 - thickness/2（紧贴画布左缘外侧）
+        this.left.scale.set(thickness, hWorld, depth);
+        this.left.position.set(-wWorld * 0.5 - thickness * 0.5, 0, 0);
+
+        this.right.scale.set(thickness, hWorld, depth);
+        this.right.position.set(wWorld * 0.5 + thickness * 0.5, 0, 0);
+
+        this._configured = true;
+    }
+
+    /** @param {number} t seconds elapsed */
+    update(t) {
+        this.material.uniforms.uTime.value = t;
+    }
+
+    /** 切到非战斗/研磨阶段时调用 */
+    setVisible(v) {
+        this.group.visible = !!v;
+    }
+
+    dispose() {
+        this.geometry.dispose();
+        this.material.dispose();
+    }
+}

--- a/src/render3d/coords.js
+++ b/src/render3d/coords.js
@@ -1,0 +1,49 @@
+/**
+ * coords.js - 2D Canvas ↔ 3D World 坐标映射
+ *
+ * 2D Canvas (现状): origin=top-left, x→right, y→down, units=px (W × H)
+ * 3D World (新版):  origin=center,   x→right, y→up,   units=world unit (1:1 映射)
+ *
+ * 所有玩法实体（钉子/弹珠/敌人）的坐标仍以 Canvas px 存在；渲染层调用 toWorld()
+ * 转换到 z=0 平面。逆向 toCanvas() 用于将世界坐标投影回 UI 层（HUD 锚定等）。
+ */
+
+export class CoordsMapper {
+    /**
+     * @param {number} canvasWidth  Canvas internal pixel width (CSS-resolved)
+     * @param {number} canvasHeight Canvas internal pixel height
+     */
+    constructor(canvasWidth, canvasHeight) {
+        this.update(canvasWidth, canvasHeight);
+    }
+
+    update(canvasWidth, canvasHeight) {
+        this.W = Math.max(1, canvasWidth | 0);
+        this.H = Math.max(1, canvasHeight | 0);
+        // 1 canvas px = 1 world unit；相机 FOV/距离已按此校准
+        this.scale = 1;
+    }
+
+    /**
+     * Canvas px → world position on z=0 plane.
+     * @returns {{x:number, y:number, z:number}}
+     */
+    toWorld(x, y, z = 0) {
+        return {
+            x: (x - this.W * 0.5) * this.scale,
+            y: -(y - this.H * 0.5) * this.scale,
+            z,
+        };
+    }
+
+    /**
+     * World → canvas px（仅 x/y 维度，z 信息丢失）。
+     * @returns {{x:number, y:number}}
+     */
+    toCanvas(x, y) {
+        return {
+            x: x / this.scale + this.W * 0.5,
+            y: -y / this.scale + this.H * 0.5,
+        };
+    }
+}

--- a/src/render3d/coords.js
+++ b/src/render3d/coords.js
@@ -2,8 +2,9 @@
  * coords.js - 2D Canvas ↔ 3D World 坐标映射
  *
  * 2D Canvas (现状): origin=top-left, x→right, y→down, units=px (W × H)
- * 3D World (新版):  origin=center,   x→right, y→up,   units=world unit (1:1 映射)
+ * 3D World (新版):  origin=center,   x→right, y→up,   units=world unit
  *
+ * scale 由 Renderer3D 基于相机 FOV/距离计算并注入，让画布高度自动占满相机视域。
  * 所有玩法实体（钉子/弹珠/敌人）的坐标仍以 Canvas px 存在；渲染层调用 toWorld()
  * 转换到 z=0 平面。逆向 toCanvas() 用于将世界坐标投影回 UI 层（HUD 锚定等）。
  */
@@ -12,16 +13,34 @@ export class CoordsMapper {
     /**
      * @param {number} canvasWidth  Canvas internal pixel width (CSS-resolved)
      * @param {number} canvasHeight Canvas internal pixel height
+     * @param {number} [scale=1]    World units per canvas px
      */
-    constructor(canvasWidth, canvasHeight) {
-        this.update(canvasWidth, canvasHeight);
+    constructor(canvasWidth, canvasHeight, scale = 1) {
+        this.update(canvasWidth, canvasHeight, scale);
     }
 
-    update(canvasWidth, canvasHeight) {
+    /**
+     * @param {number} canvasWidth
+     * @param {number} canvasHeight
+     * @param {number} [scale] if undefined, keeps previous scale
+     */
+    update(canvasWidth, canvasHeight, scale) {
         this.W = Math.max(1, canvasWidth | 0);
         this.H = Math.max(1, canvasHeight | 0);
-        // 1 canvas px = 1 world unit；相机 FOV/距离已按此校准
-        this.scale = 1;
+        if (scale !== undefined && scale > 0) this.scale = scale;
+        else if (this.scale === undefined) this.scale = 1;
+    }
+
+    /**
+     * 给定相机 FOV（度）和距离，自动计算让画布完全填充视域的 scale。
+     * @param {number} fovDeg vertical FOV in degrees
+     * @param {number} cameraDist distance from camera to z=0 plane
+     * @param {number} [fillRatio=0.94] 画布在视域内的占比（< 1 留一点边）
+     */
+    static autoScaleFromFov(fovDeg, cameraDist, H, fillRatio = 0.94) {
+        const halfFov = fovDeg * 0.5 * Math.PI / 180;
+        const visibleH = 2 * cameraDist * Math.tan(halfFov);
+        return (visibleH * fillRatio) / Math.max(1, H);
     }
 
     /**

--- a/src/styles/glass_ui.css
+++ b/src/styles/glass_ui.css
@@ -1,0 +1,171 @@
+/* ============================================================
+ * glass_ui.css - 全息玻璃风格 HUD 覆盖层（M5）
+ *
+ * 启用方式：body 添加 class `.glass-ui-enabled`，比如：
+ *     document.body.classList.add('glass-ui-enabled');
+ *
+ * 默认关闭，零影响现有 bitmap_ui.css。启用后会用 backdrop-filter
+ * + 渐变边框替换 9-slice 位图边框，把整个 HUD 升级到"全息玻璃"。
+ * ============================================================ */
+
+body.glass-ui-enabled {
+    /* 公共变量：稀有度色 */
+    --glass-common:    rgba(226, 232, 240, 0.6);
+    --glass-rare:      rgba(129, 140, 248, 0.7);
+    --glass-epic:      rgba(217, 70, 239, 0.7);
+    --glass-legendary: rgba(245, 158, 11, 0.8);
+    --glass-cursed:    rgba(159, 18, 57, 0.7);
+    --glass-cyan:      rgba(56, 189, 248, 0.6);
+
+    --glass-bg-dark:   rgba(15, 23, 42, 0.55);
+    --glass-bg-deep:   rgba(2, 6, 23, 0.7);
+}
+
+/* ===== 顶部信息栏 ===== */
+body.glass-ui-enabled #unified-top-bar {
+    background: linear-gradient(180deg, var(--glass-bg-deep) 0%, var(--glass-bg-dark) 100%);
+    backdrop-filter: blur(14px) saturate(1.4);
+    -webkit-backdrop-filter: blur(14px) saturate(1.4);
+    border-bottom: 1px solid var(--glass-cyan);
+    box-shadow:
+        0 0 24px rgba(56, 189, 248, 0.25),
+        inset 0 -1px 0 rgba(56, 189, 248, 0.2);
+}
+
+/* ===== 通用 .ui-overlay 面板（命运抉择/商店等弹层） ===== */
+body.glass-ui-enabled .ui-overlay {
+    background: radial-gradient(ellipse at center top, var(--glass-bg-dark) 0%, var(--glass-bg-deep) 80%);
+    backdrop-filter: blur(18px) saturate(1.4);
+    -webkit-backdrop-filter: blur(18px) saturate(1.4);
+}
+
+/* ===== 卡片：移除 9-slice 边框，用渐变 outline 替代 ===== */
+body.glass-ui-enabled .card,
+body.glass-ui-enabled .relic-card,
+body.glass-ui-enabled .runeword-card,
+body.glass-ui-enabled .skill-card {
+    background:
+        linear-gradient(180deg, rgba(30, 41, 59, 0.85) 0%, rgba(15, 23, 42, 0.92) 100%);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-image: none;       /* 干掉 bitmap_ui.css 的 border-image */
+    box-shadow:
+        0 0 32px rgba(15, 23, 42, 0.6),
+        inset 0 0 24px rgba(148, 163, 184, 0.05);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+body.glass-ui-enabled .card[data-rarity="common"],
+body.glass-ui-enabled .relic-card[data-rarity="common"] {
+    border-color: var(--glass-common);
+    box-shadow:
+        0 0 24px rgba(226, 232, 240, 0.20),
+        inset 0 0 18px rgba(226, 232, 240, 0.05);
+}
+body.glass-ui-enabled .card[data-rarity="rare"],
+body.glass-ui-enabled .relic-card[data-rarity="rare"] {
+    border-color: var(--glass-rare);
+    box-shadow:
+        0 0 28px rgba(129, 140, 248, 0.30),
+        inset 0 0 18px rgba(129, 140, 248, 0.08);
+}
+body.glass-ui-enabled .card[data-rarity="epic"],
+body.glass-ui-enabled .relic-card[data-rarity="epic"] {
+    border-color: var(--glass-epic);
+    box-shadow:
+        0 0 36px rgba(217, 70, 239, 0.40),
+        inset 0 0 22px rgba(217, 70, 239, 0.10);
+}
+body.glass-ui-enabled .card[data-rarity="legendary"],
+body.glass-ui-enabled .relic-card[data-rarity="legendary"] {
+    border-color: var(--glass-legendary);
+    box-shadow:
+        0 0 42px rgba(245, 158, 11, 0.50),
+        inset 0 0 28px rgba(245, 158, 11, 0.12);
+}
+body.glass-ui-enabled .card[data-rarity="cursed"],
+body.glass-ui-enabled .relic-card[data-rarity="cursed"] {
+    border-color: var(--glass-cursed);
+    box-shadow:
+        0 0 28px rgba(159, 18, 57, 0.35),
+        inset 0 0 18px rgba(159, 18, 57, 0.10);
+}
+
+body.glass-ui-enabled .card:hover,
+body.glass-ui-enabled .relic-card:hover {
+    transform: translateY(-2px);
+    border-color: rgba(56, 189, 248, 0.8);
+    box-shadow:
+        0 0 36px rgba(56, 189, 248, 0.45),
+        inset 0 0 24px rgba(56, 189, 248, 0.10);
+}
+
+/* ===== 按钮：玻璃 + 渐变 hover ===== */
+body.glass-ui-enabled button,
+body.glass-ui-enabled .btn {
+    background: linear-gradient(180deg, rgba(30, 41, 59, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-image: none;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    box-shadow:
+        0 0 12px rgba(148, 163, 184, 0.2),
+        inset 0 0 12px rgba(148, 163, 184, 0.04);
+    color: #e2e8f0;
+    text-shadow: 0 0 8px rgba(148, 163, 184, 0.6);
+    transition: all 0.15s ease;
+}
+
+body.glass-ui-enabled button:hover,
+body.glass-ui-enabled .btn:hover {
+    border-color: rgba(56, 189, 248, 0.7);
+    box-shadow:
+        0 0 18px rgba(56, 189, 248, 0.4),
+        inset 0 0 18px rgba(56, 189, 248, 0.10);
+    color: #f1f5f9;
+    text-shadow: 0 0 10px rgba(56, 189, 248, 0.8);
+}
+
+/* ===== PC 三栏边栏背景 ===== */
+body.glass-ui-enabled #pc-left-sidebar,
+body.glass-ui-enabled #pc-right-sidebar {
+    background: linear-gradient(180deg, var(--glass-bg-deep) 0%, var(--glass-bg-dark) 100%);
+    backdrop-filter: blur(20px) saturate(1.5);
+    -webkit-backdrop-filter: blur(20px) saturate(1.5);
+    border-color: rgba(56, 189, 248, 0.25);
+    box-shadow: inset 0 0 60px rgba(56, 189, 248, 0.04);
+}
+
+/* ===== 移动端底部抽屉 ===== */
+body.glass-ui-enabled .bottom-panel {
+    background: linear-gradient(0deg, var(--glass-bg-deep) 0%, var(--glass-bg-dark) 100%);
+    backdrop-filter: blur(16px) saturate(1.4);
+    -webkit-backdrop-filter: blur(16px) saturate(1.4);
+    border-top: 1px solid rgba(56, 189, 248, 0.3);
+}
+
+/* ===== Tooltip / popover ===== */
+body.glass-ui-enabled .tooltip,
+body.glass-ui-enabled .popover {
+    background: rgba(2, 6, 23, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(56, 189, 248, 0.4);
+    box-shadow: 0 0 20px rgba(56, 189, 248, 0.3);
+}
+
+/* ===== 标题文字玻璃风 ===== */
+body.glass-ui-enabled #phase-title,
+body.glass-ui-enabled .phase-text {
+    text-shadow:
+        0 0 14px rgba(56, 189, 248, 0.6),
+        0 0 28px rgba(56, 189, 248, 0.3);
+    color: #f1f5f9;
+}
+
+/* ===== 数字滚动器（金币 / 符文碎片等） ===== */
+body.glass-ui-enabled .number-display,
+body.glass-ui-enabled .currency-amount {
+    text-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
+}


### PR DESCRIPTION
## Summary

3D 视觉重构里程碑 M5：**遗物 3D 卡片 + 符文几何 + HUD 玻璃化**——全部程序化，零 sprite。

> 此 PR 当前包含 M1–M4.5 的 commit；待前序 PR 合入 3D-Main 后 diff 自动收窄到 ~850 行。

## 1. 遗物 3D 卡片 (`RelicCard.js`)

每张卡片 = 一个 `THREE.Group`，包含 4 个 mesh，**零图片资源**：

| Mesh | 角色 |
| :--- | :--- |
| `cardMesh` | ExtrudeGeometry 圆角板（共享几何）。Shader：暗色基底 + 稀有度边缘染色 + fresnel 边光 |
| `textMesh` | 2D Canvas 绘制标题/描述/tags → CanvasTexture。位置 z=+0.29 避开 bevel |
| `sigilMesh` | 程序化"星形徽记"。`hash(relic.id)` → 种子 → 花瓣数(3–8) + 内圈频率 + 相位 |
| `glowMesh` | 卡背薄圆盘，additive 稀有度光环（喂给 bloom） |

文本 Canvas 渲染：
- 顶部稀有度色带（线性渐变）+ 标题（Noto Serif TC, 48px, glow shadow）
- 中央徽记预留圈（外圈装饰纹）
- 描述自动换行（按字符）
- 底部 RARE / EPIC / LEGENDARY 大写标签 + tags + maxStacks

稀有度色板：common slate / rare indigo / epic magenta / legendary amber / cursed crimson

## 2. 符文 3D 六边形 (`RuneMesh.js`)

每个符文 = 共享的 6 棱柱薄片 + 元素专属 fragment shader：

```
pyro         → 噪声 + 向上流动
cryo         → 角向裂纹 + 闪烁星点
lightning    → 垂直锯齿带 + 闪烁
bounce       → 同心涟漪
pierce       → 中心向上箭流
scatter      → 三角辐射线
laser        → 单道竖光束
wind         → 螺旋噪声
flying_sword → 对角斜线 + 噪声
```

材质参数：`uTime + uCore + uAccent + uLevel`（等级越高边缘越亮）

## 3. HUD 玻璃化 (`glass_ui.css`)

**opt-in**：`document.body.classList.add('glass-ui-enabled')` 启用。  
默认关闭 → 零影响现有视觉。

启用后用 `backdrop-filter: blur+saturate` + 稀有度渐变边框替换 9-slice 位图。覆盖：

- `#unified-top-bar`
- `.ui-overlay` 弹层
- `.card / .relic-card / .runeword-card / .skill-card`（按 data-rarity 上色）
- 按钮 / 边栏 / 移动底部抽屉 / tooltip
- phase title 文字阴影 / 货币数字阴影

## 设计原则贯彻

✅ **零 sprite**：删除遗物图标的前置工作就绪。M6 可彻底删 `assets/icons/relic/`  
✅ **程序化 sigil**：每个遗物有"独一份"的视觉标识（hash → identicon 思路）  
✅ **玩法清晰优先**：HUD 玻璃化只是 CSS 优化，不动 DOM 结构

## Test plan

- [ ] DevTools `document.body.classList.add('glass-ui-enabled')` → 顶部栏背景变玻璃模糊
- [ ] 关闭 glass class → 立刻回到 bitmap UI（无残留）
- [ ] 渲染遗物（暂未接入实际选择 UI）—— 准备好供 M6 / 后续 UI 重做调用
- [ ] 渲染符文 —— 各元素 shader 纹饰明显不同
- [ ] 卡牌稀有度光环颜色对应正确（rare 蓝紫、legendary 金、cursed 红）

## 下一里程碑

**M6**：粒子 GPU 化 + sprite 资产目录清理 + 移动端调优  
其中 sprite 清理可以减包 ~280MB（assets/sprites/ / assets/icons/relic / assets/ui/sprites 等），  
M5 的 RelicCard 已经准备好接管所有遗物表现。

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_