### PR TITLE
feat(3d): training ground as 3D mechanism test sandbox (7 scenarios)

### DIFF
--- a/src/systems.js
+++ b/src/systems.js
@@ -810,7 +810,8 @@ const TRAINING_SCENARIOS = {
         { id: 'runeword', name: '符文詞條' },
         { id: 'relic', name: '遺物/精華' },
         { id: 'v2matrix', name: '敵人 V2 矩陣' },
-        { id: 'enemy_v2', name: '敵人 V2 / 美術驗收' }
+        { id: 'enemy_v2', name: '敵人 V2 / 美術驗收' },
+        { id: 'render3d', name: '3D 視覺驗收' }  // [3D-Main 测试沙箱]
     ],
     scenarios: [
         // ── 敵人詞條 ──────────────────────────────────────────────────
@@ -1957,14 +1958,198 @@ const TRAINING_SCENARIOS = {
         // ── 敵人 V2 矩陣（尺寸基底 + 專屬詞條可見性驗收）─────────────
         // 對應文檔 docs/enemy_visual_design_v2.md：
         // 9 種 V2 基底（1×1 / 2×1 / 1×2 / 2×2 / 3×1 / 1×3 / 2×3 / 3×2 / 3×3）
-        // 字段命名與 spawn_trySpawnArchetypes 保持一致：
-        //   - baseArchetype  基底 ID
-        //   - gridCols/gridRows 占格尺寸
-        //   - isWideEnemy    cols >= 2 時為 true
-        //   - affixes        專屬詞條
-        ...buildV2MatrixScenarios()
+        ...buildV2MatrixScenarios(),
+
+        // ── 3D 視覺驗收 / 機制測試區 [3D-Main] ────────────────────────────
+        // 通過試煉場直接驗證 3D 渲染管線的各個模塊，無需從零打教程進戰鬥
+        ...buildRender3DScenarios()
     ]
 };
+
+/**
+ * [3D-Main] 構建 3D 視覺驗收場景。
+ * 每個場景：spawn 真實 Enemy 實例 + 觸發特定 3D 渲染路徑，方便：
+ *   - 截圖對比視覺
+ *   - 驗證 affix 裝飾、Boss 鏡頭、grading 預設等是否正確啟用
+ *   - 找 regression
+ */
+function buildRender3DScenarios() {
+    const arche = [
+        ['residue',     '1×1 普通'],
+        ['bastion',     '3×1 橫棱柱'],
+        ['deflector',   '2×1 斜楔'],
+        ['echoSpire',   '1×2 雙層金字塔'],
+        ['prism',       '1×3 細長棱柱'],
+        ['hive',        '2×3 二十面體'],
+        ['siege',       '3×2 方塊炮塔'],
+        ['gravityWell', '3×3 引力炉心'],
+        ['maw',         '2×2 雙錐口'],
+    ];
+    const scenarios = [
+        // 1) 9 archetype 全展示
+        {
+            id: 'r3d_archetypes',
+            categoryId: 'render3d',
+            name: '9 archetype 全展示',
+            icon: '🎭',
+            desc: '排列所有 9 種 archetype，驗證 EnemyMeshPool 對每種幾何的生成。',
+            setup: (game) => {
+                const eW = game.enemyWidth, eH = game.enemyHeight;
+                const topY = game.combatGridTopY;
+                arche.forEach((it, i) => {
+                    const col = i % 3, row = Math.floor(i / 3);
+                    const x = (col + 1) * eW + eW / 2;
+                    const y = topY + (row + 0.5) * eH * 1.4;
+                    const e = new Enemy(x, y, eW * 0.9, eH * 0.9, 200, 200, 'normal', []);
+                    e.baseArchetype = it[0];
+                    game.enemies.push(e);
+                });
+            }
+        },
+        // 2) 全 affix 装饰展示
+        {
+            id: 'r3d_affixes',
+            categoryId: 'render3d',
+            name: '6 個 affix 裝飾',
+            icon: '✨',
+            desc: 'shield / regen / haste / rage / heal / devour 各一個，看 EnemyMeshPool 的裝飾動畫。',
+            setup: (game) => {
+                const eW = game.enemyWidth, eH = game.enemyHeight;
+                const topY = game.combatGridTopY;
+                const fixes = ['shield', 'regen', 'haste', 'rage', 'heal', 'devour'];
+                fixes.forEach((af, i) => {
+                    const col = i % 3, row = Math.floor(i / 3);
+                    const x = (col + 1) * eW + eW / 2;
+                    const y = topY + (row + 0.5) * eH * 1.4;
+                    game.enemies.push(new Enemy(x, y, eW * 0.9, eH * 0.9, 200, 200, 'normal', [af]));
+                });
+            }
+        },
+        // 3) 阶级展示（normal/elite/boss tier 顏色）
+        {
+            id: 'r3d_tiers',
+            categoryId: 'render3d',
+            name: '阶级 tier 染色',
+            icon: '🎚️',
+            desc: '同 archetype 三个 tier 並排：灰 normal / 青 elite / 金 boss',
+            setup: (game) => {
+                const eW = game.enemyWidth, eH = game.enemyHeight;
+                const y = game.combatGridTopY + eH;
+                const tiers = ['normal', 'elite', 'boss'];
+                tiers.forEach((t, i) => {
+                    const x = (i + 1) * eW + eW / 2;
+                    const e = new Enemy(x, y, eW * 0.9, eH * 0.9, 500, 500, t, []);
+                    e.baseArchetype = 'gravityWell';
+                    if (t === 'boss') { e.bossType = 'test'; e.bossName = '測試'; }
+                    game.enemies.push(e);
+                });
+            }
+        },
+        // 4) Boss 入场镜头特写 + grading 切到 boss 预设
+        {
+            id: 'r3d_boss_intro',
+            categoryId: 'render3d',
+            name: 'Boss 入場 + grading',
+            icon: '👹',
+            desc: '觸發 BOSS_INTRO 鏡頭事件 + 色調切到 boss 預設（紅紫調）。',
+            setup: (game) => {
+                const x = game.width / 2;
+                const y = game.combatGridTopY + 2 * game.enemyHeight;
+                const e = new Enemy(x, y, game.enemyWidth * 2.5, game.enemyHeight * 2.5, 800, 800, 'boss', ['shield']);
+                e.baseArchetype = 'gravityWell';
+                e.bossType = 'ouroboros';
+                e.bossName = '測試 Boss';
+                game.enemies.push(e);
+                // 触发 3D 镜头 + grading 事件
+                if (game.renderer3d && game.renderer3d.cameraEvent) {
+                    game.renderer3d.cameraEvent('BOSS_INTRO');
+                }
+                if (game.eventBus && game.eventBus.emit) {
+                    game.eventBus.emit('boss:spawned', { boss: e });
+                }
+            }
+        },
+        // 5) 粒子爆炸压力测试
+        {
+            id: 'r3d_particle_stress',
+            categoryId: 'render3d',
+            name: '粒子爆炸壓測',
+            icon: '💥',
+            desc: '連發 500 個粒子，驗證 GPU 粒子池容量上限 + bloom 表現。',
+            setup: (game) => {
+                if (!game.renderer3d || !game.renderer3d.proxy || !game.renderer3d.proxy.spawnParticles) return;
+                const cx = game.width / 2, cy = game.combatGridTopY + 200;
+                const colors = [0xfbbf24, 0xef4444, 0x60a5fa, 0xfacc15, 0xa3e635, 0xc084fc];
+                for (let i = 0; i < 25; i++) {
+                    const dx = (Math.random() - 0.5) * 200;
+                    const dy = (Math.random() - 0.5) * 200;
+                    game.renderer3d.proxy.spawnParticles({
+                        x: cx + dx, y: cy + dy,
+                        color: colors[i % colors.length],
+                        mode: ['spark', 'ember', 'shard'][i % 3],
+                        count: 20, size: 5, lifetime: 1.2, spread: 1.5, speed: 18,
+                    });
+                }
+            }
+        },
+        // 6) Grading 循環演示
+        {
+            id: 'r3d_grading_cycle',
+            categoryId: 'render3d',
+            name: 'Grading 預設循環',
+            icon: '🎨',
+            desc: '每 2 秒切換一個 grading 預設（meta → gathering → combat → boss → gameover），觀察色調呼吸。',
+            setup: (game) => {
+                if (!game.renderer3d || !game.renderer3d.postfx || !game.renderer3d.postfx.setGradingPreset) return;
+                const presets = ['meta', 'gathering', 'combat', 'boss', 'gameover'];
+                let i = 0;
+                // 清掉旧的 timer
+                if (game._r3dGradingTimer) clearInterval(game._r3dGradingTimer);
+                game._r3dGradingTimer = setInterval(() => {
+                    if (!game.renderer3d) {
+                        clearInterval(game._r3dGradingTimer);
+                        game._r3dGradingTimer = null;
+                        return;
+                    }
+                    const p = presets[i % presets.length];
+                    game.renderer3d.postfx.setGradingPreset(p);
+                    console.log('[Training/R3D] grading →', p);
+                    i++;
+                }, 2000);
+                // 顺便放个测试敌人当锚定
+                const e = new Enemy(game.width / 2, game.combatGridTopY + 2 * game.enemyHeight,
+                    game.enemyWidth * 2, game.enemyHeight * 2, 500, 500, 'elite', []);
+                e.baseArchetype = 'hive';
+                game.enemies.push(e);
+            }
+        },
+        // 7) 镜头震动测试
+        {
+            id: 'r3d_camera_shake',
+            categoryId: 'render3d',
+            name: '鏡頭事件全測',
+            icon: '📷',
+            desc: 'IMPACT / KILLED / HIT_PLAYER / BOSS_INTRO 依次觸發，看相機反應。',
+            setup: (game) => {
+                if (!game.renderer3d || !game.renderer3d.cameraEvent) return;
+                const events = [
+                    ['IMPACT', { intensity: 1.0 }, 0],
+                    ['IMPACT', { intensity: 2.0 }, 800],
+                    ['KILLED', { intensity: 1.0 }, 1600],
+                    ['HIT_PLAYER', { intensity: 1.5 }, 2400],
+                    ['BOSS_INTRO', {}, 3200],
+                ];
+                events.forEach(([type, payload, delay]) => {
+                    setTimeout(() => {
+                        if (game.renderer3d) game.renderer3d.cameraEvent(type, payload);
+                        console.log('[Training/R3D] cameraEvent →', type);
+                    }, delay);
+                });
+            }
+        },
+    ];
+    return scenarios;
+}
 
 /**
  * [V2 可見性驗收] 構建敵人 V2 矩陣演示場景。


### PR DESCRIPTION
## Summary

按你的提议，把试炼场（TrainingGround）扩成"3D 机制测试区"。新加一个 `render3d` 分类，7 个场景，每个隔离一个 3D 功能模块，方便:
- 我用 headless 自动跑（不用每次写注入脚本）
- 你手动玩验证（试炼场已有 UI 按钮）
- 找 regression / 截图对比

## 7 个测试场景

| ID | 名称 | 测什么 |
| :--- | :--- | :--- |
| `r3d_archetypes` | 9 archetype 全展示 | EnemyMeshPool 几何生成 |
| `r3d_affixes` | 6 affix 装饰 | shield/regen/haste/rage/heal/devour 动画 |
| `r3d_tiers` | normal/elite/boss tier | 阶级颜色染色 |
| `r3d_boss_intro` | Boss 入场 + grading | 镜头 BOSS_INTRO + 红紫 boss 预设 |
| `r3d_particle_stress` | 500 粒子爆炸 | GPU 池容量 + bloom |
| `r3d_grading_cycle` | 5 预设循环 | 阶段 grading 切换呼吸 |
| `r3d_camera_shake` | 镜头事件全测 | IMPACT/KILLED/HIT_PLAYER/BOSS_INTRO 弹簧 |

## 怎么用

游戏内：主页 → 真理之书 → 试炼场 → 右侧分类切到"3D 視覺驗收" → 点任一场景按钮 → 自动 spawn + 触发

自动化（用 Playwright）：
```js
await page.evaluate(() => {
    game.trainingGround.loadScenario('r3d_archetypes');
});
```

## 与现有架构契合

TrainingGround 已有完整 `scenarios[]` 注册表 + `setup(game)` callback 模式。新增的 7 个场景是 plug-in，0 破坏既有场景。

## Test plan

- [ ] 启动游戏 → 进试炼场 → 看到新分类 "3D 視覺驗收"
- [ ] 点击 r3d_archetypes → 9 个不同 mesh 排开
- [ ] 点击 r3d_grading_cycle → 画面色调每 2 秒换一次
- [ ] 点击 r3d_camera_shake → 相机依次震动
- [ ] 0 console 错误

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_