### PR TITLE
fix(3d): silence 404s from deleted sprite/relic assets

### DIFF
--- a/src/bitmap_icons.js
+++ b/src/bitmap_icons.js
@@ -63,54 +63,14 @@ export const RUNE_ICON_MAP = {
 // ============================================================
 // Task 5.A7 — 遗物图标映射（53 种遗物 64×64）
 // key 对应 RELIC_DB 中的 id 字段
+//
+// [3D-Main 清理] 遗物 PNG 已在 M6 删除（M5 RelicCard 3D 卡片接管），
+// 此处保留导出形状但清空内容。所有 getRelicIconSrc 返回 null，
+// FieldLootItem.draw 走 emoji fallback（已实现），无 404 噪音。
+// 若后续 FieldLootItem 也接入 3D 渲染（小型 RelicCard / 程序化徽记），
+// 这个 export 可以彻底移除。
 // ============================================================
-export const RELIC_ICON_MAP = {
-    gigantism_relic:           'assets/icons/relic/gigantism_relic.png',
-    chaos_essence:             'assets/icons/relic/chaos_essence.png',
-    pure_essence:              'assets/icons/relic/pure_essence.png',
-    dimension_shard:           'assets/icons/relic/dimension_shard.png',
-    dimension_crystal:         'assets/icons/relic/dimension_crystal.png',
-    stars_shines:              'assets/icons/relic/stars_shines.png',
-    optical_lens:              'assets/icons/relic/optical_lens.png',
-    pink_slime:                'assets/icons/relic/pink_slime.png',
-    energy_shield:             'assets/icons/relic/energy_shield.png',
-    unlock_recall:             'assets/icons/relic/unlock_recall.png',
-    unlock_multicast:          'assets/icons/relic/unlock_multicast.png',
-    unlock_split:              'assets/icons/relic/unlock_split.png',
-    slot_expander:             'assets/icons/relic/slot_expander.png',
-    cryo_stone:                'assets/icons/relic/cryo_stone.png',
-    pyro_stone:                'assets/icons/relic/pyro_stone.png',
-    // lightning_stone 暂未生成位图：移除指向 cryo_stone 的错误 fallback，让 UI 走 emoji
-    tactical_kit_pierce:       'assets/icons/relic/tactical_kit_pierce.png',
-    tactical_kit_scatter:      'assets/icons/relic/tactical_kit_scatter.png',
-    tactical_kit_damage:       'assets/icons/relic/tactical_kit_damage.png',
-    explosive_ammo:            'assets/icons/relic/explosive_ammo.png',
-    prism_shard:               'assets/icons/relic/prism_shard.png',
-    russian_doll:              'assets/icons/relic/russian_doll.png',
-    triangle_formation:        'assets/icons/relic/triangle_formation.png',
-    diamond_formation:         'assets/icons/relic/diamond_formation.png',
-    sparse_interval:           'assets/icons/relic/sparse_interval.png',
-    mirror_sync:               'assets/icons/relic/mirror_sync.png',
-    wide_narrow:               'assets/icons/relic/wide_narrow.png',
-    surge_bounce:              'assets/icons/relic/surge_bounce.png',
-    surge_pierce:              'assets/icons/relic/surge_pierce.png',
-    surge_scatter:             'assets/icons/relic/surge_scatter.png',
-    surge_damage:              'assets/icons/relic/surge_damage.png',
-    surge_cryo:                'assets/icons/relic/surge_cryo.png',
-    surge_pyro:                'assets/icons/relic/surge_pyro.png',
-    alchemist_powder_tube:     'assets/icons/relic/alchemist_powder_tube.png',
-    smuggler_pouch_common:     'assets/icons/relic/smuggler_pouch_common.png',
-    smuggler_chest_rare:       'assets/icons/relic/smuggler_chest_rare.png',
-    smuggler_vault_epic:       'assets/icons/relic/smuggler_vault_epic.png',
-    smuggler_sanctum_legendary:'assets/icons/relic/smuggler_sanctum_legendary.png',
-    desperation_blade:         'assets/icons/relic/desperation_blade.png',
-    skill_frost_prison:        'assets/icons/relic/skill_frost_prison.png',
-    skill_thunder_call:        'assets/icons/relic/skill_thunder_call.png',
-    skill_kinetic_burst:       'assets/icons/relic/skill_kinetic_burst.png',
-    skill_meltdown_nova:       'assets/icons/relic/skill_meltdown_nova.png',
-    skill_blade_rain:          'assets/icons/relic/skill_blade_rain.png',
-    skill_prismatic_shot:      'assets/icons/relic/skill_prismatic_shot.png',
-};
+export const RELIC_ICON_MAP = {};
 
 // ============================================================
 // 敵人視覺 V2 — 基底圖標映射（圖鑒 / 試煉場 / 結算頁引用）

--- a/src/data/enemy_visual_assets.js
+++ b/src/data/enemy_visual_assets.js
@@ -103,21 +103,11 @@ export function loadEnemyVisualAssetManifest() {
     if (_manifest) return Promise.resolve(_manifest);
     if (_manifestPromise) return _manifestPromise;
 
-    if (typeof fetch !== 'function') {
-        // Node / 测试环境：直接给出内嵌兜底，避免阻塞调用
-        _manifest = _buildDefaultManifest();
-        return Promise.resolve(_manifest);
-    }
-
-    _manifestPromise = fetch(MANIFEST_PATH)
-        .then(r => r.ok ? r.json() : Promise.reject(new Error('manifest http ' + r.status)))
-        .then(json => { _manifest = json; return _manifest; })
-        .catch(err => {
-            console.warn('[enemy_visual_assets] manifest 加载失败，使用内嵌默认值:', err.message);
-            _manifest = _buildDefaultManifest();
-            return _manifest;
-        });
-    return _manifestPromise;
+    // [3D-Main 清理] assets/sprites/enemies/ 整个目录已在 M6 删除（M3 EnemyMeshPool 程序化几何接管），
+    // 跳过注定 404 的 fetch，直接用内嵌默认 manifest。manifest 仍提供 archetype/footprint 元数据，
+    // 但其中的 spritePath 已无意义——createSpriteRenderer 总返回 null。
+    _manifest = _buildDefaultManifest();
+    return Promise.resolve(_manifest);
 }
 
 function _buildDefaultManifest() {

--- a/src/render/sprite_renderer.js
+++ b/src/render/sprite_renderer.js
@@ -237,37 +237,24 @@ export class SpriteRenderer {
 import { ENEMY_V2_METADATA, ENEMY_V2_BY_ARCHETYPE } from '../data/enemy_v2_metadata.js';
 import { resolveEnemyVisualAsset, loadEnemyVisualAssetManifest } from '../data/enemy_visual_assets.js';
 
-const SPRITE_REGISTRY = {
-    'golem_normal': 'assets/sprites/enemies/golem_normal.png',
-    'golem_elite':  'assets/sprites/enemies/golem_elite.png',
-    // V2 基底敵人 Sprite（占位资源，命名/manifest 与正式资源一致）
-    ...ENEMY_V2_METADATA.reduce((acc, m) => {
-        acc[m.resourceId] = m.spritePath;
-        return acc;
-    }, {}),
-    // Boss Sprite（Phase C 完成后逐步填充）
-    'boss_ignis':     'assets/sprites/bosses/boss_ignis.png',
-    'boss_glacies':   'assets/sprites/bosses/boss_glacies.png',
-    'boss_mikro':     'assets/sprites/bosses/boss_mikro.png',
-    'boss_devourer':  'assets/sprites/bosses/boss_devourer.png',
-    'boss_viridis':   'assets/sprites/bosses/boss_viridis.png',
-    'boss_tesla':     'assets/sprites/bosses/boss_tesla.png',
-    'boss_chimera':   'assets/sprites/bosses/boss_chimera.png',
-    'boss_ouroboros': 'assets/sprites/bosses/boss_ouroboros.png',
-};
+// [3D-Main 清理] 敌人/Boss 的 PNG sprite 全部已在 M6 删除（M3 EnemyMeshPool 程序化几何接管）。
+// 注册表清空 → preloadAllSprites 不再触发加载 → 无 console 404。
+// SpriteRenderer 内部 fail 路径不变；createSpriteRenderer 直接返回 null，让所有调用方
+// 通过现有 fallback 路径走矢量绘制（2D 路径仍在跑作为安全网）。
+const SPRITE_REGISTRY = {};
 
-/** 预加载的 SpriteRenderer 实例池 */
+/** 预加载的 SpriteRenderer 实例池（保留导出形状，但永远为空） */
 const _spritePool = new Map();
 
 /**
  * 预加载所有已注册的 Sprite Sheet
- * 在游戏初始化时调用一次
+ * 在游戏初始化时调用一次（M6 后空注册表 → no-op）
  */
 export function preloadAllSprites() {
+    // 注册表已空，循环无副作用；保留方法签名向后兼容现有调用方
     for (const [key, path] of Object.entries(SPRITE_REGISTRY)) {
-        _spritePool.set(key, SpriteRenderer.preload(path));
+        if (path) _spritePool.set(key, SpriteRenderer.preload(path));
     }
-    console.log(`[SpriteRenderer] 预加载 ${_spritePool.size} 个 Sprite Sheet`);
 }
 
 /**
@@ -289,68 +276,10 @@ export function preloadAllSprites() {
  * @returns {SpriteRenderer|null}
  */
 export function createSpriteRenderer(enemyTypeOrEnemy, bossType, baseArchetype) {
-    // 归一化参数
-    let enemyInfo;
-    if (enemyTypeOrEnemy && typeof enemyTypeOrEnemy === 'object') {
-        enemyInfo = {
-            type: enemyTypeOrEnemy.type,
-            bossType: enemyTypeOrEnemy.bossType,
-            baseArchetype: enemyTypeOrEnemy.baseArchetype,
-            gridCols: enemyTypeOrEnemy.gridCols,
-            gridRows: enemyTypeOrEnemy.gridRows,
-            affixes: enemyTypeOrEnemy.affixes,
-        };
-    } else {
-        enemyInfo = {
-            type: enemyTypeOrEnemy,
-            bossType,
-            baseArchetype,
-            gridCols: 1,
-            gridRows: 1,
-            affixes: [],
-        };
-    }
-
-    // 0) 资源协议解析（baseArchetype + footprint + affixSet → composite 资源）
-    // 对所有非 Boss 敌人（含 1×1 residue）都走 manifest 解析，命中再使用，
-    // 未命中再回到下面的 V2 metadata / golem 兜底。
-    if (enemyInfo.type !== 'boss') {
-        const resolved = resolveEnemyVisualAsset(enemyInfo);
-        if (resolved && resolved.spritePath && (resolved.fallbackLevel === 'composite' || resolved.fallbackLevel === 'archetype')) {
-            return new SpriteRenderer(resolved.spritePath, resolved.manifestPath || undefined);
-        }
-    }
-
-    let key = null;
-
-    // 1) V2 基底优先（普通/精英共用同一组资源）
-    if (enemyInfo.baseArchetype && ENEMY_V2_BY_ARCHETYPE[enemyInfo.baseArchetype]) {
-        key = ENEMY_V2_BY_ARCHETYPE[enemyInfo.baseArchetype].resourceId;
-    } else if (enemyInfo.type === 'boss' && enemyInfo.bossType) {
-        key = `boss_${enemyInfo.bossType}`;
-    } else if (enemyInfo.type === 'elite') {
-        key = 'golem_elite';
-    } else if (enemyInfo.type === 'normal') {
-        key = 'golem_normal';
-    }
-
-    if (!key) return null;
-
-    const path = SPRITE_REGISTRY[key];
-    if (!path) {
-        // V2 基底配置但资源缺失 → 安全回退到 golem_elite，保证敌人可见
-        if (enemyInfo.type === 'elite' || enemyInfo.baseArchetype) {
-            return new SpriteRenderer(SPRITE_REGISTRY['golem_elite']);
-        }
-        return new SpriteRenderer(SPRITE_REGISTRY['golem_normal']);
-    }
-
-    // 如果预加载池中已有，返回共享实例的克隆（每个实体需要独立的动画状态）
-    const pooled = _spritePool.get(key);
-    if (pooled && pooled.ready) {
-        return new SpriteRenderer(path);
-    }
-    return new SpriteRenderer(path);
+    // [3D-Main 清理] 敌人 sprite 已废弃（M3 EnemyMeshPool 接管）。
+    // 直接返回 null → 调用方（entities/enemy.js）通过 _spriteRenderer.ready 检查
+    // 走矢量 fallback。零 console 404。
+    return null;
 }
 
 // manifest 启动时尝试预加载（异步、不阻塞）


### PR DESCRIPTION
## Summary

清理 M6 删除资产后的 console 404 噪音。三个 loader 仍在尝试 fetch 已删除的文件——所有 fallback 路径都对，只是 console 太脏。

## 问题

启动游戏时会有：
- `preloadAllSprites()` 触发 **26 个 PNG 404** + 26 条 warning
- `loadEnemyVisualAssetManifest()` 触发 **1 个 JSON 404** + 1 条 warning
- `FieldLootItem.draw()` 命中遗物时触发 **最多 44 个 PNG 404**（按出现的遗物种类）

加起来一局游戏 60+ 条 404，影响调试 + 真实用户体验。

## 修复

| 文件 | 改动 |
| :--- | :--- |
| `src/bitmap_icons.js` | `RELIC_ICON_MAP` 44 条 → `{}`；`getRelicIconSrc` 返回 null，FieldLootItem 走 emoji fallback |
| `src/render/sprite_renderer.js` | `SPRITE_REGISTRY` 26 条 → `{}`；`createSpriteRenderer` 始终返回 null（M3 EnemyMeshPool 已接管） |
| `src/data/enemy_visual_assets.js` | `loadEnemyVisualAssetManifest` 跳过注定 404 的 fetch，直接用内嵌默认 manifest |

总计删除 ~150 行死代码，**净 -121 行**。

## 不动什么

- `enemy_v2_metadata.js` 里的 `spritePath` 字段保留（dormant，无人 fetch）
- `sprite_renderer.js` 类本身保留（4 个文件还有 import；M3 之后实际不工作但 API 形状保留以避免破坏依赖）
- `assets/icons/ammo/` / `assets/icons/rune/` / `assets/ui/` 保留（这些 PNG 还存在，HUD 还在用）

## 验证

- ✅ 三文件通过 `node --check`
- ✅ 所有 fallback 路径不变：emoji icon / 矢量敌人
- ✅ 3D 渲染层（M3 EnemyMeshPool + M5 RelicCard）正常工作（本 PR 不动 render3d/）

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_