### PR TITLE
feat(3d/M4): critical hit / big damage screen flash punch

### DIFF
--- a/src/render3d/CameraController.js
+++ b/src/render3d/CameraController.js
@@ -55,6 +55,7 @@ export class CameraController {
         this.chromaticBoost  = 0;   // 色散增量
         this.bloomBoost      = 0;   // bloom strength 增量
         this.exposureBoost   = 0;   // tonemap exposure 增量（罕用）
+        this.flashBoost      = 0;   // [M4] 全屏白闪 0..1，每帧快速衰减
 
         // ---- 弹簧常数 ----
         this.K_SHAKE = 90;   // 越大恢复越快
@@ -67,6 +68,7 @@ export class CameraController {
         this.DECAY_CHROMATIC  = 4.5;
         this.DECAY_BLOOM      = 2.2;
         this.DECAY_EXPOSURE   = 3.0;
+        this.DECAY_FLASH      = 7.0;   // 白闪要快进快出（~140ms 触感）
 
         // ---- 状态读取（仅 debug 用） ----
         this.lastEvent = 'IDLE';
@@ -134,6 +136,7 @@ export class CameraController {
         this.distortionBoost = Math.max(0, this.distortionBoost - this.DECAY_DISTORTION * h);
         this.chromaticBoost  = Math.max(0, this.chromaticBoost  - this.DECAY_CHROMATIC  * h);
         this.bloomBoost      = Math.max(0, this.bloomBoost      - this.DECAY_BLOOM      * h);
+        this.flashBoost      = Math.max(0, this.flashBoost      - this.DECAY_FLASH     * h);
         this.exposureBoost   = Math.max(0, this.exposureBoost   - this.DECAY_EXPOSURE   * h);
     }
 
@@ -222,6 +225,16 @@ export class CameraController {
     }
 
     /**
+     * [M4] 暴击/大伤害瞬时白闪。强度 0.3 = 轻闪，0.6 = 强闪。
+     * 配合 IMPACT 一起触发能营造"punch"感。
+     * @param {number} intensity 0..1
+     */
+    triggerFlash(intensity = 0.4) {
+        this.lastEvent = 'FLASH';
+        this.flashBoost = Math.max(this.flashBoost, Math.min(1, intensity));
+    }
+
+    /**
      * 瞄准位移目标。归一化坐标 [-1, +1]。 update 内 lerp。
      */
     setAim(normX, normY) {
@@ -239,11 +252,13 @@ export class CameraController {
             chromatic:  this.chromaticBoost,
             bloom:      this.bloomBoost,
             exposure:   this.exposureBoost,
+            flash:      this.flashBoost,
         };
     }
 
     /** 完全归零（debug / 切场景用） */
     reset() {
+        this.flashBoost = 0;
         this.shakeOffset.set(0, 0, 0);
         this.shakeVel.set(0, 0, 0);
         this.fovOffset = 0;

--- a/src/render3d/PostFX.js
+++ b/src/render3d/PostFX.js
@@ -149,6 +149,9 @@ const VIGNETTE_GRAIN_SHADER = {
         uShadowTint:       { value: new THREE.Color(0.04, 0.08, 0.18) }, // 冷蓝阴影
         uHighlightTint:    { value: new THREE.Color(0.20, 0.12, 0.04) }, // 暖橙高光
         uGradingStrength:  { value: 0.32 },   // grading 混入强度
+        // [M4] 暴击/大伤害瞬时白闪强度（0..1），由 CameraController 每帧推送，自然衰减
+        uFlash:            { value: 0.0 },
+        uFlashColor:       { value: new THREE.Color(1.0, 0.98, 0.92) }, // 略偏暖白
     },
     vertexShader: /* glsl */`
         varying vec2 vUv;
@@ -169,6 +172,8 @@ const VIGNETTE_GRAIN_SHADER = {
         uniform vec3  uShadowTint;
         uniform vec3  uHighlightTint;
         uniform float uGradingStrength;
+        uniform float uFlash;
+        uniform vec3  uFlashColor;
         varying vec2 vUv;
 
         float hash21(vec2 p) {
@@ -208,6 +213,14 @@ const VIGNETTE_GRAIN_SHADER = {
             // === Film grain ===
             float grain = hash21(vUv * uResolution + uTime * 137.0) - 0.5;
             col += grain * uGrainAmount;
+
+            // === [M4] Critical flash overlay ===
+            // uFlash 由 CameraController 在大伤害/暴击事件时拉高到 0.3-0.6，每帧衰减回 0。
+            // 用 mix 而非 add，避免完全过曝吃掉颜色信息；中心稍弱，边缘稍强（vignette-aware）。
+            if (uFlash > 0.001) {
+                float flashAmt = uFlash * (0.75 + (1.0 - vig) * 0.25);
+                col = mix(col, uFlashColor, clamp(flashAmt, 0.0, 1.0));
+            }
 
             gl_FragColor = vec4(col, 1.0);
         }
@@ -389,6 +402,11 @@ export class PostFX {
     /** 调节 bloom 强度（剧烈事件时短暂拉高） */
     setBloomStrength(s) {
         this.bloomPass.strength = s;
+    }
+
+    /** [M4] 设置全屏白闪强度 0..1（每帧由 CameraController 推送 + 自然衰减） */
+    setFlash(amt) {
+        this.vignettePass.uniforms.uFlash.value = Math.max(0, Math.min(1, amt));
     }
 
     dispose() {

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -194,6 +194,10 @@ export class Renderer3D {
             this.postfx.setBloomStrength(this._fxBaselineBloom + fx.bloom);
             // exposure 通过 renderer.toneMappingExposure 控制（OutputPass 读取）
             this.renderer.toneMappingExposure = 1.0 + fx.exposure;
+            // [M4] 全屏白闪
+            if (typeof this.postfx.setFlash === 'function') {
+                this.postfx.setFlash(fx.flash || 0);
+            }
         }
 
         if (this.postfx) {
@@ -237,6 +241,9 @@ export class Renderer3D {
                 case 'AIM':
                     this.cameraController.setAim(payload.x ?? 0, payload.y ?? 0);
                     break;
+                case 'FLASH':
+                    this.cameraController.triggerFlash(payload.intensity ?? 0.4);
+                    break;
                 default:
                     // 未知类型不报错，便于上游平滑扩展
                     break;
@@ -262,6 +269,12 @@ export class Renderer3D {
             else if (dmg >= 30) intensity = 0.42;
             if (data.killed) intensity *= 1.4;
             this.cameraEvent('IMPACT', { intensity });
+
+            // [M4] 大伤害 / 击杀 → 全屏白闪 punch
+            if (dmg >= 150 || (data.killed && dmg >= 60)) {
+                const flashAmt = Math.min(0.6, 0.25 + dmg / 600);
+                this.cameraEvent('FLASH', { intensity: flashAmt });
+            }
 
             // [M6] 击中处撒 spark 粒子；颜色按伤害属性取色（fallback 黄白）
             const proxy = this.proxy;
@@ -302,6 +315,8 @@ export class Renderer3D {
         };
         const onBossDefeated = (data) => {
             this.cameraEvent('IMPACT', { intensity: 1.4 });
+            // [M4] Boss 倒下：强白闪
+            this.cameraEvent('FLASH', { intensity: 0.55 });
             // [M6] Boss 击败：大规模 smoke + ember 爆开
             const proxy = this.proxy;
             if (proxy && proxy.spawnParticles && data && data.boss && data.boss.pos) {

--- a/src/systems.js
+++ b/src/systems.js
@@ -2147,6 +2147,25 @@ function buildRender3DScenarios() {
                 });
             }
         },
+        // 8) 白闪测试
+        {
+            id: 'r3d_flash_test',
+            categoryId: 'render3d',
+            name: '白閃 punch 測試',
+            icon: '⚡',
+            desc: '依次觸發 0.3 / 0.5 / 0.7 三档 FLASH 強度，每隔 800ms 一次，看暴擊白閃手感。',
+            setup: (game) => {
+                if (!game.renderer3d || !game.renderer3d.cameraEvent) return;
+                [0.3, 0.5, 0.7].forEach((amt, i) => {
+                    setTimeout(() => {
+                        if (game.renderer3d) {
+                            game.renderer3d.cameraEvent('FLASH', { intensity: amt });
+                            console.log('[Training/R3D] FLASH →', amt);
+                        }
+                    }, i * 800);
+                });
+            }
+        },
     ];
     return scenarios;
 }


### PR DESCRIPTION
## Summary

继续 M4 polish：**暴击 / 大伤害全屏白闪 punch**——不自动合并，等你 review。

## 实现

### PostFX 加 flash uniform

`VignetteGrainShader` 在 grading + vignette + grain 之后再过一次 mix：

```glsl
uniform float uFlash;        // 0..1, by CameraController
uniform vec3  uFlashColor;   // 默认偏暖白 (1.0, 0.98, 0.92)
...
if (uFlash > 0.001) {
    float flashAmt = uFlash * (0.75 + (1.0 - vig) * 0.25);
    col = mix(col, uFlashColor, clamp(flashAmt, 0.0, 1.0));
}
```

特性：
- **快进快出**：DECAY = 7.0/sec → 完整衰减 ~140ms（punch 感）
- **vignette-aware**：边缘比中心略强（"冲击波从外面来"的感觉）
- **暖白而非纯白**：和炼金主题色调匹配，不刺眼
- **最高 0.6**：scene + 60% 白 mix；不会盖死颜色信息

## 触发链

| 事件 | 触发 flash 强度 |
| :--- | :---: |
| `damage:dealt` damage ≥ 150 | `min(0.6, 0.25 + dmg/600)` |
| `damage:dealt` 击杀 && damage ≥ 60 | 同上 |
| `boss:defeated` | 固定 0.55 |
| 手动 `renderer3d.cameraEvent('FLASH', {intensity})` | 任意 |

CameraController.triggerFlash + getPostFXState 扩展；Renderer3D 每帧推到 PostFX uniform。

## 试炼场新场景

`r3d_flash_test`（"白閃 punch 測試"）：依次触发 0.3 / 0.5 / 0.7 三档强度，每隔 800ms 一次。在游戏内 真理之书 → 试炼场 → 3D 视觉验收 即可点。

## Test plan

- [ ] 进战斗 → 大伤害（≥150）→ 看到瞬时白闪
- [ ] 击杀敌人（damage ≥60）→ 白闪
- [ ] Boss 倒下 → 强白闪（0.55）
- [ ] 不刺眼，140ms 内衰减完
- [ ] 在边缘略强于中心
- [ ] 试炼场 r3d_flash_test → 800ms 间隔依次 3 档强度

## Smoke

headless 真游戏验证 0 错误。meta 阶段下视觉差异微弱（3D 背景本就暗），战斗场景下应该明显。

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_