### PR TITLE
feat(3d): pure 3D — fully erase 2D entities after physics update

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,16 +170,13 @@
              * 即可看到下层 3D 背景（同步降低 2D 不透明度到 0.3）。
              */
         }
-        /* [3D-Main] 默认 3D 模式（body.render3d-debug）：
+        /* [3D-Main] 纯 3D 模式（body.render3d-debug）：
          *   1. render_clearCanvas 跳过 2D 背景填充 → 3D 全息场景完整可见
          *   2. render_background 跳过 2D 网格
-         *   3. 2D canvas 整体压到 50% → 2D entities（与 3D 版本同位置）变成柔光辅助层
-         *      未来如要"纯 3D"完全去掉 2D entities，需要在 phase_*_update 里加 skip 检查
-         * 关掉 3D 模式时移除该 class，所有 2D 行为恢复原状。 */
-        body.render3d-debug #gameCanvas {
-            opacity: 0.55;
-            transition: opacity 0.25s ease;
-        }
+         *   3. sys_loop 在 phase update 跑完后整块 clearRect 2D canvas → entities 完全消失
+         *   4. 然后 floating texts / wind anchors / perf overlay 在干净 canvas 上重新绘制
+         * 切回 2D 模式时移除该 class，2D 行为恢复原状。
+         * 不需要降低 #gameCanvas 不透明度——透明区域天然让 3D 完整透出。 */
 
         @keyframes shake-hard {
             0% { transform: translate(0, 0); }

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -173,6 +173,19 @@ export const game_system = {
                 break;
         }
 
+        // [3D-Main] 纯 3D 模式：phase 跑完后把 2D canvas 上的 entity 绘制全部擦掉。
+        // 物理 update 已经执行完（粒子衰减、敌人移动等），只是把它们 .draw() 留下的像素清掉。
+        // 接下来的 floating texts / wind anchors / perf overlay / UI 在干净画布上重新绘制，
+        // 下层 WebGL 全息场景成为唯一可见的"世界视觉"。
+        // 切回 2D 模式（body 没有 render3d-debug class）时跳过此清屏，entities 正常显示。
+        if (typeof document !== 'undefined' && document.body && document.body.classList.contains('render3d-debug')) {
+            // ctx 已被外层 save + translate(shake)；clear 用 setTransform 重置避免被 shake 偏移
+            this.ctx.save();
+            this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+            this.ctx.clearRect(0, 0, this.width, this.height);
+            this.ctx.restore();
+        }
+
         // 6. 战场掉落物更新与渲染
         // [BUGFIX] fieldLootItems 已移入 phase_combat_update 的 LAYER 2（实体层）内渲染，
         // 原因：此处无阶段限制，会导致宝石在 selection 等非战斗阶段泄漏显示。


### PR DESCRIPTION
## Summary

**彻底关掉 2D entities**——上次 55% 半透叠加方案被否决。这次 phase 跑完后整块 `clearRect` 把 2D 实体绘制全部擦掉，3D 成为唯一"世界视觉"。

## 实现思路

考虑过 3 个方案，最终选最干净的：

| 方案 | 问题 |
| :--- | :--- |
| `globalAlpha = 0` 外层包装 | 100+ 处实体内部 `save() + globalAlpha=1`，被覆盖失效 |
| 空 `clip()` 区域 | 实体内部 save/restore 会重置 clip |
| 每个 entity 加 skip flag | 20+ 个类，每个 1 行，太散 |
| **✅ phase 跑完后整块 `clearRect`** | 1 处改动，物理逻辑不受影响 |

## sys_loop 流程

```
1. ctx.save + translate(shake)
2. render_clearCanvas  (3D 模式跳过 bg fill — 已在前 PR)
3. render_background   (3D 模式跳过 grid — 已在前 PR)
4. phase_*_update       ← entities 物理 update + .draw(this.ctx)
5. [新增] if (3D mode) {
       ctx.save();
       ctx.setTransform(1,0,0,1,0,0);  // 抵消 shake
       ctx.clearRect(0,0,W,H);          // 抹掉所有 entity 绘制
       ctx.restore();
   }
6. render_floatingTexts ← 在干净画布上重新画 → 可见
7. render_windAnchors   ← fresh
8. render_perfOverlay   ← fresh
9. ctx.restore
```

## 视觉结果

3D 模式下 2D canvas 现在只承载：
- ✅ floating damage numbers（击中伤害数字）
- ✅ 风系连线 / 法阵动画
- ✅ FPS 性能指示器
- ✅ 现有 HTML HUD（这本来就是独立 DOM）

3D 模式下 2D canvas 不再承载：
- ❌ pegs / enemies / balls / projectiles
- ❌ particles / shockwaves / lightning
- ❌ walls / fortune wheels / ghost pegs
- ❌ 所有"世界实体"

全部交给 3D 渲染管线（PegInstancedMesh / EnemyMeshPool / GPUParticleSystem / WallMesh / SceneProxy）。

## 性能注意

物理 update 仍跑（必须保留——影响数值）；entity .draw() 还是被调用一次然后被擦。CPU 浪费等同于之前，无 regression。后续 PR 可以在 entity draw 方法里短路（`if (3D mode) return`），把这部分 CPU 也省下来。

## Test plan

- [ ] 启动游戏 → 默认 3D 模式 → 看到 3D 全息场景
- [ ] 进入研磨阶段 → 只看到 3D 钉子（不再有 2D 钉子叠加）
- [ ] 进入战斗 → 只看到 3D 敌人
- [ ] 命中敌人 → 看到 damage 数字（floating text）+ 3D 粒子爆开 + 镜头震动
- [ ] 切到设置 → 关掉 3D 视觉 → 2D 完整回归
- [ ] 切回 → 立即恢复 3D-only

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_