### PR TITLE
feat(3d): add user-facing 3D toggle in settings panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,9 +174,6 @@
             opacity: 0.30;
             transition: opacity 0.2s ease;
         }
-        body.render3d-debug #gl-canvas {
-            outline: 1px solid rgba(56, 189, 248, 0.4);
-        }
 
         @keyframes shake-hard {
             0% { transform: translate(0, 0); }
@@ -2896,6 +2893,12 @@
                         <span class="s-label">CRT 特效</span>
                         <span class="s-badge" id="crt-badge">关闭</span>
                     </div>
+                    <!-- [3D-Main] 3D 视觉模式开关：默认关闭（2D 不透明覆盖），开启后 2D 降到 30% 透明，下层 3D 全息场景透出 -->
+                    <div class="settings-item" id="render3d-item" onclick="window.toggleRender3dMode && window.toggleRender3dMode()">
+                        <span class="s-icon">🌐</span>
+                        <span class="s-label">3D 视觉</span>
+                        <span class="s-badge" id="render3d-badge">关闭</span>
+                    </div>
 
                 </div>
             </div>
@@ -3539,6 +3542,12 @@
                         <span class="ps-label">CRT 特效</span>
                         <span class="ps-badge" id="pause-crt-badge">关闭</span>
                     </div>
+                    <!-- [3D-Main] 3D 视觉模式开关（暂停设置面板版） -->
+                    <div class="pause-setting-row" id="pause-render3d-row" onclick="window.toggleRender3dMode && window.toggleRender3dMode(); game.ui_syncPauseSettings && game.ui_syncPauseSettings();">
+                        <span class="ps-icon">🌐</span>
+                        <span class="ps-label">3D 视觉</span>
+                        <span class="ps-badge" id="pause-render3d-badge">关闭</span>
+                    </div>
 
                     <div class="pause-perf-row">
                         <span class="ps-icon">⚡</span>
@@ -3630,6 +3639,43 @@ game.sys_toggleCrt = () => {
     isCrtOn = !isCrtOn;
     localStorage.setItem('ea_crt_enabled', isCrtOn);
     updateCrtVisuals();
+};
+
+// --- [3D-Main] 3D 视觉模式 ---
+// 通过给 body 加 .render3d-debug 类（M1 已定义：把 2D #gameCanvas 透到 30%，
+// 让下层 WebGL 全息场景透出）。默认关闭——玩家看到的还是熟悉的 2D 表现。
+let is3DOn = localStorage.getItem('ea_render3d_enabled') === 'true';
+function updateRender3dVisuals() {
+    const badges = [
+        document.getElementById('render3d-badge'),
+        document.getElementById('pause-render3d-badge'),
+    ];
+    const items = [
+        document.getElementById('render3d-item'),
+        document.getElementById('pause-render3d-row'),
+    ];
+    if (is3DOn) {
+        document.body.classList.add('render3d-debug');
+    } else {
+        document.body.classList.remove('render3d-debug');
+    }
+    for (const badge of badges) {
+        if (!badge) continue;
+        badge.textContent = is3DOn ? '开启' : '关闭';
+        if (is3DOn) badge.classList.add('active');
+        else        badge.classList.remove('active');
+    }
+    for (const item of items) {
+        if (!item) continue;
+        if (is3DOn) item.classList.add('active');
+        else        item.classList.remove('active');
+    }
+}
+updateRender3dVisuals();
+window.toggleRender3dMode = () => {
+    is3DOn = !is3DOn;
+    localStorage.setItem('ea_render3d_enabled', is3DOn);
+    updateRender3dVisuals();
 };
 
 // --- 静音切换 ---


### PR DESCRIPTION
## Summary

给整个 M1–M6.5 的 3D 视觉工作加一个**用户可见的开关**——之前所有 3D 都隐藏在不透明的 2D 画布之下，玩家从未看到。这个 PR 让他们能在设置里打开。

## 设置项

| 位置 | 内容 |
| :--- | :--- |
| 顶部齿轮 → 设置面板 | 新增 🌐 "3D 视觉" 一项（在 CRT 特效旁） |
| 暂停菜单 → 设置 | 同款"3D 视觉"开关 |

## 行为

- **关闭（默认）**：2D 不透明，玩家看到的视觉与现状完全一致
- **开启**：body 加上 `render3d-debug` class（M1 已定义的 CSS），`#gameCanvas` 透到 30%，下层 WebGL 全息场景全部透出来——背景星云 + 钉板 + 敌人 + 墙 + 后处理 bloom/畸变/色散
- 状态持久化到 `localStorage.ea_render3d_enabled`，跨会话保留

## 实现

- `index.html` 设置面板 / 暂停菜单各加一行
- `window.toggleRender3dMode()` 同步两个 panel 的 badge + 高亮态
- 移除 M1 加的 debug-only 蓝色 outline（之前是 console-only 时辅助判别用，现在是用户级开关，去掉减少分心）

## 风险

零风险——默认关闭。不动现有 2D 渲染管线、不动玩法逻辑、不动 3D 模块本身。仅 1 个文件改动 +49 行。

## Test plan

- [ ] 启动游戏 → 默认与现状一致
- [ ] 点齿轮 → 设置 → 点 "3D 视觉" 一栏 → badge 变 "开启" → 立即看到 3D 背景透出
- [ ] 再点一次 → 关闭，画面立即恢复
- [ ] 刷新页面 → 状态保留
- [ ] 暂停菜单切换效果一致
- [ ] 切到关闭状态 → 没有 3D 渲染开销影响低端设备（PostFX 仍跑，但 2D 完全盖住，玩家不感知）

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_