### PR TITLE
fix(ui/3d): home promare residue + 3D vivid + peg-hit FX + element bullet FX + damage-scaled feedback

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -449,25 +449,41 @@ class Game {
             // 仅 visualMode==='promare' 启用，classic 模式完全跳过保持原行为。
             // @perf-impact: 监听器内只设字段 + 调 burst spawner（受 perf 档位限粒子数）。
             if (CONFIG.visualMode === 'promare') {
+                // [视觉调优] 用户反馈"第一回合那个小破子弹打上去闪的厉害"——
+                // 把命中反馈拆四档：tiny(<10) / normal(<30) / big(<60) / huge / kill。
+                // tiny 完全跳过停帧 + 全屏闪，只给极轻屏抖 + burst；档位越高视觉冲击越大。
                 const isKill = !!data.killed;
-                const isBig  = (data.actualDamage || data.amount || 0) > 0 && (data.amount || 0) >= 30;
-                // 移动端友好：normal 命中不停帧，仅 big/kill 触发
-                this.hitstopFrames = isKill ? 4 : (isBig ? 3 : 0);
-                // 全屏白闪：每次命中都给一个短闪，alpha 由 sys_loop 衰减
-                this.flashOverlay = { color: '#FFFFFF', alpha: isKill ? 0.5 : 0.35, frames: 4 };
-                // 屏抖：复用现有 triggerScreenShake（取 max 不叠乘）
-                const shakeAmt = isKill ? 14 : (isBig ? 9 : 5);
-                this.triggerScreenShake(shakeAmt);
+                const amt = (data.amount || 0);
+                let severity;
+                if      (isKill)    severity = 'kill';
+                else if (amt >= 60) severity = 'huge';
+                else if (amt >= 30) severity = 'big';
+                else if (amt >= 10) severity = 'normal';
+                else                severity = 'tiny';
+
+                // hitstop
+                const HITSTOP = { tiny: 0, normal: 0, big: 2, huge: 3, kill: 4 };
+                this.hitstopFrames = HITSTOP[severity];
+
+                // 全屏白闪：tiny 完全跳过，normal 极轻、big 中、huge/kill 重
+                const FLASH = { tiny: 0, normal: 0.10, big: 0.22, huge: 0.40, kill: 0.50 };
+                const flashAlpha = FLASH[severity];
+                if (flashAlpha > 0) {
+                    this.flashOverlay = { color: '#FFFFFF', alpha: flashAlpha, frames: severity === 'tiny' ? 2 : 4 };
+                }
+
+                // 屏抖：取 max，与原 triggerScreenShake 兼容
+                const SHAKE = { tiny: 2, normal: 4, big: 8, huge: 12, kill: 14 };
+                this.triggerScreenShake(SHAKE[severity]);
 
                 // [Promare] 几何碎片爆发：方向锥沿入射反向，元素决定形状
                 const hitX = data.hitX || (data.enemy ? data.enemy.pos.x : this.width / 2);
                 const hitY = data.hitY || (data.enemy ? data.enemy.pos.y : this.height / 2);
                 const elementType = data.type || (data.enemy && data.enemy._lastHitElement) || 'damage';
-                // 入射速度向量：projectile 的 vel 已存在 enemy._lastHitVel（由 combat_system 后续填充，
-                // 当前无该字段时退化为「球从下往上」假设）
                 const hitVel = (data.enemy && data.enemy._lastHitVel) || { x: 0, y: -1 };
-                const severity = isKill ? 'kill' : (isBig ? 'big' : 'normal');
-                spawnPromareBurst(this, hitX, hitY, hitVel, elementType, severity);
+                // spawnPromareBurst 只识别 normal/big/kill，把 tiny/huge 映射回去
+                const burstSeverity = severity === 'tiny' ? 'normal' : (severity === 'huge' ? 'big' : severity);
+                spawnPromareBurst(this, hitX, hitY, hitVel, elementType, burstSeverity);
                 spawnRadialImpact(this, hitX, hitY, elementType);
             }
         });

--- a/src/entities.js
+++ b/src/entities.js
@@ -2923,11 +2923,56 @@ class DropBall {
 
                     if (peg.cooldownTimer <= 0 && peg.frozenTurns <= 0) {
                         // --- [关键修改：传递速度参数] ---
-                        const impactSpeedVal = impactVel.mag(); 
+                        const impactSpeedVal = impactVel.mag();
                         peg.hit(impactSpeedVal);
-                        this.hitCount++; 
+                        this.hitCount++;
                         // 如果是普通钉子 (normal)，触发两次能量球反馈
                         game.spawn_createHitFeedback(this.pos.x, this.pos.y, impactVel, peg.type);
+
+                        // [视觉调优] 用户反馈"弹珠在钉盘上撞击获取属性时需要少量碰撞特效"——
+                        // 在 3D 渲染器开启时，给被撞钉子打一次 shader 击中冲量（白闪 + 微膨胀），
+                        // 并按钉子类型撒 3-5 颗元素色 spark 粒子；普通钉子撒得少（2-3 颗），
+                        // 特殊钉子（pyro/cryo/lightning/...）色彩更鲜明（PINK/CYAN/YELLOW）。
+                        const r3d = game.renderer3d;
+                        if (r3d && r3d.proxy && r3d.proxy.pulsePeg) {
+                            const pegIdx = game.pegs.indexOf(peg);
+                            if (pegIdx >= 0) {
+                                // 撞击力度 → 冲量强度（弹珠最大速度 ~12，clamp 到 0..1）
+                                const pulseIntensity = Math.min(1.0, Math.max(0.4, impactSpeedVal / 9.0));
+                                r3d.proxy.pulsePeg(pegIdx, pulseIntensity);
+                            }
+                            // 元素 → promare 5 色映射（与 Renderer3D ELEMENT_FX 同源）
+                            const PEG_SPARK_COLOR = {
+                                pyro:      0xFF0090, // PINK
+                                bounce:    0xFF0090,
+                                resonance: 0xFF0090,
+                                cryo:      0x00E5FF, // CYAN
+                                wind:      0x00E5FF,
+                                laser:     0x00E5FF,
+                                lightning: 0xFFD600, // YELLOW
+                                scatter:   0xFFD600,
+                                venom:     0xFFD600,
+                                damage:    0xFFFFFF,
+                                pierce:    0xFFFFFF,
+                                flying_sword: 0xFFFFFF,
+                                pink:      0xFF0090,
+                                normal:    0xFFFFFF,
+                            };
+                            const sparkColor = PEG_SPARK_COLOR[peg.type] || 0xFFFFFF;
+                            // 普通钉子粒子量小（避免视觉噪声），属性钉子稍多
+                            const sparkCount = (peg.type === 'normal' || peg.type === 'pink') ? 3 : 5;
+                            r3d.proxy.spawnParticles({
+                                x: peg.pos.x,
+                                y: peg.pos.y,
+                                color: sparkColor,
+                                mode: 'spark',
+                                count: sparkCount,
+                                size: 2.2,
+                                lifetime: 0.30,
+                                spread: 0.9,
+                                speed: 6 + impactSpeedVal * 0.6,
+                            });
+                        }
 
                         if (peg.type === 'normal' && Math.random() < CONFIG.balance.normalPegSecondEnergChancey) {
                             game.spawn_createHitFeedback(this.pos.x, this.pos.y, impactVel.mult(0.65), 'normal');

--- a/src/render3d/BackgroundLayer.js
+++ b/src/render3d/BackgroundLayer.js
@@ -89,11 +89,12 @@ export class BackgroundLayer {
         this.ringMaterial = ringMat;
 
         // 二级辉光（内圈，更小、更亮）
+        // [视觉调优] opacity 0.25→0.55，让炼金台环更"金"，作为视觉锚点。
         const innerRingGeom = new THREE.RingGeometry(26, 30, 48, 1);
         const innerRingMat = new THREE.MeshBasicMaterial({
             color: 0xfde68a,
             transparent: true,
-            opacity: 0.25,
+            opacity: 0.55,
             depthWrite: false,
             blending: THREE.AdditiveBlending,
             side: THREE.DoubleSide,
@@ -246,15 +247,16 @@ export class BackgroundLayer {
 
         // 6 根光柱全部置于远景（z < -180），靠两侧分布避开中央玩法区。
         // 不放中心柱——中心由 skydome 的炉膛暖光承担焦点引导。
-        // 透明度刻意压低，让光柱作为"帷幕灯光"而非主体。
+        // [视觉调优] 用户反馈"3D 太透明太暗"——光柱整体不透明度上调 ~2.5×，
+        // 让左右两侧的青/紫/橙/粉色帷幕真的"打进"画面，作为色板主光源。
         const config = [
             // x,    y,    z,     radius, height, colorIdx, opacity
-            [-160,  -30,  -210,   28,     300,    0, 0.12], // 远景左主光（青）
-            [ 160,  -30,  -210,   28,     300,    1, 0.12], // 远景右主光（紫）
-            [-230,  -40,  -260,   20,     260,    2, 0.09], // 更远的左侧蓝
-            [ 230,  -40,  -260,   20,     260,    3, 0.09], // 更远的右侧橙
-            [-100,  -60,  -270,   16,     240,    4, 0.07], // 中左副柱（粉）
-            [ 100,  -60,  -270,   16,     240,    4, 0.07], // 中右副柱（粉）
+            [-160,  -30,  -210,   28,     300,    0, 0.32], // 远景左主光（青）
+            [ 160,  -30,  -210,   28,     300,    1, 0.32], // 远景右主光（紫）
+            [-230,  -40,  -260,   20,     260,    2, 0.22], // 更远的左侧蓝
+            [ 230,  -40,  -260,   20,     260,    3, 0.22], // 更远的右侧橙
+            [-100,  -60,  -270,   16,     240,    4, 0.18], // 中左副柱（粉）
+            [ 100,  -60,  -270,   16,     240,    4, 0.18], // 中右副柱（粉）
         ];
 
         for (let i = 0; i < config.length; i++) {
@@ -287,9 +289,10 @@ export class BackgroundLayer {
         this.ambientPoints = [];
         this._ambientSpeeds = [];
 
+        // [视觉调优] 近层粒子 opacity 0.75→0.95（更鲜亮），远层 0.45→0.65（提示层级感）。
         const layers = [
-            { count: 180, sizeRange: [2.4, 4.2], color: PARTICLE_COL, opacity: 0.75, zRange: [-60, -10],  speedRange: [3, 8],   xRange: 320 },
-            { count: 200, sizeRange: [1.0, 2.0], color: 0xa78bfa,     opacity: 0.45, zRange: [-150, -80], speedRange: [1, 4],   xRange: 360 },
+            { count: 180, sizeRange: [2.4, 4.2], color: PARTICLE_COL, opacity: 0.95, zRange: [-60, -10],  speedRange: [3, 8],   xRange: 320 },
+            { count: 200, sizeRange: [1.0, 2.0], color: 0xa78bfa,     opacity: 0.65, zRange: [-150, -80], speedRange: [1, 4],   xRange: 360 },
         ];
 
         for (const layer of layers) {

--- a/src/render3d/BallMesh.js
+++ b/src/render3d/BallMesh.js
@@ -44,12 +44,13 @@ const FRAG_SRC = /* glsl */`
         vec3 N = normalize(vNormal);
         vec3 V = normalize(-vViewPos);
         float ndotv = max(0.0, dot(N, V));
-        float rim = pow(1.0 - ndotv, 1.8);
+        float rim = pow(1.0 - ndotv, 1.6);
 
-        // 弹珠是发光源——base emissive 高，rim 再加强
-        vec3 col = vColor * (0.6 + rim * 1.2);
-        // 中心高光（fake specular）
-        col += vec3(1.0) * pow(ndotv, 12.0) * 0.4;
+        // [视觉调优] 用户反馈"3D 太暗" → 弹珠/子弹是核心视觉焦点，提亮：
+        //   base 0.6 → 0.85，rim 系数 1.2 → 1.5，specular 0.4 → 0.55。
+        //   配合 PostFX bloom threshold 下调，弹珠会主动激活泛光。
+        vec3 col = vColor * (0.85 + rim * 1.5);
+        col += vec3(1.0) * pow(ndotv, 10.0) * 0.55;
 
         gl_FragColor = vec4(col, 1.0);
     }

--- a/src/render3d/EnemyMeshPool.js
+++ b/src/render3d/EnemyMeshPool.js
@@ -65,15 +65,14 @@ const FRAG_SRC = /* glsl */`
         // 伪光照：用 view-y 模拟从上方斜下的"舞台灯"
         float fakeLight = 0.5 + 0.5 * max(0.0, N.y * 0.6 + N.z * 0.4);
 
-        // [3D-Main 修复] 用户反馈"敌人和背景没区分开" → 大幅提亮 body：
-        //   base 0.55 → 0.95（金属面更亮，从背景里跳出来）
-        //   tier 0.18 → 0.32（全身 tier 染色更明显，elite 青/boss 金更明显）
-        //   rim 保持 1.9（已经够强）
-        //   引入一道顶光（vNormal.y 模拟 sky light）增强 3D 立体感
+        // [视觉调优] 在已有提亮基础上再加色彩鲜明度：
+        //   base 0.85+0.50 → 1.10+0.55（金属面继续提亮，去掉灰阶感）
+        //   tier 0.32 → 0.50（tier 染色覆盖更明显，normal/elite/boss 一眼分辨）
+        //   rim 1.9 → 2.4（轮廓更"切边"，符合 promare 硬切板美学）
         float skyLight = max(0.0, N.y * 0.6 + 0.4);  // 0.4..1.0
-        vec3 col = uBase * (0.85 + 0.50 * skyLight);
-        col += uTier * 0.32;
-        col += uTier * rim * 1.9 * pulse;
+        vec3 col = uBase * (1.10 + 0.55 * skyLight);
+        col += uTier * 0.50;
+        col += uTier * rim * 2.4 * pulse;
         col = mix(col, vec3(1.0), uHit * 0.85);
 
         gl_FragColor = vec4(col, 1.0);

--- a/src/render3d/PegInstancedMesh.js
+++ b/src/render3d/PegInstancedMesh.js
@@ -121,16 +121,17 @@ export class PegInstancedMesh {
                     vec3 V = normalize(-vViewPos);     // view dir in view space
 
                     float ndotv = max(0.0, dot(N, V));
-                    float rim   = pow(1.0 - ndotv, 2.2);
+                    float rim   = pow(1.0 - ndotv, 1.8);
 
                     // 缓慢呼吸 emission，每个钉子相位错开
                     float pulse = 0.75 + 0.25 * sin(uTime * 1.6 + vPhase);
 
-                    // 基底：颜色 * 0.30（暗调金属感）
-                    vec3 base     = vColor * 0.30;
-                    // 边缘高光：颜色 * rim
-                    vec3 rimLight = vColor * rim * 1.7 * pulse;
-                    // 击中冲量：emissive 全白瞬闪
+                    // [视觉调优] 用户反馈"3D 太暗"——base 从 0.30 提到 0.65（钉子主体颜色饱满可读），
+                    // 顶光（N.y 方向）再叠一道 0.35 让钉子从背景里"立"出来；rim 系数 1.7 不动；
+                    // 击中冲量保持白闪 0.9，与 base 拉开对比。
+                    float topLight = max(0.0, N.y * 0.6 + 0.4);
+                    vec3 base     = vColor * (0.65 + 0.35 * topLight);
+                    vec3 rimLight = vColor * rim * 1.9 * pulse;
                     vec3 hitFlash = vec3(1.0) * vHit * 0.9;
 
                     vec3 col = base + rimLight + hitFlash;

--- a/src/render3d/PostFX.js
+++ b/src/render3d/PostFX.js
@@ -35,46 +35,50 @@ import { FXAAShader }        from 'three/addons/shaders/FXAAShader.js';
 //   boss       深红 + 高饱和，整体压重，营造紧迫
 //   gameover   去饱和接近黑白，结束氛围
 // ===================================================================
+// [视觉调优] 用户反馈"3D 太暗 / 太透明，跟色彩鲜明的视觉要求不符"。
+// 全局降低 vignetteDarkness（边角不再吃光），提升 saturation（饱和度普涨 25-30%），
+// 削弱 split-tone 阴影/高光偏色（gradingStrength 减半），让 promare 5 色调色板
+// 不被 grading 拉灰。整体观感从"暗黑炼金"转向"高对比色块"。
 const GRADING_PRESETS = {
     meta: {
-        saturation:       0.92,
-        shadowR: 0.05, shadowG: 0.10, shadowB: 0.22,
-        highlightR: 0.10, highlightG: 0.14, highlightB: 0.22,
-        gradingStrength:  0.40,
-        vignetteDarkness: 0.50,
-        vignetteOffset:   0.62,
+        saturation:       1.30,
+        shadowR: 0.04, shadowG: 0.08, shadowB: 0.18,
+        highlightR: 0.10, highlightG: 0.10, highlightB: 0.18,
+        gradingStrength:  0.18,
+        vignetteDarkness: 0.18,
+        vignetteOffset:   0.78,
     },
     gathering: {
-        saturation:       1.05,
-        shadowR: 0.03, shadowG: 0.10, shadowB: 0.20,
-        highlightR: 0.14, highlightG: 0.18, highlightB: 0.12,
-        gradingStrength:  0.28,
-        vignetteDarkness: 0.42,
-        vignetteOffset:   0.70,
+        saturation:       1.35,
+        shadowR: 0.02, shadowG: 0.06, shadowB: 0.14,
+        highlightR: 0.12, highlightG: 0.14, highlightB: 0.10,
+        gradingStrength:  0.15,
+        vignetteDarkness: 0.18,
+        vignetteOffset:   0.82,
     },
     combat: {
-        saturation:       1.10,
-        shadowR: 0.04, shadowG: 0.08, shadowB: 0.18,
-        highlightR: 0.20, highlightG: 0.12, highlightB: 0.04,
-        gradingStrength:  0.32,
-        vignetteDarkness: 0.45,
-        vignetteOffset:   0.68,
+        saturation:       1.40,
+        shadowR: 0.03, shadowG: 0.05, shadowB: 0.12,
+        highlightR: 0.16, highlightG: 0.10, highlightB: 0.04,
+        gradingStrength:  0.16,
+        vignetteDarkness: 0.20,
+        vignetteOffset:   0.80,
     },
     boss: {
-        saturation:       1.18,
-        shadowR: 0.18, shadowG: 0.04, shadowB: 0.06,
-        highlightR: 0.28, highlightG: 0.10, highlightB: 0.02,
-        gradingStrength:  0.45,
-        vignetteDarkness: 0.55,
-        vignetteOffset:   0.60,
+        saturation:       1.50,
+        shadowR: 0.14, shadowG: 0.03, shadowB: 0.05,
+        highlightR: 0.22, highlightG: 0.08, highlightB: 0.02,
+        gradingStrength:  0.22,
+        vignetteDarkness: 0.28,
+        vignetteOffset:   0.72,
     },
     gameover: {
-        saturation:       0.35,
+        saturation:       0.45,
         shadowR: 0.05, shadowG: 0.05, shadowB: 0.10,
         highlightR: 0.10, highlightG: 0.10, highlightB: 0.10,
-        gradingStrength:  0.50,
-        vignetteDarkness: 0.65,
-        vignetteOffset:   0.50,
+        gradingStrength:  0.40,
+        vignetteDarkness: 0.50,
+        vignetteOffset:   0.55,
     },
 };
 
@@ -140,15 +144,19 @@ const VIGNETTE_GRAIN_SHADER = {
     uniforms: {
         tDiffuse:          { value: null },
         uTime:             { value: 0 },
-        uVignetteOffset:   { value: 0.68 },   // 半径外开始变暗
-        uVignetteDarkness: { value: 0.45 },   // 边角最深度（不要太黑，留出敌人可见）
-        uGrainAmount:      { value: 0.035 },  // 颗粒强度
+        // [视觉调优] 默认 baseline 从「暗黑炼金」改成「高对比硬切」：
+        // vignette 退到 0.80，darkness 0.20（仅保留极轻微的边角收口）；
+        // saturation 拉到 1.40，让 PINK/CYAN/YELLOW 鲜艳；grading 减半免拉灰；
+        // grain 减到 0.018，避免颗粒污染纯色块。
+        uVignetteOffset:   { value: 0.80 },
+        uVignetteDarkness: { value: 0.20 },
+        uGrainAmount:      { value: 0.018 },
         uResolution:       { value: new THREE.Vector2(1, 1) },
         // [M4 调优] Color grading 参数
-        uSaturation:       { value: 1.10 },   // 全局饱和度（1.0=原色）
-        uShadowTint:       { value: new THREE.Color(0.04, 0.08, 0.18) }, // 冷蓝阴影
-        uHighlightTint:    { value: new THREE.Color(0.20, 0.12, 0.04) }, // 暖橙高光
-        uGradingStrength:  { value: 0.32 },   // grading 混入强度
+        uSaturation:       { value: 1.40 },   // 全局饱和度（1.0=原色）
+        uShadowTint:       { value: new THREE.Color(0.03, 0.05, 0.12) }, // 冷蓝阴影（更轻）
+        uHighlightTint:    { value: new THREE.Color(0.16, 0.10, 0.04) }, // 暖橙高光（更轻）
+        uGradingStrength:  { value: 0.16 },   // grading 混入强度
         // [M4] 暴击/大伤害瞬时白闪强度（0..1），由 CameraController 每帧推送，自然衰减
         uFlash:            { value: 0.0 },
         uFlashColor:       { value: new THREE.Color(1.0, 0.98, 0.92) }, // 略偏暖白
@@ -272,20 +280,19 @@ export class PostFX {
         this.composer.addPass(this.renderPass);
 
         // --- Pass 2: bloom ---
-        // [M4 调优] 阈值上调避免全场泛光：只让真正亮的 emissive（强 rim、击中冲量、boss 强光）
-        // 触发 bloom。基础色被 ACES tonemap 后压在 [0, 1) 区间，不会污染。
-        // [M4 调优历史] 实测：bloom 阈值过高会让 SwiftShader 等软渲染场景几乎看不见 emissive，
-        // 真实 GPU 上又会过曝。折中默认值如下，配合 color grading + tonemap 形成稳定中间观感。
+        // [视觉调优] 用户反馈"3D 太暗"——bloom strength 上调（LDR 0.78→1.05, HDR 0.90→1.20）、
+        // threshold 下调（LDR 0.55→0.42, HDR 0.78→0.62），让弹珠/钉子/粒子的 rim 与中等亮度
+        // 区域也参与泛光，整体观感更通透。
         this.bloomPass = new UnrealBloomPass(
             new THREE.Vector2(this.width, this.height),
-            0.78,   // strength
-            0.45,   // radius
-            0.55    // threshold（LDR：luma > 0.55 触发，敌人 rim 即可激活 bloom）
+            1.05,
+            0.55,
+            0.42
         );
         if (this.usingHDR) {
-            this.bloomPass.threshold = 0.78;   // 略高于 LDR sRGB 上限，但 emissive>1 仍易激活
-            this.bloomPass.strength = 0.90;
-            this.bloomPass.radius = 0.50;
+            this.bloomPass.threshold = 0.62;
+            this.bloomPass.strength = 1.20;
+            this.bloomPass.radius = 0.55;
         }
         this.composer.addPass(this.bloomPass);
 

--- a/src/render3d/Renderer3D.js
+++ b/src/render3d/Renderer3D.js
@@ -258,40 +258,73 @@ export class Renderer3D {
      * @private
      */
     _bindEventBus(bus) {
-        // 暴击 / 强击：使用 damage:dealt 事件，按 damage 量级映射强度
+        // [视觉调优] 子弹打击的「图形 + 颜色」必须按元素绑定（与 promare codex 对齐），
+        // 不能所有元素都是同一坨橙黄小爆炸。下面这张表把 damage:dealt.type 映射成：
+        //   - GPU 粒子的 color（5 色硬切板 + 几个辅色）
+        //   - 粒子的 mode（spark/ember/shard/smoke/mist，匹配元素气质）
+        //   - 数量倍率（穿透/激光偏少而尖；爆破/火焰偏多而散）
+        const ELEMENT_FX = {
+            pyro:         { color: 0xFF0090, mode: 'ember', countMul: 1.0,  sizeMul: 1.05 }, // PINK 余烬
+            cryo:         { color: 0x00E5FF, mode: 'shard', countMul: 0.9,  sizeMul: 1.0  }, // CYAN 冰碎
+            lightning:    { color: 0xFFD600, mode: 'spark', countMul: 1.15, sizeMul: 0.9  }, // YELLOW 锐花
+            bounce:       { color: 0xFF0090, mode: 'spark', countMul: 0.9,  sizeMul: 1.05 }, // PINK 弹射
+            pierce:       { color: 0xFFFFFF, mode: 'shard', countMul: 0.7,  sizeMul: 1.1  }, // WHITE 锐碎
+            wind:         { color: 0x00E5FF, mode: 'mist',  countMul: 0.85, sizeMul: 1.2  }, // CYAN 风雾
+            scatter:      { color: 0xFFD600, mode: 'spark', countMul: 1.3,  sizeMul: 0.85 }, // YELLOW 散射
+            venom:        { color: 0xFFD600, mode: 'smoke', countMul: 0.9,  sizeMul: 1.0  },
+            echo:         { color: 0xFF0090, mode: 'spark', countMul: 0.9,  sizeMul: 1.0  },
+            laser:        { color: 0x00E5FF, mode: 'spark', countMul: 0.8,  sizeMul: 0.9  },
+            flying_sword: { color: 0xFFFFFF, mode: 'shard', countMul: 0.85, sizeMul: 1.0  },
+            damage:       { color: 0xFFFFFF, mode: 'spark', countMul: 1.0,  sizeMul: 1.0  },
+        };
+
         const onDamage = (data) => {
             if (!data) return;
             const dmg = data.damage || data.amount || 0;
             if (dmg <= 0) return;
-            // 阈值：< 30 微震，30..120 中震，>= 120 大震
-            let intensity = 0.18;
-            if (dmg >= 120) intensity = 0.85;
-            else if (dmg >= 30) intensity = 0.42;
-            if (data.killed) intensity *= 1.4;
+
+            // [视觉调优] 用户反馈"第一回合那个小破子弹打上去闪的厉害"：
+            // 微伤害（< 10）单独划档，只给极弱镜头扰动 + 几颗粒子，不触发任何全屏闪。
+            // 强击（>= 60）+ 暴击（>= 150）才有 punch。
+            const isKill = !!data.killed;
+            let bucket = 'tiny';
+            if      (dmg >= 120) bucket = 'huge';
+            else if (dmg >= 60)  bucket = 'big';
+            else if (dmg >= 18)  bucket = 'normal';
+            else                 bucket = 'tiny';
+            const BUCKET_INTENSITY = { tiny: 0.07, normal: 0.20, big: 0.48, huge: 0.85 };
+            let intensity = BUCKET_INTENSITY[bucket];
+            if (isKill) intensity = Math.min(1.0, intensity * 1.35);
             this.cameraEvent('IMPACT', { intensity });
 
-            // [M4] 大伤害 / 击杀 → 全屏白闪 punch
-            if (dmg >= 150 || (data.killed && dmg >= 60)) {
+            // 全屏白闪：tiny / normal 完全不闪；big 轻闪；huge / 击杀大伤害大闪。
+            if (bucket === 'huge' || (isKill && dmg >= 60)) {
                 const flashAmt = Math.min(0.6, 0.25 + dmg / 600);
                 this.cameraEvent('FLASH', { intensity: flashAmt });
+            } else if (bucket === 'big' && isKill) {
+                this.cameraEvent('FLASH', { intensity: 0.18 });
             }
 
-            // [M6] 击中处撒 spark 粒子；颜色按伤害属性取色（fallback 黄白）
+            // [视觉调优] 击中处撒粒子：颜色 / 形状按元素绑定，数量随档位收紧。
+            // tiny 4 颗，normal 8 颗，big 16 颗，huge 28 颗，再乘元素 countMul。
             const proxy = this.proxy;
             if (proxy && proxy.spawnParticles) {
                 const hx = data.hitX ?? (data.enemy && data.enemy.pos && data.enemy.pos.x);
                 const hy = data.hitY ?? (data.enemy && data.enemy.pos && data.enemy.pos.y);
                 if (hx !== undefined && hy !== undefined) {
-                    const cnt = Math.round(6 + intensity * 28);
+                    const fx = ELEMENT_FX[data.type] || ELEMENT_FX.damage;
+                    const BASE_COUNT = { tiny: 4, normal: 8, big: 16, huge: 28 };
+                    const baseCnt = BASE_COUNT[bucket];
+                    const cnt = Math.max(2, Math.round(baseCnt * fx.countMul));
                     proxy.spawnParticles({
                         x: hx, y: hy,
-                        color: data.color || 0xfbbf24,
-                        mode: 'spark',
+                        color: fx.color,
+                        mode: fx.mode,
                         count: cnt,
-                        size: 3 + intensity * 4,
-                        lifetime: 0.4 + intensity * 0.5,
-                        spread: 1.0 + intensity * 0.5,
-                        speed: 6 + intensity * 12,
+                        size: (2.4 + intensity * 3.5) * fx.sizeMul,
+                        lifetime: 0.30 + intensity * 0.55,
+                        spread: 0.85 + intensity * 0.55,
+                        speed: 4 + intensity * 14,
                     });
                 }
             }

--- a/src/styles/glass_ui.css
+++ b/src/styles/glass_ui.css
@@ -1,14 +1,16 @@
 /* ============================================================
  * glass_ui.css - 全息玻璃风格 HUD 覆盖层（M5）
  *
- * 启用方式：body 添加 class `.glass-ui-enabled`，比如：
- *     document.body.classList.add('glass-ui-enabled');
+ * 启用方式：body 添加 class `.glass-ui-enabled`。
  *
- * 默认关闭，零影响现有 bitmap_ui.css。启用后会用 backdrop-filter
- * + 渐变边框替换 9-slice 位图边框，把整个 HUD 升级到"全息玻璃"。
+ * [重要] 自 Promare 视觉模式（CONFIG.visualMode='promare'）成为默认后，
+ * 所有规则均加 `:not(.promare-mode)` 互斥守卫——
+ * 否则 backdrop-blur / 圆角 / 灰紫 token 会把 promare 的硬切板色板压成
+ * 老 UI 残留（首页 / 卡片 / 按钮 看起来仍是「M5 玻璃 + 老色板」）。
+ * Promare 关闭时（console: window.__promare(false)）glass-ui 自动恢复。
  * ============================================================ */
 
-body.glass-ui-enabled {
+body.glass-ui-enabled:not(.promare-mode) {
     /* 公共变量：稀有度色 */
     --glass-common:    rgba(226, 232, 240, 0.6);
     --glass-rare:      rgba(129, 140, 248, 0.7);
@@ -22,7 +24,7 @@ body.glass-ui-enabled {
 }
 
 /* ===== 顶部信息栏 ===== */
-body.glass-ui-enabled #unified-top-bar {
+body.glass-ui-enabled:not(.promare-mode) #unified-top-bar {
     background: linear-gradient(180deg, var(--glass-bg-deep) 0%, var(--glass-bg-dark) 100%);
     backdrop-filter: blur(14px) saturate(1.4);
     -webkit-backdrop-filter: blur(14px) saturate(1.4);
@@ -33,17 +35,17 @@ body.glass-ui-enabled #unified-top-bar {
 }
 
 /* ===== 通用 .ui-overlay 面板（命运抉择/商店等弹层） ===== */
-body.glass-ui-enabled .ui-overlay {
+body.glass-ui-enabled:not(.promare-mode) .ui-overlay {
     background: radial-gradient(ellipse at center top, var(--glass-bg-dark) 0%, var(--glass-bg-deep) 80%);
     backdrop-filter: blur(18px) saturate(1.4);
     -webkit-backdrop-filter: blur(18px) saturate(1.4);
 }
 
 /* ===== 卡片：移除 9-slice 边框，用渐变 outline 替代 ===== */
-body.glass-ui-enabled .card,
-body.glass-ui-enabled .relic-card,
-body.glass-ui-enabled .runeword-card,
-body.glass-ui-enabled .skill-card {
+body.glass-ui-enabled:not(.promare-mode) .card,
+body.glass-ui-enabled:not(.promare-mode) .relic-card,
+body.glass-ui-enabled:not(.promare-mode) .runeword-card,
+body.glass-ui-enabled:not(.promare-mode) .skill-card {
     background:
         linear-gradient(180deg, rgba(30, 41, 59, 0.85) 0%, rgba(15, 23, 42, 0.92) 100%);
     border: 1px solid rgba(148, 163, 184, 0.35);
@@ -56,44 +58,44 @@ body.glass-ui-enabled .skill-card {
     transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
-body.glass-ui-enabled .card[data-rarity="common"],
-body.glass-ui-enabled .relic-card[data-rarity="common"] {
+body.glass-ui-enabled:not(.promare-mode) .card[data-rarity="common"],
+body.glass-ui-enabled:not(.promare-mode) .relic-card[data-rarity="common"] {
     border-color: var(--glass-common);
     box-shadow:
         0 0 24px rgba(226, 232, 240, 0.20),
         inset 0 0 18px rgba(226, 232, 240, 0.05);
 }
-body.glass-ui-enabled .card[data-rarity="rare"],
-body.glass-ui-enabled .relic-card[data-rarity="rare"] {
+body.glass-ui-enabled:not(.promare-mode) .card[data-rarity="rare"],
+body.glass-ui-enabled:not(.promare-mode) .relic-card[data-rarity="rare"] {
     border-color: var(--glass-rare);
     box-shadow:
         0 0 28px rgba(129, 140, 248, 0.30),
         inset 0 0 18px rgba(129, 140, 248, 0.08);
 }
-body.glass-ui-enabled .card[data-rarity="epic"],
-body.glass-ui-enabled .relic-card[data-rarity="epic"] {
+body.glass-ui-enabled:not(.promare-mode) .card[data-rarity="epic"],
+body.glass-ui-enabled:not(.promare-mode) .relic-card[data-rarity="epic"] {
     border-color: var(--glass-epic);
     box-shadow:
         0 0 36px rgba(217, 70, 239, 0.40),
         inset 0 0 22px rgba(217, 70, 239, 0.10);
 }
-body.glass-ui-enabled .card[data-rarity="legendary"],
-body.glass-ui-enabled .relic-card[data-rarity="legendary"] {
+body.glass-ui-enabled:not(.promare-mode) .card[data-rarity="legendary"],
+body.glass-ui-enabled:not(.promare-mode) .relic-card[data-rarity="legendary"] {
     border-color: var(--glass-legendary);
     box-shadow:
         0 0 42px rgba(245, 158, 11, 0.50),
         inset 0 0 28px rgba(245, 158, 11, 0.12);
 }
-body.glass-ui-enabled .card[data-rarity="cursed"],
-body.glass-ui-enabled .relic-card[data-rarity="cursed"] {
+body.glass-ui-enabled:not(.promare-mode) .card[data-rarity="cursed"],
+body.glass-ui-enabled:not(.promare-mode) .relic-card[data-rarity="cursed"] {
     border-color: var(--glass-cursed);
     box-shadow:
         0 0 28px rgba(159, 18, 57, 0.35),
         inset 0 0 18px rgba(159, 18, 57, 0.10);
 }
 
-body.glass-ui-enabled .card:hover,
-body.glass-ui-enabled .relic-card:hover {
+body.glass-ui-enabled:not(.promare-mode) .card:hover,
+body.glass-ui-enabled:not(.promare-mode) .relic-card:hover {
     transform: translateY(-2px);
     border-color: rgba(56, 189, 248, 0.8);
     box-shadow:
@@ -102,8 +104,8 @@ body.glass-ui-enabled .relic-card:hover {
 }
 
 /* ===== 按钮：玻璃 + 渐变 hover ===== */
-body.glass-ui-enabled button,
-body.glass-ui-enabled .btn {
+body.glass-ui-enabled:not(.promare-mode) button,
+body.glass-ui-enabled:not(.promare-mode) .btn {
     background: linear-gradient(180deg, rgba(30, 41, 59, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
     border: 1px solid rgba(148, 163, 184, 0.4);
     border-image: none;
@@ -117,8 +119,8 @@ body.glass-ui-enabled .btn {
     transition: all 0.15s ease;
 }
 
-body.glass-ui-enabled button:hover,
-body.glass-ui-enabled .btn:hover {
+body.glass-ui-enabled:not(.promare-mode) button:hover,
+body.glass-ui-enabled:not(.promare-mode) .btn:hover {
     border-color: rgba(56, 189, 248, 0.7);
     box-shadow:
         0 0 18px rgba(56, 189, 248, 0.4),
@@ -128,8 +130,8 @@ body.glass-ui-enabled .btn:hover {
 }
 
 /* ===== PC 三栏边栏背景 ===== */
-body.glass-ui-enabled #pc-left-sidebar,
-body.glass-ui-enabled #pc-right-sidebar {
+body.glass-ui-enabled:not(.promare-mode) #pc-left-sidebar,
+body.glass-ui-enabled:not(.promare-mode) #pc-right-sidebar {
     background: linear-gradient(180deg, var(--glass-bg-deep) 0%, var(--glass-bg-dark) 100%);
     backdrop-filter: blur(20px) saturate(1.5);
     -webkit-backdrop-filter: blur(20px) saturate(1.5);
@@ -138,7 +140,7 @@ body.glass-ui-enabled #pc-right-sidebar {
 }
 
 /* ===== 移动端底部抽屉 ===== */
-body.glass-ui-enabled .bottom-panel {
+body.glass-ui-enabled:not(.promare-mode) .bottom-panel {
     background: linear-gradient(0deg, var(--glass-bg-deep) 0%, var(--glass-bg-dark) 100%);
     backdrop-filter: blur(16px) saturate(1.4);
     -webkit-backdrop-filter: blur(16px) saturate(1.4);
@@ -146,8 +148,8 @@ body.glass-ui-enabled .bottom-panel {
 }
 
 /* ===== Tooltip / popover ===== */
-body.glass-ui-enabled .tooltip,
-body.glass-ui-enabled .popover {
+body.glass-ui-enabled:not(.promare-mode) .tooltip,
+body.glass-ui-enabled:not(.promare-mode) .popover {
     background: rgba(2, 6, 23, 0.92);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
@@ -156,8 +158,8 @@ body.glass-ui-enabled .popover {
 }
 
 /* ===== 标题文字玻璃风 ===== */
-body.glass-ui-enabled #phase-title,
-body.glass-ui-enabled .phase-text {
+body.glass-ui-enabled:not(.promare-mode) #phase-title,
+body.glass-ui-enabled:not(.promare-mode) .phase-text {
     text-shadow:
         0 0 14px rgba(56, 189, 248, 0.6),
         0 0 28px rgba(56, 189, 248, 0.3);
@@ -165,8 +167,8 @@ body.glass-ui-enabled .phase-text {
 }
 
 /* ===== 数字滚动器（金币 / 符文碎片等） ===== */
-body.glass-ui-enabled .number-display,
-body.glass-ui-enabled .currency-amount {
+body.glass-ui-enabled:not(.promare-mode) .number-display,
+body.glass-ui-enabled:not(.promare-mode) .currency-amount {
     text-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
 }
 


### PR DESCRIPTION
## 用户反馈对应修复

| # | 反馈 | 修复 |
|---|---|---|
| 1 | 首页老 UI 残留 | `glass_ui.css` 全部 `body.glass-ui-enabled` 选择器加 `:not(.promare-mode)` 互斥守卫，让 backdrop-blur/圆角/灰紫 token 不再压住 promare 5 色硬切板。`window.__promare(false)` 关闭 promare 时 glass-ui 仍正常工作。 |
| 2 | 3D 太暗太透明 | PostFX vignetteDarkness 0.45→0.20，saturation 1.10→1.40，gradingStrength 减半，bloom strength 0.78→1.05、threshold 0.55→0.42。Peg base 0.30→0.65；Ball base 0.6→0.85；Enemy tier 0.32→0.50；BackgroundLayer 光柱不透明度 ~2.5×、炼金台环 0.25→0.55、环境粒子 +30%。整体观感从「暗黑炼金」转向「高对比色块」。 |
| 3 | 弹珠击钉缺碰撞反馈 | `entities.js` DropBall 碰撞回调内增加 3D 钉子 shader `pulsePeg()`（白闪 + 微膨胀）+ 3-5 颗元素色 spark 粒子（普通钉 3 颗、属性钉 5 颗）。 |
| 4 | 子弹击中元素未与图形/颜色绑定 | `Renderer3D.js` 新增 `ELEMENT_FX` 表：pyro→PINK ember、cryo→CYAN shard、lightning→YELLOW spark、bounce→PINK spark、pierce→WHITE shard、wind→CYAN mist、scatter→YELLOW spark、venom→YELLOW smoke、laser/flying_sword/echo/damage 各自映射；mode 与 countMul 按元素气质收敛。 |
| 5 | 小伤害闪得太过 | 命中反馈拆 4 档：tiny(<10) / normal(<30) / big(<60) / huge / kill。`core.js` flashOverlay alpha：tiny=0、normal=0.10、big=0.22、huge=0.40、kill=0.50；hitstop / shake / 粒子数同步分档。`Renderer3D.js` 镜头 intensity 同步分档：tiny 0.07 / normal 0.20 / big 0.48 / huge 0.85。 |

## 文件修改

- `src/styles/glass_ui.css` — 加 `:not(.promare-mode)` 守卫（全文 replace）
- `src/render3d/PostFX.js` — GRADING_PRESETS 全部重调；vignette / bloom baseline 提亮
- `src/render3d/PegInstancedMesh.js` — peg shader base 0.30→0.65 + 顶光
- `src/render3d/BallMesh.js` — 弹珠 shader base 0.6→0.85
- `src/render3d/EnemyMeshPool.js` — enemy shader 整体亮度 / tier 染色提升
- `src/render3d/BackgroundLayer.js` — 光柱 / 炼金环 / 粒子不透明度上调
- `src/render3d/Renderer3D.js` — onDamage 元素色映射 + 4 档强度
- `src/core.js` — promare hit-feedback 4 档分级
- `src/entities.js` — DropBall 碰撞触发 3D peg 反馈 + 元素 spark

## Test plan

- [ ] 加载首页：promare-mode 默认开，所有按钮无 backdrop-blur / 圆角 / slate 渐变；标题黄色硬切大字、菱形 icon
- [ ] 关闭 promare (`window.__promare(false)`)：glass-ui 自动恢复
- [ ] 进研磨阶段：弹珠击中钉子时 3D 钉子有瞬间白闪 + 元素色火花 (~3-5 颗)
- [ ] 进战斗阶段，第 1 回合小子弹（dmg < 10）打敌人：不再有全屏白闪，仅极轻屏抖
- [ ] 大伤害（dmg ≥ 60）：屏闪 + 镜头大幅 IMPACT
- [ ] pyro 子弹击中：PINK 余烬粒子；cryo：CYAN 碎片；lightning：YELLOW 锐花

https://claude.ai/code/session_01PeUYWdktFCxQpDjiuncTtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeUYWdktFCxQpDjiuncTtv)_