### PR TITLE
perf+docs(3d): skip 2D shadow/light loops in 3D + 3D-Main retro doc

### DIFF
--- a/docs/3d_main_retro.md
+++ b/docs/3d_main_retro.md
@@ -1,0 +1,122 @@
+# 3D-Main 复盘 (Retro)
+
+> 状态：3D-Main 分支已积累 30+ commit、~4400 行新代码、~140MB 资产删除。
+> 本文记录架构、已完成、已知问题、下一步建议。
+
+## 1. 累计成果
+
+| 项 | 数据 |
+| :--- | :--- |
+| commit 数 | 30+（vs main） |
+| 新模块 | 13 个 `src/render3d/*.js` + 1 个 `src/ui/relic_sigil.js` |
+| 新代码行 | ~3,800 (render3d) + ~600 (CSS / UI) |
+| 修改 game 代码 | ~120 行（hook 点） |
+| 删除资产 | 181 文件 / ~140 MB |
+| Milestone | M1–M6.5 + 10+ polish PR |
+
+## 2. 架构
+
+```
+core.js  (Game 实例)
+  ├─ new Renderer3D(canvas, w, h, { eventBus })
+  │     ├─ WebGLRenderer (WebGL2 if available)
+  │     ├─ Scene + FogExp2
+  │     ├─ PerspectiveCamera (FOV=28°, narrow → near-orthographic 玩法面板)
+  │     ├─ BackgroundLayer        (L0/L1 远景天幕/光柱/粒子/炼金台环)
+  │     ├─ CameraController       (state machine + spring physics)
+  │     ├─ PostFX                 (Bloom + LensDistortion + VignetteGrain
+  │     │                          + ACES Filmic + 5 grading 预设)
+  │     ├─ QualityProfile         (high/medium/low + auto detect)
+  │     └─ SceneProxy
+  │           ├─ PegInstancedMesh    (M2)
+  │           ├─ WallMesh             (M2)
+  │           ├─ EnemyMeshPool + Factory  (M3 - 9 archetype)
+  │           ├─ GPUParticleSystem    (M6 - 4096 capacity)
+  │           └─ (外挂) RelicCard / RuneMesh  (M5 - 未接入实战)
+  │
+  └─ sys_loop (每帧):
+       1. renderer3d.render()        ← 3D 全场景 + PostFX
+       2. 2D phase update            ← entity.draw() 在 3D 模式首行 return
+       3. clearRect (3D 模式)         ← 兜底擦掉漏网 entity
+       4. floating texts / wind / UI ← 在干净 2D canvas 上绘制
+```
+
+## 3. eventBus 自动接线
+
+| 事件 | 触发 |
+| :--- | :--- |
+| `damage:dealt` | 镜头 IMPACT（按伤害分档）+ spark 粒子 |
+| `enemy:killed` | 镜头 KILLED + ember + shard 爆开 |
+| `boss:defeated` | 镜头大震 + 大爆炸 + grading 回 combat |
+| `boss:spawned` | grading 切到 boss 预设（红紫调） |
+| `phase:change` | 镜头 PHASE_TRANS + grading 跟阶段切 |
+
+## 4. 验收状态
+
+| 项 | 状态 | 备注 |
+| :--- | :---: | :--- |
+| 3D 默认开 | ✅ | body 默认带 `render3d-debug` |
+| 设置开关 | ✅ | 顶栏 + 暂停菜单两处 |
+| LocalStorage 持久 | ✅ | `ea_render3d_enabled` |
+| 0 console 错 | ✅ | 实测 headless 真游戏 |
+| 0 资产 404 | ✅ | PR #120 已清理 |
+| WebGL2 HDR + Bloom | ✅ | profile=high 自动启用 |
+| 软渲染降级 | ✅ | SwiftShader → low 自动跳 PostFX |
+| 移动端检测 | ✅ | 小屏 → medium 或 low |
+| 2D entity 早 return | ✅ | 29 个 .draw() 全覆盖（除 FloatingText） |
+| shadow/light 跳过 | ✅ | 本次 PR 加（前略漏） |
+| 真游戏跑过 combat | ⚠️ | headless 注入假敌人成功，没手动玩过 |
+| RelicCard 接选择面板 | ❌ | M5 mesh 类未在真 UI 使用 |
+| RuneMesh 接符文 UI | ❌ | M5 mesh 类未在真 UI 使用 |
+| DoF / Bokeh | ❌ | M4 计划但 deferred |
+| Lens flares | ❌ | 未做 |
+
+## 5. 已知 gaps / 后续候选
+
+按"价值 × 改动成本"排序：
+
+| 优先级 | 项 | 简述 | 成本 |
+| :---: | :--- | :--- | :---: |
+| 🔥 高 | 真机手动测试 | 在浏览器实际玩一局，发现 demo 测不到的问题 | 极低（你来） |
+| 🔥 高 | RelicCard 接选择面板 | 让 M5 真正发挥作用 | 中 |
+| 中 | 低 HP 红 vignette 脉冲 | 玩家危险时画面边缘红色告警 | 低 |
+| 中 | 暴击全屏 1 帧白闪 | 大伤害 punch impact | 低 |
+| 中 | RuneMesh 接符文网格 | 替换 emoji 符文图标 | 中 |
+| 低 | DoF (Bokeh) | M4 deferred 项 | 高 |
+| 低 | Lens flares | 亮 emissive 上水平拉光条 | 中 |
+| 低 | 删 unused 模块 | RelicCard/RuneMesh 不用就删（26KB） | 低 |
+
+## 6. 性能现状
+
+每帧（3D 模式）：
+- WebGL render: 1 次 composer.render (postFX = 6 pass)
+- InstancedMesh: pegs (1 draw) + walls (2 draws) + enemy pool (N draws, N≈20)
+- 2D entity .draw(): 首行 return（已优化）
+- 2D shadow/light loop: 整段跳过（本 PR 优化）
+- 2D clearRect: 安全网兜底（廉价）
+
+主要 CPU 仍在：
+- physics update（必须保留）
+- HUD DOM 更新
+- 事件处理
+
+## 7. 调优历程要点
+
+| PR | 关键发现 |
+| :--- | :--- |
+| #122 | PegInstancedMesh shader 缺 `attribute vec3 instanceColor` 声明，导致 program invalid 每帧 spam INVALID_OPERATION |
+| #123-124 | 2D 不透明覆盖让 3D 完全隐藏；改成默认 3D + sys_loop 末 clearRect |
+| #125 | 性能：29 个 entity .draw() 加 guard |
+| #126 | bloom 阈值过低导致全场泛光；上调 + 引入 color grading |
+| #127 | 阶段感知 grading 让画面随游戏状态呼吸 |
+| 本 PR | shadow/light 计算还在跑（未被 .draw guard 覆盖），独立优化 |
+
+## 8. 下一步建议
+
+**最高 ROI**：先**真机手动测试**一局，发现 demo 测不到的问题（教程交互、状态保存、phase 转换）。  
+**次高**：把 **RelicCard 接到选择面板**——M5 工作只在 demo 里被看到，没有进入玩家手里。
+
+如继续做 polish：
+- 低 HP vignette 红脉冲（5 行 shader）
+- 暴击瞬白闪（1 个 ShaderPass 或简单 alpha 叠加）
+- RuneMesh 接符文网格（M5 的另一半工作）

--- a/src/entities.js
+++ b/src/entities.js
@@ -896,6 +896,9 @@ class Peg {
     // --- 在 Peg 类中替换此方法 ---
     // --- 在 Peg 类中替换此方法 ---
     drawShadow(ctx, lightPos, lightRadius) {
+        // [3D-Main 性能] 3D 模式下整个 2D 阴影渲染都被擦除/不可见，跳过 ctx 调用
+        if (isSuppressed2DEntities()) return;
+
         const dx = this.pos.x - lightPos.x;
         const dy = this.pos.y - lightPos.y;
         const distSq = dx * dx + dy * dy;
@@ -994,6 +997,10 @@ class Peg {
     }
     //  计算来自某个光源的影响
     calculateLight(sourcePos, lightRadius) {
+        // [3D-Main 性能] 3D 模式下 lightIntensity 不会被读（peg.draw 被 guard 跳过），
+        // 整个计算可以省。这是 O(N*M) 循环里调的，开销显著。
+        if (isSuppressed2DEntities()) return;
+
         const dx = sourcePos.x - this.pos.x;
         const dy = sourcePos.y - this.pos.y;
         const distSq = dx*dx + dy*dy;

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -2785,46 +2785,46 @@ phase_gathering_getRandomPegType() {
         );
         const LIGHT_RADIUS = 150;
         const LIGHT_RADIUS_SQ = LIGHT_RADIUS * LIGHT_RADIUS;// 预计算平方，避免开根号
-        // --- 绘制阴影 (传入动态光源) ---
-        // DropBalls 发出的光
-        this.dropBalls.forEach(ball => {
-            if (!ball.active) return;
-            this.pegs.forEach(p => {
-                 // 这里是原有的小球光照阴影
-                p.drawShadow(this.ctx, ball.pos, LIGHT_RADIUS);
-            });
-        });
 
-        //  全局环境光阴影 (基于倾斜)
-        // 让所有钉子都有一个基于板子倾斜的微弱基础阴影，增加立体感
-        this.pegs.forEach(p => {
-            // 我们利用 drawShadow 的逻辑，制造一个伪造的“太阳”
-            p.drawShadow(this.ctx, lightSourcePos, 9999); // 半径很大，覆盖全屏
-        });
+        // [3D-Main 性能] 整个 2D 阴影/光照系统在 3D 模式完全不可见（3D 渲染层有自己的光照
+        // 模型，且 2D canvas 被 sys_loop 整块清屏）。跳过外层 O(N*M) 循环。
+        const _is3D = typeof document !== 'undefined'
+            && document.body
+            && document.body.classList.contains('render3d-debug');
         const lightSources = [...this.dropBalls];
 
-        // --- 优化开始：只对范围内的钉子画阴影 ---
-        lightSources.forEach(ball => {
-            if (!ball.active) return;
-            
-            // 遍历所有钉子
-            for (let i = 0; i < this.pegs.length; i++) {
-                const p = this.pegs[i];
-                // 简单的 AABB 预判或距离平方判断
-                const dx = ball.pos.x - p.pos.x;
-                // @section:gathering_update_slots - 槽位触发检测与属性收集
-                const dy = ball.pos.y - p.pos.y;
-                
-                // 只有距离小于 LIGHT_RADIUS 时才绘制阴影
-                // Math.abs 检查比乘法快，先做粗略筛选
-                if (Math.abs(dx) < LIGHT_RADIUS && Math.abs(dy) < LIGHT_RADIUS) {
-                    if ((dx*dx + dy*dy) < LIGHT_RADIUS_SQ) {
-                        p.drawShadow(this.ctx, ball.pos, LIGHT_RADIUS);
-                        p.calculateLight(ball.pos, LIGHT_RADIUS); // 光照计算也放这里
+        if (!_is3D) {
+            // --- 绘制阴影 (传入动态光源) ---
+            // DropBalls 发出的光
+            this.dropBalls.forEach(ball => {
+                if (!ball.active) return;
+                this.pegs.forEach(p => {
+                    p.drawShadow(this.ctx, ball.pos, LIGHT_RADIUS);
+                });
+            });
+
+            //  全局环境光阴影 (基于倾斜)
+            this.pegs.forEach(p => {
+                p.drawShadow(this.ctx, lightSourcePos, 9999);
+            });
+
+            // --- 只对范围内的钉子画阴影 ---
+            lightSources.forEach(ball => {
+                if (!ball.active) return;
+                for (let i = 0; i < this.pegs.length; i++) {
+                    const p = this.pegs[i];
+                    const dx = ball.pos.x - p.pos.x;
+                    // @section:gathering_update_slots - 槽位触发检测与属性收集
+                    const dy = ball.pos.y - p.pos.y;
+                    if (Math.abs(dx) < LIGHT_RADIUS && Math.abs(dy) < LIGHT_RADIUS) {
+                        if ((dx*dx + dy*dy) < LIGHT_RADIUS_SQ) {
+                            p.drawShadow(this.ctx, ball.pos, LIGHT_RADIUS);
+                            p.calculateLight(ball.pos, LIGHT_RADIUS);
+                        }
                     }
                 }
-            }
-        });
+            });
+        }
         // 繪製釘子
         // [修复] 增加保底半径，防止 this.width 为 0 时钉子消失
         // [3D-Main M2] 半径区间 [4,8] → [6,11]、除数 60 → 45（视觉 +33%，与 PEG_RADIUS 物理 6→8 同步）
@@ -2857,15 +2857,15 @@ phase_gathering_getRandomPegType() {
         }
 
         
-        lightSources.forEach(ball => {
-            // 优化：只检查垂直距离接近的行，或者直接遍历所有 (钉子数量不多，直接遍历性能没问题)
-            this.pegs.forEach(p => {
-                // 简单的性能优化：如果Y轴距离太远就不用算平方根了
-                if (Math.abs(ball.pos.y - p.pos.y) < LIGHT_RADIUS) {
-                    p.calculateLight(ball.pos, LIGHT_RADIUS);
-                }
+        if (!_is3D) {
+            lightSources.forEach(ball => {
+                this.pegs.forEach(p => {
+                    if (Math.abs(ball.pos.y - p.pos.y) < LIGHT_RADIUS) {
+                        p.calculateLight(ball.pos, LIGHT_RADIUS);
+                    }
+                });
             });
-        });
+        }
         this.specialSlots = this.specialSlots.filter(s => !s.hit);
         // 繪製特殊槽位
         this.specialSlots.forEach(s => s.draw(this.ctx));


### PR DESCRIPTION
## Summary

继续优化 + 复盘双管齐下。

## 性能优化：堵 shadow/light leak

M6.5 加了 entity `.draw()` 的早返回守卫，但 **`peg.drawShadow()` 和 `peg.calculateLight()` 不是通过 .draw() 调的**——直接在 `phase_gathering_update` 里被 forEach 调用。所以这两个方法以及它们所在的 O(N×M) 循环之前依然在跑。

### 修复两层

**1. entities.js**：两个方法加同样的 guard

```js
drawShadow(...)     { if (isSuppressed2DEntities()) return; ... }
calculateLight(...) { if (isSuppressed2DEntities()) return; ... }
```

**2. game_phase.js**：外层循环也 skip

之前 phase_gathering_update 里有 4 个 forEach 循环算阴影/光照：

```
balls × pegs × drawShadow   (~50×60 = 3000 iter)
pegs × drawShadow (global ambient)
balls × pegs × (drawShadow + calculateLight)
balls × pegs × calculateLight (final pass)
```

3D 模式下全部包在 `if (!_is3D)` 里跳过。每帧省 ~9k 无效迭代。

`_is3D` 在函数头读一次 `document.body.classList.contains('render3d-debug')`，整个函数块复用。

## 复盘文档

新增 `docs/3d_main_retro.md`：

- 累计成果（30+ commits / 4400 行 / 删 140MB）
- 完整架构图（Renderer3D → SceneProxy → 各 mesh pool）
- eventBus 自动接线表
- ✅/❌ 验收状态清单
- 性能现状
- 调优历程关键发现（含 shader bug 等踩坑）
- 排序的下一步建议（**真机手动测试** + **RelicCard 接选择面板** 是 ROI 最高的两件）

## Test plan

- [ ] DevTools Performance：phase_gathering_update self-time 应大幅下降
- [ ] 玩法功能不变：切换 3D toggle 关掉后阴影/光照恢复
- [ ] 0 errors（headless 真游戏跑过 ✓）

## 关键 finding（复盘里详细写）

| 优先级 | 项 | 备注 |
| :---: | :--- | :--- |
| 🔥 高 | 真机手动测试 | demo 测不到教程交互、状态保存等真实场景 |
| 🔥 高 | RelicCard 接选择面板 | M5 mesh 还只在 demo 里，没进玩家手里 |
| 中 | 低 HP 红 vignette | 玩家危险时画面边缘脉冲告警 |
| 中 | 暴击全屏白闪 | punch impact |
| 中 | RuneMesh 接符文网格 | M5 另一半 |
| 低 | DoF / Lens flare | 进阶 polish |
| 低 | 删除 RelicCard/RuneMesh | 如不接入就删省 26KB |

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_