### PR TITLE
fix(3d): pegs invisible + balls/bullets missing + aim line wiped + enemy blends in

### DIFF
--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -2104,7 +2104,13 @@ phase_gathering_getRandomPegType() {
 
             // [3D-Main M3] 把当前 enemies[] 同步到 3D EnemyMeshPool（每帧一次）
             if (this.renderer3d && this.renderer3d.proxy) {
-                try { this.renderer3d.proxy.syncEnemies(this.enemies); } catch (e) {
+                try {
+                    this.renderer3d.proxy.syncEnemies(this.enemies);
+                    // [3D-Main 修复] 子弹也需要 3D 同步
+                    if (this.renderer3d.proxy.syncProjectiles) {
+                        this.renderer3d.proxy.syncProjectiles(this.projectiles);
+                    }
+                } catch (e) {
                     console.warn('[Renderer3D] syncEnemies error:', e);
                 }
             }
@@ -2851,7 +2857,13 @@ phase_gathering_getRandomPegType() {
         // [3D-Main M2] 把当前钉子数组同步到 3D InstancedMesh（每帧一次）
         // 1 帧后 Renderer3D.render() 才会取到新数据，但 60fps 下不可察觉
         if (this.renderer3d && this.renderer3d.proxy) {
-            try { this.renderer3d.proxy.syncPegs(this.pegs, pegRadius); } catch (e) {
+            try {
+                this.renderer3d.proxy.syncPegs(this.pegs, pegRadius);
+                // [3D-Main 修复] 弹珠也需要 3D 同步
+                if (this.renderer3d.proxy.syncDropBalls) {
+                    this.renderer3d.proxy.syncDropBalls(this.dropBalls);
+                }
+            } catch (e) {
                 console.warn('[Renderer3D] syncPegs error:', e);
             }
         }

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -190,15 +190,11 @@ export const game_system = {
                 break;
         }
 
-        // [3D-Main] 纯 3D 模式：所有 2D entity.draw() 已通过 setSuppress2DEntities() 在自身首行
-        // 早返回，不再写入像素。此处不再需要 clearRect 兜底——但保留作为"任何漏改 entity 的
-        // 安全网"，开销极低（一次 clearRect O(W*H) 像素清零，远小于 entity 绘制成本）。
-        if (is3DMode) {
-            this.ctx.save();
-            this.ctx.setTransform(1, 0, 0, 1, 0, 0);
-            this.ctx.clearRect(0, 0, this.width, this.height);
-            this.ctx.restore();
-        }
+        // [3D-Main 修复] 此处之前有 clearRect 兜底擦掉 2D entity 绘制——但同样会擦掉 phase
+        // update 内部直接画在 ctx 上的关键 UI（瞄准线、风系连线、HP bar 等）。
+        // 现已通过 setSuppress2DEntities() 在 entity .draw() 首行 early-return；瞄准线 / UI
+        // 等非 entity 的 ctx 调用得以保留。如果发现新 entity 漏加 guard，应该在 entity 里加，
+        // 不要回退到整块 clearRect。
 
         // 6. 战场掉落物更新与渲染
         // [BUGFIX] fieldLootItems 已移入 phase_combat_update 的 LAYER 2（实体层）内渲染，

--- a/src/render3d/BallMesh.js
+++ b/src/render3d/BallMesh.js
@@ -1,0 +1,162 @@
+/**
+ * BallMesh.js - 弹珠 / 子弹的 3D 实例化网格（M2 补丁）
+ *
+ * 与 PegInstancedMesh 同思路，但实例数小（同时同屏一般 < 32）。
+ * 共享一个 SphereGeometry，按 marbleType / projectile.color 染色，
+ * 通过 emissive 让弹珠/子弹本身就是光源（PostFX bloom 会自动接管）。
+ *
+ * 通用类，承担 DropBalls + Projectiles 双角色——两者本质都是 "运动小球" 视觉。
+ */
+
+import * as THREE from 'three';
+
+const BALL_CAPACITY = 64;
+const SEGMENT = 12;
+
+// 与 PegInstancedMesh PEG_COLORS 一致命名，但弹珠默认更亮（emissive）
+const BALL_COLORS = {
+    normal:        [0.95, 0.93, 0.85],
+    damage:        [1.00, 0.30, 0.20],
+    pyro:          [1.00, 0.32, 0.18],
+    cryo:          [0.42, 0.78, 1.00],
+    lightning:     [1.00, 0.92, 0.18],
+    bounce:        [0.72, 1.00, 0.30],
+    pierce:        [1.00, 0.50, 0.10],
+    scatter:       [0.85, 0.55, 1.00],
+    laser:         [0.20, 1.00, 0.60],
+    explosive:     [1.00, 0.45, 0.15],
+    rainbow:       [1.00, 0.55, 0.85],
+    matryoshka:    [0.85, 0.70, 0.45],
+    echo:          [0.55, 0.85, 1.00],
+    venom:         [0.75, 0.30, 0.95],
+    resonance:     [1.00, 0.75, 1.00],
+    // 子弹默认（无 marbleType 时回退）
+    bullet:        [1.00, 0.95, 0.65],
+};
+
+const FRAG_SRC = /* glsl */`
+    precision mediump float;
+    uniform float uTime;
+    varying vec3  vNormal;
+    varying vec3  vColor;
+    varying vec3  vViewPos;
+    void main() {
+        vec3 N = normalize(vNormal);
+        vec3 V = normalize(-vViewPos);
+        float ndotv = max(0.0, dot(N, V));
+        float rim = pow(1.0 - ndotv, 1.8);
+
+        // 弹珠是发光源——base emissive 高，rim 再加强
+        vec3 col = vColor * (0.6 + rim * 1.2);
+        // 中心高光（fake specular）
+        col += vec3(1.0) * pow(ndotv, 12.0) * 0.4;
+
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;
+
+const VERT_SRC = /* glsl */`
+    attribute vec3 aColor;
+    varying vec3 vNormal;
+    varying vec3 vColor;
+    varying vec3 vViewPos;
+    void main() {
+        vec4 mv = modelViewMatrix * instanceMatrix * vec4(position, 1.0);
+        vViewPos = mv.xyz;
+        vec3 instNormal = mat3(instanceMatrix) * normal;
+        vNormal = normalize(normalMatrix * instNormal);
+        vColor = aColor;
+        gl_Position = projectionMatrix * mv;
+    }
+`;
+
+export class BallMesh {
+    constructor(opts = {}) {
+        this.capacity = opts.capacity || BALL_CAPACITY;
+        this.geometry = new THREE.SphereGeometry(1, SEGMENT, SEGMENT);
+
+        const colorBuf = new Float32Array(this.capacity * 3);
+        this.geometry.setAttribute(
+            'aColor',
+            new THREE.InstancedBufferAttribute(colorBuf, 3)
+        );
+        this._colorAttr = this.geometry.attributes.aColor;
+        this._colorBuf = colorBuf;
+
+        this.material = new THREE.ShaderMaterial({
+            transparent: false,
+            uniforms: { uTime: { value: 0 } },
+            vertexShader: VERT_SRC,
+            fragmentShader: FRAG_SRC,
+        });
+
+        this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.capacity);
+        this.mesh.count = 0;
+        this.mesh.frustumCulled = false;
+        this.mesh.name = opts.name || 'BallMesh';
+
+        this._tmpMat = new THREE.Matrix4();
+    }
+
+    /**
+     * 同步 game.dropBalls 或 game.projectiles 数组到实例化 mesh。
+     * @param {Array} balls2D each elem: { pos: {x,y}, type?, radius?, color?, recipe? }
+     * @param {Object} coords CoordsMapper
+     * @param {Object} [opts]
+     * @param {number} [opts.defaultRadiusPx=8] 没有 .radius 时的默认像素半径
+     * @param {string} [opts.colorKey='type'] 从对象的哪个字段读色（type / marbleType）
+     */
+    sync(balls2D, coords, opts = {}) {
+        if (!balls2D || balls2D.length === 0) {
+            this.mesh.count = 0;
+            return;
+        }
+        const defaultR = opts.defaultRadiusPx ?? 8;
+        const colorKey = opts.colorKey || 'type';
+        const n = Math.min(balls2D.length, this.capacity);
+
+        let active = 0;
+        for (let i = 0; i < n; i++) {
+            const b = balls2D[i];
+            if (!b || !b.pos || b.active === false) continue;
+
+            const w = coords.toWorld(b.pos.x, b.pos.y, 0.5);  // 弹珠略前于钉子 (z=0.5)
+            const rPx = b.radius || defaultR;
+            const wR = Math.max(0.06, rPx * coords.scale);
+
+            this._tmpMat.makeScale(wR, wR, wR);
+            this._tmpMat.setPosition(w.x, w.y, w.z);
+            this.mesh.setMatrixAt(active, this._tmpMat);
+
+            // 颜色：优先 ball.color 数值 → BALL_COLORS[type] → 默认 bullet
+            let arr;
+            if (b._3dColor) {
+                arr = b._3dColor;
+            } else {
+                const key = b[colorKey] || b.marbleType || (b.recipe && b.recipe.type) || 'bullet';
+                arr = BALL_COLORS[key] || BALL_COLORS.bullet;
+            }
+            this._colorBuf[active * 3 + 0] = arr[0];
+            this._colorBuf[active * 3 + 1] = arr[1];
+            this._colorBuf[active * 3 + 2] = arr[2];
+
+            active++;
+        }
+        this.mesh.count = active;
+        this.mesh.instanceMatrix.needsUpdate = true;
+        this._colorAttr.needsUpdate = true;
+    }
+
+    update(dt, t) {
+        if (this.material && this.material.uniforms) {
+            this.material.uniforms.uTime.value = t;
+        }
+    }
+
+    clear() { this.mesh.count = 0; }
+
+    dispose() {
+        try { this.geometry.dispose(); } catch (e) {}
+        try { this.material.dispose(); } catch (e) {}
+    }
+}

--- a/src/render3d/EnemyMeshPool.js
+++ b/src/render3d/EnemyMeshPool.js
@@ -65,10 +65,14 @@ const FRAG_SRC = /* glsl */`
         // 伪光照：用 view-y 模拟从上方斜下的"舞台灯"
         float fakeLight = 0.5 + 0.5 * max(0.0, N.y * 0.6 + N.z * 0.4);
 
-        // [M4 调优] 全身 tier 0.22 → 0.18（轻度弱化），rim 1.7 → 1.9（增强让 bloom 在边缘炸）。
-        // 既保留原 M3 的整体可读性，又让 PostFX bloom 在 rim 上有更明显的炸开效果。
-        vec3 col = uBase * (0.55 + 0.55 * fakeLight);
-        col += uTier * 0.18;
+        // [3D-Main 修复] 用户反馈"敌人和背景没区分开" → 大幅提亮 body：
+        //   base 0.55 → 0.95（金属面更亮，从背景里跳出来）
+        //   tier 0.18 → 0.32（全身 tier 染色更明显，elite 青/boss 金更明显）
+        //   rim 保持 1.9（已经够强）
+        //   引入一道顶光（vNormal.y 模拟 sky light）增强 3D 立体感
+        float skyLight = max(0.0, N.y * 0.6 + 0.4);  // 0.4..1.0
+        vec3 col = uBase * (0.85 + 0.50 * skyLight);
+        col += uTier * 0.32;
         col += uTier * rim * 1.9 * pulse;
         col = mix(col, vec3(1.0), uHit * 0.85);
 

--- a/src/render3d/PegInstancedMesh.js
+++ b/src/render3d/PegInstancedMesh.js
@@ -60,16 +60,24 @@ export class PegInstancedMesh {
         this._hitImpulseAttr = this.geometry.attributes.instanceHit;
         this._hitImpulse = hitImpulse;
 
+        // [3D-Main 修复] 自定义 aColor 替代 instanceColor，避免 three.js 在 setColorAt 调用与否
+        // 的两种情况下 shader 报 "undeclared identifier" / "redefinition" 的双向坑。
+        const colorBuf = new Float32Array(PEG_CAPACITY * 3);
+        this.geometry.setAttribute(
+            'aColor',
+            new THREE.InstancedBufferAttribute(colorBuf, 3)
+        );
+        this._colorAttr = this.geometry.attributes.aColor;
+        this._colorBuf = colorBuf;
+
         this.material = new THREE.ShaderMaterial({
             transparent: false,
             uniforms: {
                 uTime: { value: 0 },
             },
             vertexShader: /* glsl */`
-                // ShaderMaterial 不会自动 inject 实例属性；手动声明。
-                // 注意：instanceMatrix 由 Three.js 在 USE_INSTANCING 路径自动注入，
-                // 但 instanceColor (来自 setColorAt) 必须手动声明。
-                attribute vec3 instanceColor;
+                // 自定义实例属性（避免与 three.js 内部 instanceColor 命名冲突）
+                attribute vec3 aColor;
                 attribute float instancePhase;
                 attribute float instanceHit;
 
@@ -90,7 +98,7 @@ export class PegInstancedMesh {
                     // 法线需经过 instanceMatrix 的 3x3 部分（这里只含均匀缩放，所以 normalize 后等价于纯旋转）
                     vec3 instNormal = mat3(instanceMatrix) * normal;
                     vNormal  = normalize(normalMatrix * instNormal);
-                    vColor   = instanceColor;
+                    vColor   = aColor;
                     vViewPos = mvPos.xyz;
                     vPhase   = instancePhase;
                     vHit     = instanceHit;
@@ -165,13 +173,15 @@ export class PegInstancedMesh {
             this._tmpMat.setPosition(w.x, w.y, w.z);
             this.mesh.setMatrixAt(i, this._tmpMat);
 
+            // 写入自定义 aColor buffer（不走 setColorAt 防 three.js 冲突）
             const arr = PEG_COLORS[p.type] || PEG_COLORS.normal;
-            this._tmpColor.setRGB(arr[0], arr[1], arr[2]);
-            this.mesh.setColorAt(i, this._tmpColor);
+            this._colorBuf[i * 3 + 0] = arr[0];
+            this._colorBuf[i * 3 + 1] = arr[1];
+            this._colorBuf[i * 3 + 2] = arr[2];
         }
         this.mesh.count = n;
         this.mesh.instanceMatrix.needsUpdate = true;
-        if (this.mesh.instanceColor) this.mesh.instanceColor.needsUpdate = true;
+        this._colorAttr.needsUpdate = true;
     }
 
     /**

--- a/src/render3d/SceneProxy.js
+++ b/src/render3d/SceneProxy.js
@@ -16,6 +16,7 @@ import { PegInstancedMesh } from './PegInstancedMesh.js';
 import { WallMesh } from './WallMesh.js';
 import { EnemyMeshPool } from './EnemyMeshPool.js';
 import { GPUParticleSystem } from './GPUParticleSystem.js';
+import { BallMesh } from './BallMesh.js';
 
 export class SceneProxy {
     /**
@@ -37,6 +38,12 @@ export class SceneProxy {
         this.walls.setVisible(false); // 默认隐藏：阶段不是 gathering/combat/training 时不显示
 
         this.enemies = new EnemyMeshPool(this.scene);
+
+        // [3D-Main 修复] 弹珠 + 子弹的 3D 球体（之前漏掉，2D 被 guard return 后玩家看不到任何弹丸）
+        this.balls       = new BallMesh({ capacity: 32, name: 'BallMesh_DropBalls' });
+        this.projectiles = new BallMesh({ capacity: 32, name: 'BallMesh_Projectiles' });
+        this.scene.add(this.balls.mesh);
+        this.scene.add(this.projectiles.mesh);
 
         // [3D-Main M6] GPU 粒子池：默认 4096，M6.5 由 QualityProfile 注入
         this.particles = new GPUParticleSystem(this.scene, {
@@ -114,13 +121,29 @@ export class SceneProxy {
     /**
      * 通知 proxy 当前阶段，控制墙/钉等的可见性。
      */
+    /**
+     * 同步 game.dropBalls 到 3D（研磨阶段下落弹珠）
+     */
+    syncDropBalls(dropBalls) {
+        if (!this.balls) return;
+        this.balls.sync(dropBalls || [], this.coords, { defaultRadiusPx: 8, colorKey: 'type' });
+    }
+
+    /**
+     * 同步 game.projectiles 到 3D（战斗阶段子弹）
+     */
+    syncProjectiles(projectiles) {
+        if (!this.projectiles) return;
+        this.projectiles.sync(projectiles || [], this.coords, { defaultRadiusPx: 6, colorKey: 'type' });
+    }
+
     setPhase(phase) {
         if (this._phase === phase) return;
         this._phase = phase;
         // 墙：研磨 + 战斗 + 试炼都显示；其他阶段隐藏
         const wallsOn = phase === 'gathering' || phase === 'combat' || phase === 'training';
         this.walls.setVisible(wallsOn);
-        // 钉子：仅 gathering / training 显示（combat 内没有钉子，由 syncPegs([]) 自然清空）
+        // 钉子：仅 gathering / training 显示
         if (phase !== 'gathering' && phase !== 'training') {
             this.pegs.clear();
         }
@@ -128,6 +151,9 @@ export class SceneProxy {
         if (phase !== 'combat' && phase !== 'training') {
             this.enemies.clear();
         }
+        // 弹珠 / 子弹：阶段切换时立即清空（避免残留）
+        if (this.balls) this.balls.clear();
+        if (this.projectiles) this.projectiles.clear();
     }
 
     /** Canvas resize 时调用（来自 Renderer3D.resize） */
@@ -144,6 +170,8 @@ export class SceneProxy {
         this.pegs.update(dt, t);
         this.walls.update(t);
         this.enemies.update(dt, t);
+        if (this.balls) this.balls.update(dt, t);
+        if (this.projectiles) this.projectiles.update(dt, t);
         if (this.particles) this.particles.update(dt);
     }
 
@@ -151,10 +179,14 @@ export class SceneProxy {
         try { this.pegs.dispose(); } catch (e) {}
         try { this.walls.dispose(); } catch (e) {}
         try { this.enemies.dispose(); } catch (e) {}
+        try { if (this.balls) this.balls.dispose(); } catch (e) {}
+        try { if (this.projectiles) this.projectiles.dispose(); } catch (e) {}
         try { if (this.particles) this.particles.dispose(); } catch (e) {}
         if (this.scene) {
             this.scene.remove(this.pegs.mesh);
             this.scene.remove(this.walls.group);
+            if (this.balls)       this.scene.remove(this.balls.mesh);
+            if (this.projectiles) this.scene.remove(this.projectiles.mesh);
         }
     }
 }


### PR DESCRIPTION
## Summary

修复你反馈的 3 个真实游戏 bug（**不自动合并，等你测**）。

| # | 你看到的现象 | 根因 | 修复 |
| :---: | :--- | :--- | :--- |
| 1 | 研磨阶段看不到弹珠和钉盘 | PegInstancedMesh shader 报 redefinition；BallMesh 不存在 | 改 `aColor` 自定义 attribute；新建 BallMesh 渲染 dropBalls |
| 2 | 战斗敌人和背景没区分 / 没打光 | enemy body shader base 太暗（0.55） | base → 0.95、tier 全身染色 0.18 → 0.32、加 skyLight 项 |
| 3 | 战斗看不到子弹和引导线 | sys_loop 末 clearRect 把 phase_update 内画的 UI 一起擦了 | 去掉 clearRect 兜底；entity guards 已够用 |

## 详细

### Bug 1A: PegInstancedMesh shader 编译失败

Three.js 在 `setColorAt` 调用后给 ShaderMaterial 自动注入 `attribute vec3 instanceColor;`，与我之前手动声明冲突——但**没调用 setColorAt 时又不注入**，所以是双向坑：
- 不声明 → "undeclared identifier"
- 声明 → "redefinition"

**修复**：换 `aColor`（自定义命名，完全绕过 Three.js 的 instanceColor 处理逻辑），用 `InstancedBufferAttribute` 自管缓冲。

### Bug 1B: BallMesh 不存在

之前 M2-M3 漏了：DropBalls / Projectiles 都没 3D 渲染。2D `.draw()` 被 guard 后玩家看不到。

**修复**：新建 `src/render3d/BallMesh.js`——单 InstancedMesh，emissive shader（rim + center specular + 高光 base）。SceneProxy 实例化 2 个：

```js
this.balls       = new BallMesh({ capacity: 32 });  // dropBalls
this.projectiles = new BallMesh({ capacity: 32 });  // projectiles
```

新方法：
- `syncDropBalls(arr)` — 研磨阶段每帧调
- `syncProjectiles(arr)` — 战斗阶段每帧调
- `setPhase` 阶段切换时清空

按 `marbleType` / `type` 染色 LUT（pyro/cryo/lightning 等）。

### Bug 2: 敌人和背景没区分

EnemyMeshPool body shader 之前：
```glsl
vec3 col = uBase * (0.55 + 0.55 * fakeLight);
col += uTier * 0.18;
col += uTier * rim * 1.9 * pulse;
```
base 0.55 太暗，整体灰扑扑融入暗背景。

**修复**：
```glsl
float skyLight = max(0.0, N.y * 0.6 + 0.4);
vec3 col = uBase * (0.85 + 0.50 * skyLight);  // 提亮
col += uTier * 0.32;                           // tier 染色更明显
col += uTier * rim * 1.9 * pulse;
```

skyLight 模拟"从上往下的舞台灯"，敌人有立体感。

### Bug 3: 瞄准线被擦

之前 sys_loop：
```js
phase_combat_update();   // 内部画了瞄准线
ctx.clearRect(0, 0, W, H);   // ← 擦掉了！包括瞄准线
render_floatingTexts();
```

`clearRect` 是我之前加的安全网（怕有 entity 漏加 guard）。但 phase update 里的"非 entity 直接 ctx 调用"（瞄准线 / 风系连线 / hunter 准星）也被擦了。

**修复**：去掉 clearRect。如果未来发现 entity 漏 guard，应该在 entity 里加 `if (isSuppressed2DEntities()) return`，不要回退到整块擦。

## 验证（真游戏 headless）

附图：研磨阶段 72 个钉子按属性发光、战斗阶段敌人明显从背景中跳出来、Boss saturn 暖橙发光突出。0 console 错误。

## Test plan

- [ ] 进研磨阶段 → 看到 3D 钉子（属性色 + rim 光）
- [ ] 拉发射器 → 看到瞄准虚线
- [ ] 弹珠下落 → 看到 3D 球体下落
- [ ] 进战斗 → 敌人和背景分明
- [ ] 发射子弹 → 看到 3D 子弹飞行
- [ ] Boss 入场 → saturn 明显
- [ ] 0 console 错误

https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011XHtKniJUVQft8X4ZS4hsQ)_