### PR TITLE
feat(3d): default 3D mode ON + skip 2D bg fill

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,9 +170,15 @@
              * 即可看到下层 3D 背景（同步降低 2D 不透明度到 0.3）。
              */
         }
+        /* [3D-Main] 默认 3D 模式（body.render3d-debug）：
+         *   1. render_clearCanvas 跳过 2D 背景填充 → 3D 全息场景完整可见
+         *   2. render_background 跳过 2D 网格
+         *   3. 2D canvas 整体压到 50% → 2D entities（与 3D 版本同位置）变成柔光辅助层
+         *      未来如要"纯 3D"完全去掉 2D entities，需要在 phase_*_update 里加 skip 检查
+         * 关掉 3D 模式时移除该 class，所有 2D 行为恢复原状。 */
         body.render3d-debug #gameCanvas {
-            opacity: 0.30;
-            transition: opacity 0.2s ease;
+            opacity: 0.55;
+            transition: opacity 0.25s ease;
         }
 
         @keyframes shake-hard {
@@ -2806,7 +2812,7 @@
     }
     </script>
 </head>
-<body>
+<body class="render3d-debug">
 <div id="app-wrapper">
 
 <!-- ===== PC 左侧边栏：收集队列 + 配方 HUD ===== -->
@@ -2893,11 +2899,11 @@
                         <span class="s-label">CRT 特效</span>
                         <span class="s-badge" id="crt-badge">关闭</span>
                     </div>
-                    <!-- [3D-Main] 3D 视觉模式开关：默认关闭（2D 不透明覆盖），开启后 2D 降到 30% 透明，下层 3D 全息场景透出 -->
-                    <div class="settings-item" id="render3d-item" onclick="window.toggleRender3dMode && window.toggleRender3dMode()">
+                    <!-- [3D-Main] 3D 视觉模式开关：默认开启，3D 全息场景为主，关闭则退回纯 2D（兼容/性能保底） -->
+                    <div class="settings-item active" id="render3d-item" onclick="window.toggleRender3dMode && window.toggleRender3dMode()">
                         <span class="s-icon">🌐</span>
                         <span class="s-label">3D 视觉</span>
-                        <span class="s-badge" id="render3d-badge">关闭</span>
+                        <span class="s-badge active" id="render3d-badge">开启</span>
                     </div>
 
                 </div>
@@ -3542,11 +3548,11 @@
                         <span class="ps-label">CRT 特效</span>
                         <span class="ps-badge" id="pause-crt-badge">关闭</span>
                     </div>
-                    <!-- [3D-Main] 3D 视觉模式开关（暂停设置面板版） -->
-                    <div class="pause-setting-row" id="pause-render3d-row" onclick="window.toggleRender3dMode && window.toggleRender3dMode(); game.ui_syncPauseSettings && game.ui_syncPauseSettings();">
+                    <!-- [3D-Main] 3D 视觉模式开关（暂停设置面板版）：默认开启 -->
+                    <div class="pause-setting-row active" id="pause-render3d-row" onclick="window.toggleRender3dMode && window.toggleRender3dMode(); game.ui_syncPauseSettings && game.ui_syncPauseSettings();">
                         <span class="ps-icon">🌐</span>
                         <span class="ps-label">3D 视觉</span>
-                        <span class="ps-badge" id="pause-render3d-badge">关闭</span>
+                        <span class="ps-badge active" id="pause-render3d-badge">开启</span>
                     </div>
 
                     <div class="pause-perf-row">
@@ -3642,9 +3648,11 @@ game.sys_toggleCrt = () => {
 };
 
 // --- [3D-Main] 3D 视觉模式 ---
+// 默认开启：让全套 M1–M6.5 重建的 3D 视觉真正展现给玩家。
 // 通过给 body 加 .render3d-debug 类（M1 已定义：把 2D #gameCanvas 透到 30%，
-// 让下层 WebGL 全息场景透出）。默认关闭——玩家看到的还是熟悉的 2D 表现。
-let is3DOn = localStorage.getItem('ea_render3d_enabled') === 'true';
+// 让下层 WebGL 全息场景透出）。
+// 关闭开关意味着回退到纯 2D（兼容性 / 性能保底 / 怀旧模式）。
+let is3DOn = localStorage.getItem('ea_render3d_enabled') !== 'false';
 function updateRender3dVisuals() {
     const badges = [
         document.getElementById('render3d-badge'),

--- a/src/render_system.js
+++ b/src/render_system.js
@@ -30,6 +30,9 @@ export const render_system = {
      */
     render_clearCanvas() {
         this.ctx.clearRect(0, 0, this.width, this.height);
+        // [3D-Main] 3D 模式下跳过 2D 背景填充，让下层 WebGL 全息场景完整可见
+        const is3D = typeof document !== 'undefined' && document.body && document.body.classList.contains('render3d-debug');
+        if (is3D) return;
         this.ctx.fillStyle = CONFIG.colors.bg;
         this.ctx.fillRect(0, 0, this.width, this.height);
         // 主底图位图（已生成 720×1280 暗黑赛博炼金风），未加载完成时回退到纯色底
@@ -57,12 +60,15 @@ export const render_system = {
      * [RENDER] 绘制背景网格。
      */
     render_background() {
+        // [3D-Main] 3D 模式下跳过背景网格——下层 3D 已有星云 + 远景 + 体积光，不需要再叠 2D 网格
+        if (typeof document !== 'undefined' && document.body && document.body.classList.contains('render3d-debug')) return;
+
         this.ctx.save();
         const gridSpacing = 40;
-        const tiltX = -this.boardTilt.current.x * 15; 
+        const tiltX = -this.boardTilt.current.x * 15;
         const tiltY = this.boardTilt.current.y * 10;
-        
-        this.ctx.strokeStyle = 'rgba(71, 85, 105, 0.15)'; 
+
+        this.ctx.strokeStyle = 'rgba(71, 85, 105, 0.15)';
         this.ctx.lineWidth = 1;
 
         for (let x = (tiltX % gridSpacing); x < this.width; x += gridSpacing) {


### PR DESCRIPTION
## Summary

把 3D 视觉变成**默认体验**，而不是 opt-in。新玩家进游戏直接看到 M1–M6.5 的全套 3D 重建。

## 行为切换

| 用户场景 | 之前 | 现在 |
| :--- | :--- | :--- |
| 全新玩家（无 localStorage） | 纯 2D | **默认 3D** |
| 老玩家（之前明确关掉） | 纯 2D（保留） | 仍然纯 2D |
| 老玩家（之前明确开启） | 3D | 仍然 3D |

`localStorage.ea_render3d_enabled` 只在显式设为 `'false'` 时关闭，其他都视为开启。

## 视觉实现

3D 模式下（默认）：
1. **2D 背景填充跳过**：`render_clearCanvas` 在 body 带 `.render3d-debug` 时只 `clearRect`，不 `fillRect` → 3D backdrop（星云 / 远景 / 体积光 / 炉膛 / 舞台环）100% 可见
2. **2D 网格跳过**：`render_background` 同样早返回
3. **2D canvas 整体 55% 不透明**：2D entities（pegs/enemies/balls）从"主"降为"辅"层，作为柔光辉光附着在 3D 版本上；floating damage numbers + UI 仍可读
4. **HTML `<body>`**：默认带 `class="render3d-debug"`，首帧无 flash

切换关 3D 时，`transition: opacity 0.25s ease` 把 2D canvas 从 55% 拉回 100%，背景填充恢复，回到熟悉的 2D 表现。

## 设置 UI

- 顶部齿轮 → 设置面板 → "🌐 3D 视觉"：badge 默认 "开启" + active 高亮
- 暂停菜单同款行
- 点击切换 → localStorage 持久化 → 跨刷新保留

## 验证（headless Playwright + vendored Three.js）

```
首次加载：bodyClasses = "render3d-debug" ✅
toggle 后：bodyClasses = "", badge "关闭" ✅
0 errors, 0 404s
Renderer3D 正常运行（30 帧 / 2.5s）
```

## 尚未做（后续 PR）

完全跳过 2D entity 绘制——目前 2D pegs/enemies 还在 55% 透明状态下叠加在 3D 之上，形成"双层"轻微 ghosting。要做"纯 3D"需要在 `phase_gathering_update` / `phase_combat_update` 的实体 draw 块加 skip 检查。当前 55% 是过渡平衡，不算糟。

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_