### PR TITLE
fix(3d): declare instanceColor in peg shader (real-game test caught this)

### DIFF
--- a/src/render3d/PegInstancedMesh.js
+++ b/src/render3d/PegInstancedMesh.js
@@ -67,6 +67,9 @@ export class PegInstancedMesh {
             },
             vertexShader: /* glsl */`
                 // ShaderMaterial 不会自动 inject 实例属性；手动声明。
+                // 注意：instanceMatrix 由 Three.js 在 USE_INSTANCING 路径自动注入，
+                // 但 instanceColor (来自 setColorAt) 必须手动声明。
+                attribute vec3 instanceColor;
                 attribute float instancePhase;
                 attribute float instanceHit;
 


### PR DESCRIPTION
## Summary

真实游戏集成测试找出的关键 shader bug：`PegInstancedMesh` 的 vertex shader 用了 `instanceColor` 但没声明，导致 program 编译失败 + 每帧 spam `INVALID_OPERATION: useProgram: program not valid`。

## 症状（修复前）

把游戏跑在 headless Chrome 里（routing CDN 到本地 vendor 的 three.js）：

```
[error] THREE.WebGLProgram: Shader Error 0 - VALIDATE_STATUS false
ERROR: 0:90: 'instanceColor' : undeclared identifier
[warning] WebGL: INVALID_OPERATION: useProgram x 200+ 每秒
```

252 个 console event。钉子完全不渲染（program 不可用）。

## 根因

`ShaderMaterial` 不像 stock 材质会自动 inject `attribute vec3 instanceColor`。`instanceMatrix` 是特殊的（Three.js 检测 `USE_INSTANCING` 自动注入），但 per-instance color 必须手动声明。

## 修复

```glsl
// 在 vertex shader 头部加：
attribute vec3 instanceColor;
```

3 行新增，1 个文件。

## 验证（修复后）

同一 headless 测试：
- 252 console events → **8 events**
- **0 个错误，0 个 404**
- 游戏正常启动，主菜单 + 教程对话框正常显示
- 3D toggle 切换正常（body class 添加，badge 切换）
- Renderer3D 已渲染 133 帧

## 兄弟模块检查

| 模块 | 实例属性使用 | 状态 |
| :--- | :--- | :---: |
| `PegInstancedMesh` | `instanceColor` shader 内 | **本 PR 修复** |
| `EnemyMeshPool` | 每敌 material clone uniforms（uTier）| ✅ 不受影响 |
| `GPUParticleSystem` | `color` attribute + `vertexColors: true` | ✅ Three.js 自动识别 |

## 来源

这个 bug 不在前 8 个 PR 的代码 review 阶段发现，因为 headless 测试 + 真游戏环境直到 #120 + #121 才能完整跑起来（之前 CDN 被沙箱拦截）。今天把 three.js vendor 进 demo 时才能本地跑。

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_