### PR TITLE
polish(3d): entity draw early-return + RelicCard sigil + glass HUD default

### DIFF
--- a/index.html
+++ b/index.html
@@ -2809,7 +2809,7 @@
     }
     </script>
 </head>
-<body class="render3d-debug">
+<body class="render3d-debug glass-ui-enabled">
 <div id="app-wrapper">
 
 <!-- ===== PC 左侧边栏：收集队列 + 配方 HUD ===== -->

--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -17,6 +17,7 @@
  */
 import { Vec2, lerp } from '../utils/math_utils.js';
 import { sb as _sb } from '../utils/perf.js';
+import { isSuppressed2DEntities } from '../render3d/draw_mode.js';
 
 class Particle {
     constructor(x, y, color, mode = 'normal') {
@@ -139,6 +140,7 @@ class Particle {
 
     // --- Particle 类的 draw 方法 ---
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         ctx.translate(this.pos.x, this.pos.y);
@@ -283,6 +285,7 @@ class SlashEffect {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         ctx.save();
         ctx.translate(this.x, this.y);
@@ -357,6 +360,7 @@ class CollectionBeam {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         ctx.globalCompositeOperation = 'lighter';
@@ -411,6 +415,7 @@ class Shockwave {
     }
 
     draw(ctx) { 
+        if (isSuppressed2DEntities()) return;
         if(this.alpha <= 0) return; 
         ctx.save(); 
         
@@ -476,6 +481,7 @@ class LaserBeam {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         ctx.lineCap = 'round';
@@ -634,6 +640,7 @@ class EnergyOrb {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         ctx.save();
         
@@ -739,6 +746,7 @@ class LightningBolt {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         ctx.lineCap = 'round';
@@ -800,6 +808,7 @@ class FireWave {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         // 使用 lighter 混合模式讓火焰看起來更亮
@@ -844,6 +853,7 @@ class IceWave {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         ctx.globalCompositeOperation = 'lighter';
@@ -1031,6 +1041,7 @@ class DeathExplosion {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
 
@@ -1173,6 +1184,7 @@ class HealWave {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         ctx.save();
         ctx.globalCompositeOperation = 'lighter';
@@ -1292,6 +1304,7 @@ class BladeStormRing {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active || this.life <= 0) return;
         ctx.save();
         ctx.globalCompositeOperation = 'lighter';
@@ -1348,6 +1361,7 @@ class SwordScar {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active || this.life <= 0) return;
         ctx.save();
         ctx.translate(this.x + this.offsetX, this.y + this.offsetY);
@@ -1550,6 +1564,7 @@ class RewardDropEffect {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.life <= 0) return;
         const alpha = Math.max(0, this.life);
         ctx.save();

--- a/src/entities.js
+++ b/src/entities.js
@@ -40,6 +40,7 @@ import {
 import { Enemy, setEnemyAudioProvider } from './entities/enemy.js';
 import { Projectile, setProjectileAudioProvider } from './entities/projectile.js';
 import { RUNE_DB } from './rune_config.js';
+import { isSuppressed2DEntities } from './render3d/draw_mode.js';
 import {
     resolveEnhancedCollision,
     calcMagnusForce,
@@ -146,6 +147,7 @@ class SpecialSlot {
      * @param {CanvasRenderingContext2D} ctx
      */
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (this.hit) return;
 
         this.animTimer += 0.05;
@@ -351,6 +353,7 @@ class FortuneWheel {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         
         // 繪製半透明黑色背景遮罩，突出輪盤
@@ -542,6 +545,7 @@ class GhostPeg {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         const x = this.pos.x, y = this.pos.y, r = this.radius;
         const lifeRatio = this.life / this.maxLife;
@@ -699,6 +703,7 @@ class TriangleSideWheel {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         const x = this.x, y = this.y, r = this.radius;
         const pulse = (Math.sin(Date.now() / 500) + 1) / 2;
 
@@ -1039,6 +1044,7 @@ class Peg {
     // --- 替换 Peg 类的 draw 方法 ---
     // @section:peg_shadow_and_transform - 软阴影与碰撞旋转变换初始化
     draw(ctx, baseRadius, tilt = {x:0, y:0}) {
+        if (isSuppressed2DEntities()) return;
         const currentRadius = baseRadius * this.scale;
         const isSpecial = this.type !== 'normal';
         const isLit = this.lit;
@@ -3041,6 +3047,7 @@ class DropBall {
          * @description 分层绘制弹珠 (更新：爆破弹珠专属视觉)
          */
         draw(ctx) {
+            if (isSuppressed2DEntities()) return;
             if (!this.active) return;
             
             const x = this.pos.x;
@@ -3500,6 +3507,7 @@ class SwordQi {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         ctx.save();
         ctx.translate(this.pos.x, this.pos.y);
@@ -3534,6 +3542,7 @@ class SlashAnim {
         if (this.life <= 0) this.active = false;
     }
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         ctx.save();
         ctx.translate(this.pos.x, this.pos.y);
@@ -3914,6 +3923,7 @@ class SonSword {
     }
 
         draw(ctx) {
+            if (isSuppressed2DEntities()) return;
         if (!this.active || this.state === 'stuck') return; 
 
         const color = this.level >= 3 ? '#f43f5e' : (this.level >= 2 ? '#6366f1' : '#0ea5e9');
@@ -4054,6 +4064,7 @@ class CloneSpore {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         ctx.save();
         ctx.translate(this.pos.x, this.pos.y);
@@ -4306,6 +4317,7 @@ class Player {
      * @param {CanvasRenderingContext2D} ctx - 绘图上下文
      */
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         const nextAmmo = this.game.ammoQueue.length > 0 ? this.game.ammoQueue[0] : null;
         
         // 计算当前绘制位置（可能有抖动）
@@ -4713,6 +4725,7 @@ class FieldLootItem {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active || this.opacity <= 0) return;
 
         const floatY = Math.sin(this._animTimer) * 5;
@@ -4797,6 +4810,7 @@ class RuneLoot {
      * @param {CanvasRenderingContext2D} ctx - 绘图上下文
      */
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
 
         this._animTimer += 0.05;

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -21,6 +21,7 @@ import { Particle } from '../effects/particles.js';
 import { sb as _sb } from '../utils/perf.js';
 import { eventBus } from '../event_bus.js';
 import { createSpriteRenderer } from '../render/sprite_renderer.js'; // [Phase 5B Task 5.B3] Sprite 动画渲染器
+import { isSuppressed2DEntities } from '../render3d/draw_mode.js';
 
 // audio 代理由 entities.js 注入，通过模块级变量共享
 // 注意：Enemy 类使用的 audio 对象来自 entities.js 的依赖注入机制
@@ -1361,6 +1362,7 @@ class Enemy {
     // [核心修改] 绘制方法：修复冰冻视觉过大和边缘粗糙问题
     // @section:draw_entry_and_perf_check - 绘制入口与性能等级检查
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active) return;
         ctx.save(); 
         ctx.translate(this.pos.x, this.pos.y + this.bumpOffsetY);

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -22,6 +22,7 @@ import { CONFIG } from '../config.js';
 import { Vec2 } from '../utils/math_utils.js';
 import { Particle, SlashEffect } from '../effects/particles.js';
 import { sb as _sb } from '../utils/perf.js';
+import { isSuppressed2DEntities } from '../render3d/draw_mode.js';
 
 // audio 代理由 entities.js 注入，通过模块级变量共享
 let _audioProvider = null;
@@ -919,6 +920,7 @@ class Projectile {
     }
 
     draw(ctx) {
+        if (isSuppressed2DEntities()) return;
         if (!this.active && !this.destroyed) return;
         const integrity = (this.bouncesLeft + this.piercesLeft) / (this.maxDurability || 1);
         // [拖尾 #6] 在主体之前先绘制拖尾，主体覆盖在最前

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -19,6 +19,7 @@ import { audio } from './audio.js';
 import { loot_calcRuneDrop } from './loot_system.js';
 import { COUNTER_MAP, RUNE_DB } from './rune_config.js';
 import { eventBus, EVENT_TYPES } from './event_bus.js';
+import { setSuppress2DEntities } from './render3d/draw_mode.js';
 
 export const game_system = {
 
@@ -117,6 +118,13 @@ export const game_system = {
 
         const timeScale = this.timeScale;
 
+        // [3D-Main] 每帧同步"是否抑制 2D 实体绘制"开关。
+        // body.render3d-debug 由 #render3d-item 设置控制；entity.draw() 内首行查询此 flag。
+        const is3DMode = typeof document !== 'undefined'
+            && document.body
+            && document.body.classList.contains('render3d-debug');
+        setSuppress2DEntities(is3DMode);
+
         // 处理震动衰减
         let shakeX = 0, shakeY = 0;
         if (this.screenShake > 0) {
@@ -173,13 +181,10 @@ export const game_system = {
                 break;
         }
 
-        // [3D-Main] 纯 3D 模式：phase 跑完后把 2D canvas 上的 entity 绘制全部擦掉。
-        // 物理 update 已经执行完（粒子衰减、敌人移动等），只是把它们 .draw() 留下的像素清掉。
-        // 接下来的 floating texts / wind anchors / perf overlay / UI 在干净画布上重新绘制，
-        // 下层 WebGL 全息场景成为唯一可见的"世界视觉"。
-        // 切回 2D 模式（body 没有 render3d-debug class）时跳过此清屏，entities 正常显示。
-        if (typeof document !== 'undefined' && document.body && document.body.classList.contains('render3d-debug')) {
-            // ctx 已被外层 save + translate(shake)；clear 用 setTransform 重置避免被 shake 偏移
+        // [3D-Main] 纯 3D 模式：所有 2D entity.draw() 已通过 setSuppress2DEntities() 在自身首行
+        // 早返回，不再写入像素。此处不再需要 clearRect 兜底——但保留作为"任何漏改 entity 的
+        // 安全网"，开销极低（一次 clearRect O(W*H) 像素清零，远小于 entity 绘制成本）。
+        if (is3DMode) {
             this.ctx.save();
             this.ctx.setTransform(1, 0, 0, 1, 0, 0);
             this.ctx.clearRect(0, 0, this.width, this.height);

--- a/src/render3d/draw_mode.js
+++ b/src/render3d/draw_mode.js
@@ -1,0 +1,20 @@
+/**
+ * draw_mode.js - 2D 实体绘制抑制开关（M6.5+ 性能优化）
+ *
+ * sys_loop 每帧基于 body.render3d-debug 设置此标志。
+ * 所有 2D entity 的 draw() 在方法首行查询本标志，true 即直接 return，
+ * 节省 .draw() 内部的 JS 计算 + Canvas API 调用。
+ *
+ * FloatingText（伤害数字）是例外——属于 UI 反馈层，不属于"世界实体"，
+ * 在 3D 模式下仍要可见。它自己的 draw() 不调用 isSuppressed2DEntities()。
+ */
+
+let _suppressed = false;
+
+export function setSuppress2DEntities(v) {
+    _suppressed = !!v;
+}
+
+export function isSuppressed2DEntities() {
+    return _suppressed;
+}

--- a/src/styles/glass_ui.css
+++ b/src/styles/glass_ui.css
@@ -169,3 +169,41 @@ body.glass-ui-enabled .number-display,
 body.glass-ui-enabled .currency-amount {
     text-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
 }
+
+/* ============================================================
+ * [3D-Main] 遗物图标：程序化徽记 + emoji 双层
+ * 替代旧的 64×64 PNG（M6 已删除）。徽记由 src/ui/relic_sigil.js
+ * 按 hash(relic.id) 程序化生成，存为 DataURL 内嵌 <img>。
+ * ============================================================ */
+.relic-card .relic-icon {
+    position: relative;
+    display: inline-block;
+    width: 96px;
+    height: 96px;
+    max-width: 100%;
+    max-height: 100%;
+}
+.relic-card .relic-icon .relic-sigil {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    /* 边缘柔光，让徽记融入卡牌 */
+    filter: drop-shadow(0 0 12px rgba(255, 255, 255, 0.15));
+    pointer-events: none;
+}
+.relic-card .relic-icon .relic-emoji {
+    position: absolute;
+    right: -4px;
+    bottom: -4px;
+    font-size: 22px;
+    line-height: 1;
+    text-shadow: 0 0 6px rgba(0, 0, 0, 0.85);
+    pointer-events: none;
+    /* 小角标：让 emoji 作为辅助识别符 */
+    padding: 2px 4px;
+    background: rgba(2, 6, 23, 0.55);
+    border-radius: 6px;
+    backdrop-filter: blur(4px);
+}

--- a/src/ui/relic_sigil.js
+++ b/src/ui/relic_sigil.js
@@ -1,0 +1,172 @@
+/**
+ * relic_sigil.js - 遗物程序化徽记（2D Canvas 版本，shop UI / field loot 用）
+ *
+ * 将 M5 `render3d/RelicCard.js` 的 WebGL 徽记 shader 逻辑移植成 2D Canvas：
+ *   - hash(relic.id) → 种子 → 花瓣数(3..8) + 相位 + 内圈频率
+ *   - 由"星花+圆环+中央亮点"组合，颜色按 rarity 取
+ *   - 输出 DataURL，配合 <img src> 直接挂到 HTML 卡片上
+ *
+ * 同一 relicId + 同一尺寸 → 永远生成同一张图。结果缓存在 Map 里，
+ * 避免每次开商店都重渲染。
+ */
+
+// 与 RelicCard 的 RARITY_COLORS 保持一致
+const RARITY_COLORS = {
+    common:    { core: '#94a3b8', glow: '#e2e8f0' },
+    rare:      { core: '#6366f1', glow: '#818cf8' },
+    epic:      { core: '#c026d3', glow: '#d946ef' },
+    legendary: { core: '#ea580c', glow: '#f59e0b' },
+    cursed:    { core: '#be123c', glow: '#9f1239' },
+};
+
+function hashStr(s) {
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+    }
+    return (h >>> 0) / 0xffffffff;
+}
+
+function _hexA(hex, alpha) {
+    // hex: '#rrggbb', alpha: 0..1
+    const a = Math.max(0, Math.min(255, Math.round(alpha * 255)));
+    return hex + a.toString(16).padStart(2, '0');
+}
+
+// 缓存：key = `${id}|${rarity}|${size}` → DataURL
+const _cache = new Map();
+
+/**
+ * @param {Object} relic { id, rarity }
+ * @param {number} [size=96]  输出 canvas 边长
+ * @returns {string} dataURL（'data:image/png;base64,...'）
+ */
+export function getRelicSigilDataURL(relic, size = 96) {
+    if (!relic || !relic.id) return '';
+    const rarity = relic.rarity || 'common';
+    const cacheKey = `${relic.id}|${rarity}|${size}`;
+    const cached = _cache.get(cacheKey);
+    if (cached) return cached;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return '';
+
+    const seed = hashStr(relic.id);
+    const colors = RARITY_COLORS[rarity] || RARITY_COLORS.common;
+    _drawSigil(ctx, size, size, seed, colors);
+
+    const dataURL = canvas.toDataURL('image/png');
+    _cache.set(cacheKey, dataURL);
+    return dataURL;
+}
+
+/**
+ * 也支持就地绘制到现有 canvas / ctx（避免 dataURL 开销）
+ * @param {Object} relic
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} x  绘制中心 x
+ * @param {number} y  绘制中心 y
+ * @param {number} size  外径 × 2（边长）
+ */
+export function drawRelicSigil(relic, ctx, x, y, size) {
+    if (!relic || !ctx) return;
+    const rarity = relic.rarity || 'common';
+    const seed = hashStr(relic.id || '');
+    const colors = RARITY_COLORS[rarity] || RARITY_COLORS.common;
+    ctx.save();
+    ctx.translate(x - size / 2, y - size / 2);
+    _drawSigil(ctx, size, size, seed, colors);
+    ctx.restore();
+}
+
+function _drawSigil(ctx, w, h, seed, colors) {
+    const cx = w / 2, cy = h / 2;
+    const armCount = 3 + Math.floor(seed * 7919) % 6;      // 3..8
+    const phase = (seed * 6.28 * 13) % (Math.PI * 2);
+    const innerArms = 2 + Math.floor(seed * 7333) % 4;     // 2..5
+
+    ctx.save();
+    // 居中
+    ctx.translate(cx, cy);
+
+    // 1) 软光晕背景（径向渐变）
+    const glow = ctx.createRadialGradient(0, 0, 0, 0, 0, w * 0.55);
+    glow.addColorStop(0,    _hexA(colors.glow, 0.45));
+    glow.addColorStop(0.55, _hexA(colors.core, 0.20));
+    glow.addColorStop(1,    _hexA(colors.core, 0.00));
+    ctx.fillStyle = glow;
+    ctx.beginPath();
+    ctx.arc(0, 0, w * 0.5, 0, Math.PI * 2);
+    ctx.fill();
+
+    // 2) 外环
+    ctx.strokeStyle = _hexA(colors.glow, 0.75);
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(0, 0, w * 0.42, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // 3) 内环（更细，距离更近）
+    ctx.strokeStyle = _hexA(colors.glow, 0.45);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(0, 0, w * 0.28, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // 4) 花瓣（armCount 片）—— 主视觉
+    const petalOuter = w * 0.40;
+    const petalInner = w * 0.10;
+    const halfAngle = (Math.PI * 2 / armCount) * 0.32;
+    ctx.fillStyle = _hexA(colors.glow, 0.95);
+    for (let i = 0; i < armCount; i++) {
+        const a = phase + i * (Math.PI * 2 / armCount);
+        ctx.beginPath();
+        // 起点：内圈
+        ctx.moveTo(Math.cos(a) * petalInner, Math.sin(a) * petalInner);
+        // 左肩
+        ctx.lineTo(Math.cos(a - halfAngle) * (petalOuter * 0.78), Math.sin(a - halfAngle) * (petalOuter * 0.78));
+        // 尖端
+        ctx.lineTo(Math.cos(a) * petalOuter, Math.sin(a) * petalOuter);
+        // 右肩
+        ctx.lineTo(Math.cos(a + halfAngle) * (petalOuter * 0.78), Math.sin(a + halfAngle) * (petalOuter * 0.78));
+        ctx.closePath();
+        ctx.fill();
+    }
+
+    // 5) 内部小尖刺（innerArms 片，错相位增加细节）
+    const innerOuter = w * 0.20;
+    const innerInner = w * 0.04;
+    const innerHalf = (Math.PI * 2 / innerArms) * 0.30;
+    ctx.fillStyle = _hexA(colors.core, 0.9);
+    for (let i = 0; i < innerArms; i++) {
+        const a = phase * 0.5 + i * (Math.PI * 2 / innerArms);
+        ctx.beginPath();
+        ctx.moveTo(Math.cos(a) * innerInner, Math.sin(a) * innerInner);
+        ctx.lineTo(Math.cos(a - innerHalf) * (innerOuter * 0.6), Math.sin(a - innerHalf) * (innerOuter * 0.6));
+        ctx.lineTo(Math.cos(a) * innerOuter, Math.sin(a) * innerOuter);
+        ctx.lineTo(Math.cos(a + innerHalf) * (innerOuter * 0.6), Math.sin(a + innerHalf) * (innerOuter * 0.6));
+        ctx.closePath();
+        ctx.fill();
+    }
+
+    // 6) 中央光点（双层）
+    ctx.fillStyle = _hexA(colors.glow, 1.0);
+    ctx.beginPath();
+    ctx.arc(0, 0, w * 0.055, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.arc(0, 0, w * 0.025, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.restore();
+}
+
+/** 清空缓存（debug 用） */
+export function clearRelicSigilCache() {
+    _cache.clear();
+}

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -18,6 +18,7 @@ import { RUNE_DB } from '../rune_config.js';
 import { showToast } from '../entities.js';
 import { eventBus } from '../event_bus.js';
 import { getRelicIconSrc } from '../bitmap_icons.js'; // [Phase 5A Task 5.A7] 位图遗物图标
+import { getRelicSigilDataURL } from './relic_sigil.js'; // [3D-Main] 程序化徽记（M5 RelicCard 2D 移植）
 
 // ==================== [v2 即时感重塑] 子弹评分与属性操作辅助函数 ====================
 // 这些工具函数被 mirror_magazine / element_injector 调用以判定"最强/最弱"子弹与属性翻倍。
@@ -174,11 +175,16 @@ export const shop_system = {
                     `;
                 }
                 
-                // [Phase 5A Task 5.A7] 位图遗物图标：优先使用 64×64 位图，fallback 到 emoji
-                const relicBitmapSrc = getRelicIconSrc(relic.id);
-                const relicIconHtml = relicBitmapSrc
-                    ? `<img src="${relicBitmapSrc}" alt="${relic.icon}" style="width:100%;height:100%;object-fit:contain;" loading="lazy" onerror="this.style.display='none';this.insertAdjacentText('afterend','${relic.icon}');"/>`
-                    : relic.icon;
+                // [3D-Main] 遗物 PNG 已废弃，改用 M5 RelicCard 风格的程序化徽记 +
+                // 角落保留 emoji 作为快速识别标记。
+                // 徽记按 hash(relic.id) → 形状，按 relic.rarity → 颜色，shop 内同一遗物
+                // 永远渲染同样的图（缓存 DataURL）。
+                const sigilSrc = getRelicSigilDataURL(relic, 96);
+                el.setAttribute('data-rarity', relic.rarity || 'common');
+                const relicIconHtml = sigilSrc
+                    ? `<img src="${sigilSrc}" alt="${relic.icon}" class="relic-sigil"/>
+                       <span class="relic-emoji">${relic.icon || ''}</span>`
+                    : (relic.icon || '');
                 el.innerHTML = `
                     <div class="relic-icon">${relicIconHtml}</div>
                     <div class="relic-name">${relic.name}</div>


### PR DESCRIPTION
## Summary

三件 polish 一起做：

| # | 改动 |
| :---: | :--- |
| **1. 性能** | 29 个 entity `.draw()` 在 3D 模式首行直接 `return`，省下 JS 计算 + Canvas API 调用 |
| **2. 遗物 UI** | 商店遗物卡现在用 M5 RelicCard 的程序化徽记（2D Canvas 移植），不再依赖已删除的 PNG |
| **3. HUD 玻璃化** | `body` 默认带 `glass-ui-enabled`，M5 的玻璃风样式直接生效 |

## 1. 性能优化

### 新模块 `src/render3d/draw_mode.js`

```js
let _suppressed = false;
export function setSuppress2DEntities(v) { _suppressed = !!v; }
export function isSuppressed2DEntities() { return _suppressed; }
```

`sys_loop` 每帧根据 `body.classList.contains('render3d-debug')` 设置 flag。

### 29 个 entity draw 加守卫（FloatingText 例外）

| 文件 | 类数 | 类 |
| :--- | ---: | :--- |
| `entities.js` | 13 | SpecialSlot, FortuneWheel, GhostPeg, TriangleSideWheel, Peg, DropBall, SwordQi, SlashAnim, SonSword, CloneSpore, Player, FieldLootItem, RuneLoot |
| `entities/enemy.js` | 1 | Enemy |
| `entities/projectile.js` | 1 | Projectile |
| `effects/particles.js` | 14 | Particle, SlashEffect, CollectionBeam, Shockwave, LaserBeam, EnergyOrb, LightningBolt, FireWave, IceWave, DeathExplosion, HealWave, BladeStormRing, SwordScar, RewardDropEffect |

`FloatingText.draw()` **没加守卫**——伤害数字是 UI 反馈层，3D 模式下必须可见。

### 节省

之前：phase update 跑 → entities 各自计算 + 写 canvas 像素 → 整块 `clearRect` 抹掉。  
现在：phase update 跑 → entities 一行 `return` 直接退出 → 跳过本帧的 JS 计算 + Canvas API。

按 100+ 实体 × 60 fps 估算，恢复一大块 CPU。`clearRect` 兜底保留——未来新增 entity 忘加 guard 也不会泄露 2D 像素。

## 2. 遗物 RelicCard 接入

### 新模块 `src/ui/relic_sigil.js`

把 M5 `RelicCard.js` 的 WebGL 徽记 shader 移植成 2D Canvas 实现：

```
hash(relic.id) → seed → armCount(3..8) + innerArms(2..5) + phase
↓
绘制：花瓣 armCount 片 + 内圈尖刺 innerArms 片 + 双环 + 径向光晕 + 中央双层亮点
↓
按 rarity 取色（common/rare/epic/legendary/cursed）
↓
缓存 DataURL（同一遗物永远同一张图）
```

### `shop.js` 集成

替换旧的 ``&lt;img src=getRelicIconSrc()&gt;``（已死引用）为：

```html
<div class="relic-icon" data-rarity="legendary">
  `&lt;img class="relic-sigil" src="data:image/png;base64,..."/&gt;`
  <span class="relic-emoji">🔥</span>
</div>
```

emoji 保留作为右下角小角标——既保持快速识别，又让程序化徽记成为视觉主体。

### CSS

`glass_ui.css` 新增 `.relic-card .relic-icon` 规则，96×96 区域 + 绝对定位的 sigil + 角标 emoji。徽记带柔光 `drop-shadow`。

## 3. HUD 玻璃化默认 ON

```diff
- <body class="render3d-debug">
+ <body class="render3d-debug glass-ui-enabled">
```

M5 的 `glass_ui.css` 整套（顶部栏、UI overlay、卡片、按钮、tooltip 等）现在默认生效。  
关掉 3D 视觉不影响 glass 类，玻璃感始终在。

## Test plan

- [ ] 启动游戏 → 默认 3D + glass HUD
- [ ] DevTools Performance：phase update 期间 entity draw 的 self-time 应趋近 0（除 FloatingText）
- [ ] 打开商店 → 遗物卡显示程序化徽记 + 右下角 emoji 标记
- [ ] 同一遗物多次出现 → 徽记一致（cached）
- [ ] 不同遗物 → 徽记形状/颜色明显不同
- [ ] HUD 看起来是玻璃感（不是 9-slice PNG 边框）
- [ ] 关闭 3D toggle → 2D 实体恢复显示，glass HUD 保留

## Smoke test 结果

```
Loading game from local http server...
bodyClasses = "render3d-debug glass-ui-enabled"
After 3D toggle: bodyClasses = "glass-ui-enabled", badge = "关闭"
Captured 8 console events. 0 errors. 0 404s.
```

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_