### PR TITLE
fix(promare): inject 7 pervasive Promare traits (Tier 1 of 3)

### DIFF
--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -1401,7 +1401,7 @@ export const combat_system = {
                     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
                 }
                 ctx.closePath();
-                ctx.fillStyle = '#00E5FF';
+                ctx.fillStyle = '#00B4FF';
                 ctx.fill();
                 ctx.restore();
 
@@ -1415,9 +1415,9 @@ export const combat_system = {
                     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
                 }
                 ctx.closePath();
-                ctx.fillStyle = '#0a0a0a';
+                ctx.fillStyle = '#1B0B2E';
                 ctx.fill();
-                ctx.strokeStyle = '#00E5FF';
+                ctx.strokeStyle = '#00B4FF';
                 ctx.lineWidth = 2;
                 ctx.stroke();
 
@@ -1430,7 +1430,7 @@ export const combat_system = {
                 ctx.stroke();
 
                 ctx.globalAlpha = core.alpha;
-                ctx.strokeStyle = '#FFD600';
+                ctx.strokeStyle = '#FFE94A';
                 ctx.lineWidth = 4;
                 ctx.beginPath();
                 ctx.arc(0, 0, r * 0.7, -Math.PI/2, -Math.PI/2 + Math.PI * 2 * energyRatio);
@@ -1445,7 +1445,7 @@ export const combat_system = {
                 ctx.lineTo(0, r * 0.35);
                 ctx.lineTo(-r * 0.35, 0);
                 ctx.closePath();
-                ctx.fillStyle = '#00E5FF';
+                ctx.fillStyle = '#00B4FF';
                 ctx.fill();
                 ctx.strokeStyle = '#FFFFFF';
                 ctx.lineWidth = 1.5;
@@ -1458,10 +1458,10 @@ export const combat_system = {
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'middle';
                 const txt = `${core.energy}/${core.energyRequired}`;
-                ctx.fillStyle = '#0a0a0a';
+                ctx.fillStyle = '#1B0B2E';
                 const offs = [[2, 0], [-2, 0], [0, 2], [0, -2]];
                 for (const [ox, oy] of offs) ctx.fillText(txt, ox, r + 22 + oy);
-                ctx.fillStyle = '#FFD600';
+                ctx.fillStyle = '#FFE94A';
                 ctx.fillText(txt, 0, r + 22);
 
                 ctx.restore();

--- a/src/config.js
+++ b/src/config.js
@@ -348,49 +348,49 @@ const CONFIG = {
     // colors.promareOverride 由渲染器读取替换 colors.*，gameplay 逻辑不受影响
     colorsPromareOverride: {
         // 元素子弹/钉子映射到 5 色家族
-        matBounce:      '#FF0090',   // PINK 系
+        matBounce:      '#FF2EA6',   // PINK 系
         matPierce:      '#FFFFFF',   // WHITE 主 + PINK accent
-        matScatter:     '#FFD600',   // YELLOW
+        matScatter:     '#FFE94A',   // YELLOW
         matDamage:      '#FFFFFF',
-        matCryo:        '#00E5FF',   // CYAN
-        matPyro:        '#FF0090',   // PINK
-        matLightning:   '#FFD600',   // YELLOW
-        matWind:        '#00E5FF',   // CYAN
-        matWind_lv2:    '#00E5FF',
-        matWind_lv3:    '#00E5FF',
-        matVenom:       '#FFD600',
+        matCryo:        '#00B4FF',   // CYAN
+        matPyro:        '#FF2EA6',   // PINK
+        matLightning:   '#FFE94A',   // YELLOW
+        matWind:        '#00B4FF',   // CYAN
+        matWind_lv2:    '#00B4FF',
+        matWind_lv3:    '#00B4FF',
+        matVenom:       '#FFE94A',
         marbleWhite:    '#FFFFFF',
-        matMatryoshka:  '#FF0090',
-        marbleRedStripe:'#FF0090',
+        matMatryoshka:  '#FF2EA6',
+        marbleRedStripe:'#FF2EA6',
 
         flying_sword:   '#FFFFFF',
         flying_sword_lv2:'#FFFFFF',
-        flying_sword_lv3:'#FF0090',
-        laser:          '#00E5FF',
-        resonance:      '#FFD600',
-        resonanceRipple:'#00E5FF',
+        flying_sword_lv3:'#FF2EA6',
+        laser:          '#00B4FF',
+        resonance:      '#FFE94A',
+        resonanceRipple:'#00B4FF',
 
         // 背景/钉子
-        bg:             '#0a0a0a',
+        bg:             '#1B0B2E',
         peg:            '#FFFFFF',   // 中性钉子（半透明 WHITE，由 promare_peg_draw 控）
         pegActive:      '#FFFFFF',
-        pegPink:        '#FF0090',
+        pegPink:        '#FF2EA6',
 
         // 敌人状态色 → 全收敛到 WHITE，靠加法 alpha 区分强度
         enemy:          '#FFFFFF',
         enemyHit:       '#FFFFFF',
-        enemyFrozen:    '#00E5FF',
-        enemyOverheat:  '#FF0090',
+        enemyFrozen:    '#00B4FF',
+        enemyOverheat:  '#FF2EA6',
         enemyShield:    '#FFFFFF',
 
         // 槽位 glyph 颜色 → 按语义收敛
-        slotRecall:     '#FF0090',   // 撤回 = 危险
-        slotMulticast:  '#00E5FF',   // 增益
-        slotSplit:      '#00E5FF',
-        slotGiant:      '#FF0090',
-        slotSkill:      '#FFD600',
-        slotWheel:      '#FFD600',
-        wheelPointer:   '#FFD600',
+        slotRecall:     '#FF2EA6',   // 撤回 = 危险
+        slotMulticast:  '#00B4FF',   // 增益
+        slotSplit:      '#00B4FF',
+        slotGiant:      '#FF2EA6',
+        slotSkill:      '#FFE94A',
+        slotWheel:      '#FFE94A',
+        wheelPointer:   '#FFE94A',
     },
 
     evolutionRules: {

--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -19,13 +19,26 @@ import { Vec2, lerp } from '../utils/math_utils.js';
 import { sb as _sb } from '../utils/perf.js';
 import { isSuppressed2DEntities } from '../render3d/draw_mode.js';
 import { CONFIG } from '../config.js'; // [Promare] visualMode gate
-import { PROMARE_PALETTE } from '../render/promare_tokens.js';
+import { PROMARE_PALETTE, PROMARE_MODES, isPromareMode } from '../render/promare_tokens.js';
 import {
     drawShape_cone3, drawShape_oct2, drawShape_zigzagZ, drawShape_lance4,
     drawShape_hex6, drawShape_star4, drawShape_diamond, drawShape_crescent,
     drawShape_triDown, drawShape_ringOuter, drawShape_ringInner,
-    drawShape_radialSpoke, fillStroke_promare
+    drawShape_radialSpoke, fillStroke_promare, fillPosterized_promare
 } from '../render/promare_shapes.js';
+
+// ==================== F1 / F3 / F6 Promare 特征工具 ====================
+// F1: 12fps 时间量化步长（60fps 下每 5 frame 才推进 pos/angle）
+const PROMARE_STUTTER_FRAMES = 5;
+
+// F3: Pop-Hold-Snap 生命周期 — 计算视觉缩放与 alpha
+// 行为：r >= 0.15 直接全尺寸全 alpha；r < 0.15 snap 缩小同时 alpha 加速降到 0
+function _promareLifeVisual(p) {
+    const r = p.maxLife > 0 ? (p.life / p.maxLife) : 0;
+    if (r >= 0.15) return { scale: 1.0, alpha: 1.0 };
+    const snap = r / 0.15;            // 0..1 线性
+    return { scale: snap, alpha: snap * snap }; // 缩小快、alpha 平方降速
+}
 
 class Particle {
     constructor(x, y, color, mode = 'normal') {
@@ -243,6 +256,20 @@ class Particle {
             vel.x = (Math.random() - 0.5) * 4; vel.y = (Math.random() - 0.5) * 4;
             this.drag = 0.92; this.gravity = 0; this.decay = 0.05; this.size = Math.random() * 2 + 1;
         }
+
+        // ==================== F6: Promare 直线运动覆盖 ====================
+        // 所有 promare mode：去掉 gravity / drag friction / 连续 spin。
+        // 保留 mode 自己设的初始 vel 和 angle —— 那是方向，电影里直线扇形扩散的根。
+        // _promareMode 也是 F1 stutter 与 F3 pop-hold-snap 的判定 flag。
+        if (PROMARE_MODES.has(mode)) {
+            this._promareMode   = true;
+            this.gravity        = 0;
+            this.drag           = 1.0;
+            this.spin           = 0;
+            // 错峰起步：避免所有粒子同帧 stutter 出现"群体闪烁"
+            this._stutterAccum  = Math.random() * PROMARE_STUTTER_FRAMES;
+        }
+
         this.maxLife = this.life;
     }
 
@@ -254,16 +281,18 @@ class Particle {
             // 毒液滴横向正弦摆动，模拟液体漂浮
             this.pos.x += Math.sin(this.life * 6 + this.wobble) * 0.4 * timeScale;
         }
-        // [Promare] thunder_z 高频抖动（每帧 ±0.04 单位）
-        if (this.mode === 'thunder_z') {
+        // [Promare F6] thunder_z 高频抖动：Promare 模式下抑制（与 stutter 不兼容、会看起来糊）
+        //   strobe 视觉效果仍在 draw 阶段，不依赖这里的 pos 抖动。
+        if (this.mode === 'thunder_z' && !this._promareMode) {
             this.pos.x += (Math.random() - 0.5) * 0.4 * timeScale;
             this.pos.y += (Math.random() - 0.5) * 0.4 * timeScale;
         }
-        // [Promare] venom_tri x-wobble
+        // [Promare F6] venom_tri x-wobble：Promare 模式下保留信号但缩到 1/3，避免与 stutter 冲突
         if (this.mode === 'venom_tri') {
-            this.pos.x += Math.sin(this.life * 6 + this.wobble) * 0.4 * timeScale;
+            const w = this._promareMode ? 0.13 : 0.4;
+            this.pos.x += Math.sin(this.life * 6 + this.wobble) * w * timeScale;
         }
-        // [Promare] bounce_hex 落地反弹（仅一次）
+        // [Promare] bounce_hex 落地反弹（F6 下 gravity=0 → vel.y 不变 → 永不触发；保留兼容）
         if (this.mode === 'bounce_hex' && !this._bounced && this.vel.y > 0 && this.pos.y >= this._bounceY) {
             this.vel.y *= -0.55;
             this._bounced = true;
@@ -308,17 +337,31 @@ class Particle {
                 this.pos = this.pos.add(perp.mult(wave * timeScale));
             }
         }
-        this.pos = this.pos.add(this.vel.mult(timeScale));
-        this.vel = this.vel.mult(Math.pow(this.drag, timeScale));
-        this.vel.y += this.gravity * timeScale;
-        if (this.mode === 'shard' || this.mode === 'mist') {
-            this.angle += this.spin * timeScale;
+
+        // ==================== 主 pos / vel / angle 推进 ====================
+        if (this._promareMode) {
+            // [F1] 12fps 时间量化：累积 timeScale，到阈值才一次性 pop 出位移
+            // _init 已经把 gravity / drag / spin 清零，所以 vel 是常量，无需 drag/重力推进
+            this._stutterAccum += timeScale;
+            if (this._stutterAccum >= PROMARE_STUTTER_FRAMES) {
+                this.pos = this.pos.add(this.vel.mult(this._stutterAccum));
+                this._stutterAccum = 0;
+            }
+            // angle 也按 stutter 节奏（spin=0 时实际无变化，保留逻辑供未来 Tier 2 使用）
+        } else {
+            this.pos = this.pos.add(this.vel.mult(timeScale));
+            this.vel = this.vel.mult(Math.pow(this.drag, timeScale));
+            this.vel.y += this.gravity * timeScale;
+            if (this.mode === 'shard' || this.mode === 'mist') {
+                this.angle += this.spin * timeScale;
+            }
+            // 非 promare 模式的旧 promare 旋转逻辑（如其他来源也借用了这些 mode 名）
+            if (this.mode === 'pyro_cone' || this.mode === 'cryo_oct' || this.mode === 'bounce_hex'
+                || this.mode === 'scatter_star' || this.mode === 'damage_diamond') {
+                this.angle += (this.spin || 0) * timeScale;
+            }
         }
-        // [Promare] 旋转更新
-        if (this.mode === 'pyro_cone' || this.mode === 'cryo_oct' || this.mode === 'bounce_hex'
-            || this.mode === 'scatter_star' || this.mode === 'damage_diamond') {
-            this.angle += (this.spin || 0) * timeScale;
-        }
+
         this.life -= this.decay * timeScale;
     }
 
@@ -328,7 +371,7 @@ class Particle {
         if (this.life <= 0) return;
         ctx.save();
         ctx.translate(this.pos.x, this.pos.y);
-        
+
         // 设置混合模式
         if (this.mode === 'mist' && this.color && this.color.includes('0,0,0')) {
              ctx.globalCompositeOperation = 'source-over'; // 黑烟
@@ -337,6 +380,18 @@ class Particle {
         }
 
         ctx.globalAlpha = Math.max(0, this.life);
+
+        // ==================== F3: Pop-Hold-Snap 生命周期 ====================
+        // Promare 模式覆盖 globalAlpha 与 scale —— 不再线性褪色
+        // - r ≥ 0.15: 全尺寸全 alpha（"持续期"）
+        // - r < 0.15: snap 缩小 + alpha 平方降速（"snap 死亡"）
+        // 同时强制 source-over 抑制粒子重叠出现的白雾（F2 外层）
+        if (this._promareMode) {
+            const viz = _promareLifeVisual(this);
+            ctx.globalAlpha = viz.alpha;
+            if (viz.scale !== 1.0) ctx.scale(viz.scale, viz.scale);
+            ctx.globalCompositeOperation = 'source-over';
+        }
 
         // --- 优化：根据模式简化绘制 ---
         if (this.mode === 'mist') {
@@ -938,7 +993,7 @@ class FloatingText {
             ctx.textBaseline = 'middle';
 
             // 黑色 stamp 3 个偏移（替代 shadowBlur）
-            ctx.fillStyle = '#0a0a0a';
+            ctx.fillStyle = '#1B0B2E';
             const offs = [[2, 0], [0, 2], [-2, 0], [0, -2]];
             for (const [ox, oy] of offs) {
                 ctx.fillText(this.text, this.pos.x + ox, this.pos.y + oy);
@@ -946,9 +1001,9 @@ class FloatingText {
             // 顶层主色（pyro→PINK / cryo→CYAN / lightning→YELLOW / 其他→WHITE）
             let mainColor = '#FFFFFF';
             const c = (this.color || '').toLowerCase();
-            if (c.includes('f97316') || c.includes('ef4444') || c.includes('fca5a5')) mainColor = '#FF0090';
-            else if (c.includes('06b6d4') || c.includes('22d3ee') || c.includes('06b6')) mainColor = '#00E5FF';
-            else if (c.includes('facc15') || c.includes('c084fc') || c.includes('fbbf24') || c.includes('ffd600')) mainColor = '#FFD600';
+            if (c.includes('f97316') || c.includes('ef4444') || c.includes('fca5a5')) mainColor = '#FF2EA6';
+            else if (c.includes('06b6d4') || c.includes('22d3ee') || c.includes('06b6')) mainColor = '#00B4FF';
+            else if (c.includes('facc15') || c.includes('c084fc') || c.includes('fbbf24') || c.includes('ffd600')) mainColor = '#FFE94A';
             ctx.fillStyle = mainColor;
             ctx.fillText(this.text, this.pos.x, this.pos.y);
             ctx.restore();

--- a/src/entities.js
+++ b/src/entities.js
@@ -173,13 +173,13 @@ class SpecialSlot {
             const override = CONFIG.colorsPromareOverride || {};
             // 按 type 映射到 5 色
             let promareColor = '#FFFFFF';
-            if (this.type === 'recall')        promareColor = override.slotRecall    || '#FF0090';
-            else if (this.type === 'multicast') promareColor = override.slotMulticast || '#00E5FF';
-            else if (this.type === 'split')     promareColor = override.slotSplit     || '#00E5FF';
-            else if (this.type === 'giant')     promareColor = override.slotGiant     || '#FF0090';
-            else if (this.type === 'skill_point')promareColor = override.slotSkill    || '#FFD600';
-            else if (this.type === 'wheel')     promareColor = override.slotWheel     || '#FFD600';
-            else                                promareColor = '#FFD600';
+            if (this.type === 'recall')        promareColor = override.slotRecall    || '#FF2EA6';
+            else if (this.type === 'multicast') promareColor = override.slotMulticast || '#00B4FF';
+            else if (this.type === 'split')     promareColor = override.slotSplit     || '#00B4FF';
+            else if (this.type === 'giant')     promareColor = override.slotGiant     || '#FF2EA6';
+            else if (this.type === 'skill_point')promareColor = override.slotSkill    || '#FFE94A';
+            else if (this.type === 'wheel')     promareColor = override.slotWheel     || '#FFE94A';
+            else                                promareColor = '#FFE94A';
 
             ctx.save();
             ctx.globalCompositeOperation = 'lighter';
@@ -600,7 +600,7 @@ class FortuneWheel {
         ctx.save();
         ctx.translate(this.pos.x, this.pos.y);
 
-        const PAL = { PINK: '#FF0090', CYAN: '#00E5FF', YELLOW: '#FFD600', WHITE: '#FFFFFF', BLACK: '#0a0a0a' };
+        const PAL = { PINK: '#FF2EA6', CYAN: '#00B4FF', YELLOW: '#FFE94A', WHITE: '#FFFFFF', BLACK: '#1B0B2E' };
         const R = this.radius;
 
         // 外圈：BLACK 大圆 + PINK 厚边框（不旋转）
@@ -5014,10 +5014,10 @@ class FieldLootItem {
             ctx.scale(finalScale, finalScale);
             ctx.globalAlpha = this.opacity;
             // 按类型选色
-            let primary = '#FFD600'; // 默认 relic 黄
-            if (this.type === 'chaos_essence') primary = '#FF0090';     // 混沌 = 粉
+            let primary = '#FFE94A'; // 默认 relic 黄
+            if (this.type === 'chaos_essence') primary = '#FF2EA6';     // 混沌 = 粉
             else if (this.type === 'pure_essence') primary = '#FFFFFF'; // 纯净 = 白
-            else if (this.type === 'rune_fragments') primary = '#00E5FF'; // 符文碎片 = 青
+            else if (this.type === 'rune_fragments') primary = '#00B4FF'; // 符文碎片 = 青
             // 外层菱形容器（黑底白边）
             const r = 18;
             ctx.beginPath();
@@ -5026,7 +5026,7 @@ class FieldLootItem {
             ctx.lineTo(0, r);
             ctx.lineTo(-r, 0);
             ctx.closePath();
-            ctx.fillStyle = '#0a0a0a';
+            ctx.fillStyle = '#1B0B2E';
             ctx.fill();
             ctx.strokeStyle = '#FFFFFF';
             ctx.lineWidth = 2;
@@ -5041,7 +5041,7 @@ class FieldLootItem {
             ctx.fillStyle = primary;
             ctx.fill();
             // 4 顶点黄色装饰菱形（拼贴感）
-            ctx.fillStyle = '#FFD600';
+            ctx.fillStyle = '#FFE94A';
             const corners = [{x: 0, y: -r * 1.15}, {x: r * 1.15, y: 0}, {x: 0, y: r * 1.15}, {x: -r * 1.15, y: 0}];
             for (const c of corners) {
                 ctx.beginPath();
@@ -5143,10 +5143,10 @@ class RuneLoot {
             const runeDef = (typeof RUNE_DB !== 'undefined') ? RUNE_DB[this.runeId] : null;
             // 元素色映射
             const elem = runeDef && runeDef.element;
-            let primary = '#FFD600';
-            if (elem === 'pyro' || elem === 'bounce') primary = '#FF0090';
-            else if (elem === 'cryo' || elem === 'wind' || elem === 'laser') primary = '#00E5FF';
-            else if (elem === 'lightning' || elem === 'scatter' || elem === 'venom') primary = '#FFD600';
+            let primary = '#FFE94A';
+            if (elem === 'pyro' || elem === 'bounce') primary = '#FF2EA6';
+            else if (elem === 'cryo' || elem === 'wind' || elem === 'laser') primary = '#00B4FF';
+            else if (elem === 'lightning' || elem === 'scatter' || elem === 'venom') primary = '#FFE94A';
             else if (elem === 'pierce') primary = '#FFFFFF';
             const floatY = Math.sin(this._animTimer * 2) * 4;
             const drawY = this.y + floatY;
@@ -5163,7 +5163,7 @@ class RuneLoot {
                 else ctx.lineTo(px, py);
             }
             ctx.closePath();
-            ctx.fillStyle = '#0a0a0a';
+            ctx.fillStyle = '#1B0B2E';
             ctx.fill();
             ctx.strokeStyle = primary;
             ctx.lineWidth = 2;

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -975,17 +975,17 @@ class Projectile {
 
         // [Promare] 拖尾色映射到 5 色硬切板（保留元素家族编码）
         if (CONFIG.visualMode === 'promare') {
-            if (cfg.isLaser)                       trailColor = '#00E5FF';
+            if (cfg.isLaser)                       trailColor = '#00B4FF';
             else if (cfg.type === 'flying_sword')  trailColor = '#FFFFFF';
-            else if (cfg.type === 'rainbow')       trailColor = '#FF0090';
-            else if (cfg.explosive)                trailColor = '#FF0090';
-            else if ((cfg.pyro || 0) > 0)          trailColor = '#FF0090';
-            else if ((cfg.cryo || 0) > 0)          trailColor = '#00E5FF';
-            else if ((cfg.lightning || 0) > 0)     trailColor = '#FFD600';
-            else if ((cfg.wind || 0) > 0)          trailColor = '#00E5FF';
+            else if (cfg.type === 'rainbow')       trailColor = '#FF2EA6';
+            else if (cfg.explosive)                trailColor = '#FF2EA6';
+            else if ((cfg.pyro || 0) > 0)          trailColor = '#FF2EA6';
+            else if ((cfg.cryo || 0) > 0)          trailColor = '#00B4FF';
+            else if ((cfg.lightning || 0) > 0)     trailColor = '#FFE94A';
+            else if ((cfg.wind || 0) > 0)          trailColor = '#00B4FF';
             else if ((cfg.pierce || 0) > 0)        trailColor = '#FFFFFF';
-            else if ((cfg.bounce || 0) > 0)        trailColor = '#FF0090';
-            else if ((cfg.scatter || 0) > 0)       trailColor = '#FFD600';
+            else if ((cfg.bounce || 0) > 0)        trailColor = '#FF2EA6';
+            else if ((cfg.scatter || 0) > 0)       trailColor = '#FFE94A';
             else                                    trailColor = '#FFFFFF';
         }
 

--- a/src/render/promare_background.js
+++ b/src/render/promare_background.js
@@ -54,7 +54,7 @@ function _buildScanlineCanvas(w, h) {
     ctx.translate(w / 2, h / 2);
     ctx.rotate(-Math.PI / 4);
     ctx.globalCompositeOperation = 'lighter';
-    ctx.strokeStyle = 'rgba(0,229,255,0.04)';
+    ctx.strokeStyle = 'rgba(0, 180, 255,0.04)';
     ctx.lineWidth = 2;
     for (let y = -diag; y <= diag; y += 160) {
         ctx.beginPath();
@@ -83,7 +83,7 @@ function _buildGridCanvas(w, h) {
     const vanishY = h * 0.45;
 
     ctx.save();
-    ctx.strokeStyle = 'rgba(0,229,255,0.06)';
+    ctx.strokeStyle = 'rgba(0, 180, 255,0.06)';
     ctx.lineWidth = 1;
 
     // 1) 纵向「轨道」：从屏底等距分布的点连线到消失点

--- a/src/render/promare_burst.js
+++ b/src/render/promare_burst.js
@@ -42,7 +42,7 @@ export function ensurePromareGlobals(game) {
         for (let i = 0; i < 3; i++) {
             const a = Math.random() * Math.PI * 2;
             const sp = 1.5 + Math.random() * 1.5;
-            const sub = game.spawn_createParticle(x, y, color || '#FFD600', 'scatter_star');
+            const sub = game.spawn_createParticle(x, y, color || '#FFE94A', 'scatter_star');
             if (sub && sub.vel) {
                 sub.vel.x = Math.cos(a) * sp;
                 sub.vel.y = Math.sin(a) * sp;
@@ -60,7 +60,7 @@ export function ensurePromareGlobals(game) {
         for (let i = 0; i < 2; i++) {
             const a = (i === 0 ? -1 : 1) * (0.3 + Math.random() * 0.4); // 左右分裂
             const sp = 0.8 + Math.random() * 0.6;
-            const sub = game.spawn_createParticle(x, y, color || '#00E5FF', 'cryo_oct');
+            const sub = game.spawn_createParticle(x, y, color || '#00B4FF', 'cryo_oct');
             if (sub) {
                 if (sub.vel) {
                     sub.vel.x = Math.cos(a) * sp;
@@ -147,6 +147,12 @@ export function spawnPromareBurst(game, x, y, hitVel, elementType, severity = 'n
     const vy = (hitVel && hitVel.y) || 1;
     const baseA = Math.atan2(-vy, -vx);
 
+    // ===== F5: 超大剪影层 — Promare 构图骨架 =====
+    // 在所有碎片之前生成 1 个比"大碎片"还大 2× 的静止粒子，沿入射反方向锁向。
+    // 它不移动、寿命极短（~0.2s），作用是给玩家一帧"剪影定格"，碎片群从它内部炸开。
+    // _splitFired=true 防止 scatter_star 类型触发二次爆裂（避免无意义粒子链）。
+    _spawnBigSilhouette(game, x, y, baseA, mode, codex);
+
     // ===== 大碎片：立即出生 =====
     for (let i = 0; i < bigN; i++) {
         const aOffset = (Math.random() - 0.5) * BURST.dirConeBig * 2;
@@ -196,7 +202,7 @@ function _spawnElementSignature(game, x, y, baseA, elementKey, perf) {
         const ripples = perf.useStagger ? 3 : 1;
         for (let i = 0; i < ripples; i++) {
             const fire = () => {
-                const p = game.spawn_createParticle(x, y, '#FF0090', 'echo_ring');
+                const p = game.spawn_createParticle(x, y, '#FF2EA6', 'echo_ring');
                 if (p) {
                     p.size = 4 + i * 2;
                     p._expandRate = 0.5 + i * 0.15;
@@ -214,7 +220,7 @@ function _spawnElementSignature(game, x, y, baseA, elementKey, perf) {
         for (let i = 0; i < lineCount; i++) {
             const a = baseA + (Math.random() - 0.5) * 0.6; // ±17° 锥
             const sp = 5 + Math.random() * 3;
-            const p = game.spawn_createParticle(x, y, '#00E5FF', 'wind_slash');
+            const p = game.spawn_createParticle(x, y, '#00B4FF', 'wind_slash');
             if (p) {
                 if (p.vel) {
                     p.vel.x = Math.cos(a) * sp;
@@ -294,6 +300,39 @@ export function spawnRadialImpact(game, x, y, elementType) {
     if (typeof game.spawn_createShockwave === 'function') {
         game.spawn_createShockwave(x, y, '#FFFFFF');
     }
+}
+
+// ==================== 内部：F5 超大剪影粒子 ====================
+
+/**
+ * 在 (x, y) 处生成 1 个超大、静止、短寿的 silhouette 粒子。
+ * 作用：Promare 构图骨架（power-law 尺寸层级的顶端） —— 玩家先看到剪影，
+ * 然后碎片群从内部炸开，符合电影"大色块 + 内含小动作"的视觉节奏。
+ *
+ * @param {Game} game
+ * @param {number} x
+ * @param {number} y
+ * @param {number} angle - 沿入射反方向锁向（baseA）
+ * @param {string} mode  - 元素 mode（pyro_cone 等）
+ * @param {Object} codex - ELEMENT_CODEX[elementKey]
+ */
+function _spawnBigSilhouette(game, x, y, angle, mode, codex) {
+    const p = game.spawn_createParticle(x, y, codex.primary || '#FFFFFF', mode);
+    if (!p) return; // 预算超限
+    // 不移动：速度归零（_promareMode 下 drag=1 + gravity=0，没有阻力/重力消化它）
+    if (p.vel) { p.vel.x = 0; p.vel.y = 0; }
+    // 超大尺寸：~3× big 碎片 → 占冲击半径的核心位置
+    p.size = (p.size || 2) * (3.0 + Math.random() * 0.6);
+    // 锁向：沿入射反方向，pierce/wind 类的 angle 字段会被各 mode draw 用
+    p.angle = angle;
+    // 短寿：~0.2s（F1 stutter 下大约 2-3 个可见帧 → 闪现感）
+    p.life = 0.6;
+    p.maxLife = p.life;
+    p.decay = 0.05;
+    // 抑制 scatter / cryo 类的二次分裂（剪影不应该再裂）
+    p._splitFired = true;
+    // 抑制 venom_tri 的 drip（避免奇怪的尾迹）
+    if (p._dripPositions) p._dripPositions.length = 0;
 }
 
 // ==================== 内部：单粒子 spawn ====================

--- a/src/render/promare_explosion.js
+++ b/src/render/promare_explosion.js
@@ -142,17 +142,17 @@ export function spawnPromareKillExplosion(game, x, y, elementType, enemySize) {
 // ==================== 元素拟声词字典（Promare 拟声词视觉化技法）====================
 
 const ONOMATOPOEIA = {
-    pyro:         { text: 'BURN!',    color: '#FF0090' },
-    cryo:         { text: 'FREEZE!',  color: '#00E5FF' },
-    lightning:    { text: 'ZAP!',     color: '#FFD600' },
+    pyro:         { text: 'BURN!',    color: '#FF2EA6' },
+    cryo:         { text: 'FREEZE!',  color: '#00B4FF' },
+    lightning:    { text: 'ZAP!',     color: '#FFE94A' },
     pierce:       { text: 'PIERCE!',  color: '#FFFFFF' },
-    bounce:       { text: 'BOUNCE!',  color: '#FF0090' },
-    scatter:      { text: 'SPLIT!',   color: '#FFD600' },
+    bounce:       { text: 'BOUNCE!',  color: '#FF2EA6' },
+    scatter:      { text: 'SPLIT!',   color: '#FFE94A' },
     damage:       { text: 'CRIT!',    color: '#FFFFFF' },
-    wind:         { text: 'SLASH!',   color: '#00E5FF' },
+    wind:         { text: 'SLASH!',   color: '#00B4FF' },
     laser:        { text: 'FLASH!',   color: '#FFFFFF' },
-    venom:        { text: 'POISON!',  color: '#FFD600' },
-    echo:         { text: 'ECHO!',    color: '#FF0090' },
+    venom:        { text: 'POISON!',  color: '#FFE94A' },
+    echo:         { text: 'ECHO!',    color: '#FF2EA6' },
     flying_sword: { text: 'STRIKE!',  color: '#FFFFFF' },
 };
 
@@ -199,24 +199,18 @@ export function spawnPromareOnomatopoeia(game, x, y, elementType, enemyType) {
 }
 
 /**
- * 全屏色差通道偏移：通过 body 添加临时 class，CSS filter 处理。
- * 闪电主体本身不偏移（粒子绘制时已写死无偏移）。
+ * [Promare v2 F7] 色差通道偏移 — 已废弃为 no-op。
  *
- * @param {Game} game
- * @param {number} durationSec - 持续时间秒
+ * 电影《普罗米亚》几乎完全不使用色差（chromatic aberration）—— 这个滤镜是"模拟廉价镜头"的
+ * cinematography 语言，与 Promare 的"平涂硬切"取向相反。原版在 pyro/lightning/scatter/bounce
+ * 击杀时触发的 0.15s 全屏 RGB 分离是反 Promare 的"故障艺术"惯例，移除以恢复硬边色块。
+ *
+ * 调用位置（_triggerChromaticAberration / CHROMATIC_ELEMENTS）保持兼容，但不再产生效果。
+ * 击杀冲击感由 hitstop + flashRect + 大三角剪影碎裂承担（Tier 2 落地）。
+ *
+ * @param {Game} _game
+ * @param {number} _durationSec
  */
-function _triggerChromaticAberration(game, durationSec = 0.15) {
-    if (typeof document === 'undefined' || !document.body) return;
-    // 用 dataset 计数防止多次触发叠加导致一直卡在 chromatic 态
-    const body = document.body;
-    body.classList.add('promare-chromatic');
-    const stamp = Date.now();
-    body.dataset.promareChromaticStamp = String(stamp);
-    setTimeout(() => {
-        // 仅在 stamp 仍是最新时移除，防止覆盖更晚触发的色差
-        if (body.dataset.promareChromaticStamp === String(stamp)) {
-            body.classList.remove('promare-chromatic');
-            delete body.dataset.promareChromaticStamp;
-        }
-    }, Math.max(50, durationSec * 1000));
+function _triggerChromaticAberration(_game, _durationSec = 0.15) {
+    // intentionally empty — see comment above
 }

--- a/src/render/promare_shapes.js
+++ b/src/render/promare_shapes.js
@@ -14,7 +14,7 @@
  *   ctx.translate(p.x, p.y);
  *   ctx.rotate(p.angle);
  *   drawShape_cone3(ctx, p.size);
- *   ctx.fillStyle = '#FF0090';
+ *   ctx.fillStyle = '#FF2EA6';
  *   ctx.fill();
  *   ctx.restore();
  */
@@ -162,23 +162,70 @@ export function drawRadialImpact(ctx, r, spokeCount = 8) {
     ctx.arc(0, 0, r, 0, Math.PI * 2);
 }
 
-// ==================== Path 描边内发光辅助 ====================
-// 调用约定：path 已绘制；本函数封装「主色填充 + 白色内描边」的双 fill+stroke 组合。
+// ==================== Path 双层渲染：F2 + F4 ====================
+// 调用约定：path 已绘制；本函数完成「不透明主色填充 + 暗调描边」的双 fill+stroke 组合。
+//
+// [v2 改造] 反"加法发光"路线：
+//   - F2 改 source-over（不再 lighter）—— 多粒子重叠不再产生白雾 whitewash
+//   - F4 改暗调描边（不再统一白）—— 描边查 PROMARE_OUTLINES，没查到回退到调用方传入
+//   - fillAlpha 默认从 0.5 提到 0.95 —— Promare 是平涂色块，不是半透叠加
+//
+// 历史调用方继续传 strokeColor='#FFFFFF' 时，函数会忽略它并自动查暗调表。
+// 想强制走主色 stroke 时可以传非白色。
+//
+// @perf-impact: 单粒子 1 fill + 1 stroke + source-over；性能与原版基本持平。
 
-/**
- * 双层渲染：主色加法填充 + 白色内描边。模拟 Promare 内发光。
- * 假设 path 已 beginPath 并 closePath，调用方仅传入颜色与描边宽度。
- * @perf-impact: 单粒子 1 fill + 1 stroke + lighter composite。
- */
-export function fillStroke_promare(ctx, fillColor, strokeColor, strokeWidth = 1, fillAlpha = 0.5) {
+import { PROMARE_OUTLINES, PROMARE_PALETTE } from './promare_tokens.js';
+
+export function fillStroke_promare(ctx, fillColor, strokeColor, strokeWidth = 1, fillAlpha = 0.95) {
+    // F4: 描边色 = 主色暗调；白色描边请求被忽略
+    let outline = PROMARE_OUTLINES[fillColor];
+    if (!outline) {
+        // strokeColor 是显式覆盖（如 pierce_lance 传 PINK 描白主体），但白色描白色没意义 → 走默认
+        outline = (strokeColor && strokeColor !== PROMARE_PALETTE.WHITE) ? strokeColor : PROMARE_PALETTE.BLACK;
+    }
+
     ctx.save();
-    ctx.globalCompositeOperation = 'lighter';
+    ctx.globalCompositeOperation = 'source-over';  // F2: 平涂色块，不要加法
     ctx.globalAlpha = fillAlpha;
     ctx.fillStyle = fillColor;
     ctx.fill();
     ctx.globalAlpha = 1.0;
     ctx.lineWidth = strokeWidth;
-    ctx.strokeStyle = strokeColor;
+    ctx.strokeStyle = outline;
     ctx.stroke();
+    ctx.restore();
+}
+
+// ==================== F2: posterized 多段同心填充 ====================
+// 一次 path → 主色填充 + 内核更亮色（白/黄）二段同心；模拟两段硬切色块。
+// 调用前 path 必须未 fill。调用后会 fill 两次：外圈（fillColor）+ 内圈（coreColor, 0.55× scale）。
+//
+// @perf-impact: 单粒子 2 fill + 1 stroke；比单层多 1 fill。
+//   为了控制开销，只在"主体粒子"用 posterized；signature 装饰（drip / kanada）仍可单层。
+
+export function fillPosterized_promare(ctx, shapeDrawerFn, size, fillColor, coreColor, strokeWidth = 1) {
+    const outline = PROMARE_OUTLINES[fillColor] || PROMARE_PALETTE.BLACK;
+    ctx.save();
+    ctx.globalCompositeOperation = 'source-over';
+
+    // 外圈：主色平涂 + 暗描边
+    shapeDrawerFn(ctx, size);
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+    ctx.lineWidth = strokeWidth;
+    ctx.strokeStyle = outline;
+    ctx.stroke();
+
+    // 内核：0.55× 尺寸 + 高亮色
+    if (coreColor) {
+        ctx.save();
+        ctx.scale(0.55, 0.55);
+        shapeDrawerFn(ctx, size);
+        ctx.fillStyle = coreColor;
+        ctx.fill();
+        ctx.restore();
+    }
+
     ctx.restore();
 }

--- a/src/render/promare_tokens.js
+++ b/src/render/promare_tokens.js
@@ -13,14 +13,57 @@
  */
 
 // ==================== 5 色硬切板（核心 palette）====================
+// [v2 校色] 调到电影实拍取色 + 把"黑底"改为深紫底（F7：Promare 不用纯黑）。
+// 原版 #FF0090 / #00E5FF / #FFD600 / #0a0a0a 偏霓虹电子感，本次替换为：
+//   - PINK   #FF2EA6  研究里 Burnish 攻击色（更"糖果荧光"，少电子感）
+//   - CYAN   #00B4FF  Lio / 保护性蓝（更厚重，少屏幕青）
+//   - YELLOW #FFE94A  暖核高光（少塑料感）
+//   - BLACK  #1B0B2E  深紫底（电影里所有"阴影"都是带紫调的，不是真黑）
 
 export const PROMARE_PALETTE = {
-    PINK:   '#FF0090',   // 主色 1：火焰 / 弹射 / 穿透 accent / 危险
-    CYAN:   '#00E5FF',   // 主色 2：冰霜 / 风 / 激光 / 工具
-    YELLOW: '#FFD600',   // 主色 3：闪电 / 散射 / 警示
+    PINK:   '#FF2EA6',   // 主色 1：火焰 / 弹射 / 穿透 accent / 危险
+    CYAN:   '#00B4FF',   // 主色 2：冰霜 / 风 / 激光 / 工具
+    YELLOW: '#FFE94A',   // 主色 3：闪电 / 散射 / 警示
     WHITE:  '#FFFFFF',   // 中性高亮 / 核心 / 子弹白心
-    BLACK:  '#0a0a0a',   // 背景 / 阴影 / 实体填充
+    BLACK:  '#1B0B2E',   // 深紫底（命名保留 BLACK 防止全文 import 改名；语义=深紫底）
+    PURPLE_BRIDGE: '#9B5CFF',  // 粉-蓝过渡（备用）
 };
+
+// ==================== F4: 暗调描边色 ====================
+// 每个主色配一个暗化版本作为描边色（不是白、不是黑）。
+// fillStroke_promare 会自动查这张表；调用方传 strokeColor 时仍可覆盖。
+
+export const PROMARE_OUTLINES = {
+    [PROMARE_PALETTE.PINK]:   '#660F40',   // 暗紫红
+    [PROMARE_PALETTE.CYAN]:   '#003E5C',   // 暗深蓝
+    [PROMARE_PALETTE.YELLOW]: '#5C5008',   // 暗琥珀
+    [PROMARE_PALETTE.WHITE]:  '#1B0B2E',   // 白色描深紫底
+};
+
+// ==================== F1/F3/F6: Promare 粒子 mode 集合 ====================
+// 凡是属于这个集合的 mode，Particle 引擎会自动套用：
+//   - F1 时间量化 stutter（每 5 帧才推进 pos / angle）
+//   - F3 Pop-Hold-Snap 生命周期（draw 时不线性褪色）
+//   - F6 直线运动（gravity=0、drag=1、spin=0 覆盖各 mode 自带物理）
+// 不在集合里的 mode（spark/ember/mist/shard/...）保持原行为。
+
+export const PROMARE_MODES = new Set([
+    'pyro_cone',
+    'cryo_oct',
+    'thunder_z',
+    'pierce_lance',
+    'bounce_hex',
+    'scatter_star',
+    'damage_diamond',
+    'venom_tri',
+    'echo_ring',
+    'laser_beam',
+    'radial_spoke',
+]);
+
+export function isPromareMode(mode) {
+    return PROMARE_MODES.has(mode);
+}
 
 // ==================== Element Codex（12 元素）====================
 // 每元素的 shape / motion / 颜色映射；rendering 模块按 key 查表。

--- a/src/render3d/PostFX.js
+++ b/src/render3d/PostFX.js
@@ -35,49 +35,53 @@ import { FXAAShader }        from 'three/addons/shaders/FXAAShader.js';
 //   boss       深红 + 高饱和，整体压重，营造紧迫
 //   gameover   去饱和接近黑白，结束氛围
 // ===================================================================
-// [视觉调优] 用户反馈"3D 太暗 / 太透明，跟色彩鲜明的视觉要求不符"。
-// 全局降低 vignetteDarkness（边角不再吃光），提升 saturation（饱和度普涨 25-30%），
-// 削弱 split-tone 阴影/高光偏色（gradingStrength 减半），让 promare 5 色调色板
-// 不被 grading 拉灰。整体观感从"暗黑炼金"转向"高对比色块"。
+// [Promare v2 — F7] 反"暗黑炼金"路线：Promare 不靠后期，靠饱和 + 硬边 + 12fps stutter。
+// 历史调优把 bloom 0.85 / chromatic 0.005 / vignette 0.18-0.50 / grading 0.15-0.22 都拉得很满，
+// 结果是粒子被 bloom 糊成光雾、色差让颜色边缘抖、vignette 把深紫底拖向黑、grading 把粉/青拉灰。
+// 本次：
+//   - bloom 减半（baseline 0.55 / HDR 0.65）+ threshold 抬高，让 bloom 只挑真高光
+//   - chromatic / distortion 全关（电影里这两个滤镜几乎不出现，是 Promare 反例）
+//   - vignetteDarkness 各预设清零或几乎清零（不再吃边角，深紫底全屏铺）
+//   - gradingStrength 减半（保留阶段情绪 split-tone，但不拉灰原色）
 const GRADING_PRESETS = {
     meta: {
         saturation:       1.30,
         shadowR: 0.04, shadowG: 0.08, shadowB: 0.18,
         highlightR: 0.10, highlightG: 0.10, highlightB: 0.18,
-        gradingStrength:  0.18,
-        vignetteDarkness: 0.18,
+        gradingStrength:  0.09,
+        vignetteDarkness: 0.0,
         vignetteOffset:   0.78,
     },
     gathering: {
         saturation:       1.35,
         shadowR: 0.02, shadowG: 0.06, shadowB: 0.14,
         highlightR: 0.12, highlightG: 0.14, highlightB: 0.10,
-        gradingStrength:  0.15,
-        vignetteDarkness: 0.18,
+        gradingStrength:  0.08,
+        vignetteDarkness: 0.0,
         vignetteOffset:   0.82,
     },
     combat: {
         saturation:       1.40,
         shadowR: 0.03, shadowG: 0.05, shadowB: 0.12,
         highlightR: 0.16, highlightG: 0.10, highlightB: 0.04,
-        gradingStrength:  0.16,
-        vignetteDarkness: 0.20,
+        gradingStrength:  0.08,
+        vignetteDarkness: 0.0,
         vignetteOffset:   0.80,
     },
     boss: {
         saturation:       1.50,
         shadowR: 0.14, shadowG: 0.03, shadowB: 0.05,
         highlightR: 0.22, highlightG: 0.08, highlightB: 0.02,
-        gradingStrength:  0.22,
-        vignetteDarkness: 0.28,
+        gradingStrength:  0.11,
+        vignetteDarkness: 0.06,  // Boss 阶段保留极轻边角收口营造紧迫
         vignetteOffset:   0.72,
     },
     gameover: {
         saturation:       0.45,
         shadowR: 0.05, shadowG: 0.05, shadowB: 0.10,
         highlightR: 0.10, highlightG: 0.10, highlightB: 0.10,
-        gradingStrength:  0.40,
-        vignetteDarkness: 0.50,
+        gradingStrength:  0.30,
+        vignetteDarkness: 0.30,  // 结束氛围保留 vignette 帮助叙事
         vignetteOffset:   0.55,
     },
 };
@@ -92,8 +96,11 @@ const LENS_DISTORTION_SHADER = {
     name: 'LensDistortionShader',
     uniforms: {
         tDiffuse:    { value: null },
-        uDistortion: { value: 0.06 },    // 桶形畸变强度
-        uChromatic:  { value: 0.005 },   // RGB 色散
+        // [Promare v2 F7] 桶形畸变 + RGB 色散全部关到 0 ——
+        // 电影几乎不用这两个滤镜；桶形是"模拟变形镜头"，色散是"模拟廉价镜头"，
+        // 都是 cinematography 语言，与 Promare 的"平涂硬切"取向相反。
+        uDistortion: { value: 0.0 },
+        uChromatic:  { value: 0.0 },
         uVignettePower: { value: 0.0 },  // 不在这里做 vignette
     },
     vertexShader: /* glsl */`
@@ -144,19 +151,17 @@ const VIGNETTE_GRAIN_SHADER = {
     uniforms: {
         tDiffuse:          { value: null },
         uTime:             { value: 0 },
-        // [视觉调优] 默认 baseline 从「暗黑炼金」改成「高对比硬切」：
-        // vignette 退到 0.80，darkness 0.20（仅保留极轻微的边角收口）；
-        // saturation 拉到 1.40，让 PINK/CYAN/YELLOW 鲜艳；grading 减半免拉灰；
-        // grain 减到 0.018，避免颗粒污染纯色块。
+        // [Promare v2 F7] vignette / grain baseline 全清零；grading 减半。
+        // setGradingPreset() 会立刻把这些 lerp 到 GRADING_PRESETS 里对应阶段值。
         uVignetteOffset:   { value: 0.80 },
-        uVignetteDarkness: { value: 0.20 },
-        uGrainAmount:      { value: 0.018 },
+        uVignetteDarkness: { value: 0.0 },   // 旧 0.20 → 0（让深紫底铺满屏）
+        uGrainAmount:      { value: 0.0 },   // 旧 0.018 → 0（颗粒污染平涂色块）
         uResolution:       { value: new THREE.Vector2(1, 1) },
         // [M4 调优] Color grading 参数
         uSaturation:       { value: 1.40 },   // 全局饱和度（1.0=原色）
         uShadowTint:       { value: new THREE.Color(0.03, 0.05, 0.12) }, // 冷蓝阴影（更轻）
         uHighlightTint:    { value: new THREE.Color(0.16, 0.10, 0.04) }, // 暖橙高光（更轻）
-        uGradingStrength:  { value: 0.16 },   // grading 混入强度
+        uGradingStrength:  { value: 0.08 },   // 旧 0.16 → 0.08（保留情绪 split-tone，但不拉灰）
         // [M4] 暴击/大伤害瞬时白闪强度（0..1），由 CameraController 每帧推送，自然衰减
         uFlash:            { value: 0.0 },
         uFlashColor:       { value: new THREE.Color(1.0, 0.98, 0.92) }, // 略偏暖白
@@ -280,19 +285,21 @@ export class PostFX {
         this.composer.addPass(this.renderPass);
 
         // --- Pass 2: bloom ---
-        // [视觉调优] 用户反馈"3D 太暗"——bloom strength 上调（LDR 0.78→1.05, HDR 0.90→1.20）、
-        // threshold 下调（LDR 0.55→0.42, HDR 0.78→0.62），让弹珠/钉子/粒子的 rim 与中等亮度
-        // 区域也参与泛光，整体观感更通透。
+        // [Promare v2 F7] Bloom 大幅收紧 ——
+        // Promare 不靠 bloom 营造亮度，靠"饱和原色 + 硬切色块"。原版 strength 0.78-1.20 让所有
+        // 中等亮度区域都参与发光 → 粒子糊成光雾、丢失硬边。
+        // 新值：strength 半截以下 + threshold 抬到 0.78（LDR）/ 0.90（HDR），只让真正过曝的
+        // 点（白核 / 闪光帧）触发 bloom，正常色块保持硬边。
         this.bloomPass = new UnrealBloomPass(
             new THREE.Vector2(this.width, this.height),
-            1.05,
-            0.55,
-            0.42
+            0.35,    // strength：旧 1.05 → 0.35
+            0.45,    // radius：旧 0.55 → 0.45（更聚焦）
+            0.78     // threshold：旧 0.42 → 0.78
         );
         if (this.usingHDR) {
-            this.bloomPass.threshold = 0.62;
-            this.bloomPass.strength = 1.20;
-            this.bloomPass.radius = 0.55;
+            this.bloomPass.threshold = 0.90;
+            this.bloomPass.strength = 0.45;
+            this.bloomPass.radius = 0.50;
         }
         this.composer.addPass(this.bloomPass);
 

--- a/src/render_system.js
+++ b/src/render_system.js
@@ -108,7 +108,7 @@ export const render_system = {
 
                 // 连线 — 硬 zigzag 折线（替代虚线 + shadowBlur）
                 if (this.windAnchors.length > 1) {
-                    ctx.strokeStyle = '#00E5FF';
+                    ctx.strokeStyle = '#00B4FF';
                     ctx.lineWidth = 2 + linePulse * 1.5;
                     ctx.globalAlpha = 0.55 + linePulse * 0.25;
                     ctx.beginPath();
@@ -143,7 +143,7 @@ export const render_system = {
                     ctx.lineTo(0, r);
                     ctx.lineTo(-r, 0);
                     ctx.closePath();
-                    ctx.fillStyle = '#00E5FF';
+                    ctx.fillStyle = '#00B4FF';
                     ctx.globalAlpha = 0.6 + pulse * 0.3;
                     ctx.fill();
                     // 内层钻石（白色实心）
@@ -163,13 +163,13 @@ export const render_system = {
                     ctx.font = 'bold 10px "Inter Mono", monospace';
                     ctx.textAlign = 'center';
                     ctx.textBaseline = 'middle';
-                    ctx.fillStyle = '#0a0a0a';
+                    ctx.fillStyle = '#1B0B2E';
                     const ox = a.x + 12, oy = a.y - 12;
                     ctx.fillText(idx + 1, ox + 1, oy);
                     ctx.fillText(idx + 1, ox - 1, oy);
                     ctx.fillText(idx + 1, ox, oy + 1);
                     ctx.fillText(idx + 1, ox, oy - 1);
-                    ctx.fillStyle = '#FFD600';
+                    ctx.fillStyle = '#FFE94A';
                     ctx.fillText(idx + 1, ox, oy);
                 });
                 ctx.restore();
@@ -747,9 +747,9 @@ export const render_system = {
             ctx.lineTo( halfW,     halfH);
             ctx.lineTo(-halfW,     halfH);
             ctx.closePath();
-            ctx.fillStyle = '#0a0a0a';
+            ctx.fillStyle = '#1B0B2E';
             ctx.fill();
-            ctx.strokeStyle = '#FF0090';
+            ctx.strokeStyle = '#FF2EA6';
             ctx.lineWidth = 2;
             ctx.stroke();
             // 充能内饰：从顶部向下填 CYAN，按 chargeProgress
@@ -765,12 +765,12 @@ export const render_system = {
                 const fillH = halfH * 2 * chargeProgress;
                 ctx.globalCompositeOperation = 'lighter';
                 ctx.globalAlpha = 0.6;
-                ctx.fillStyle = '#00E5FF';
+                ctx.fillStyle = '#00B4FF';
                 ctx.fillRect(-halfW, halfH - fillH, halfW * 2, fillH);
                 ctx.restore();
             }
             // 顶部装饰：3 小菱形
-            ctx.fillStyle = '#FFD600';
+            ctx.fillStyle = '#FFE94A';
             for (let i = -1; i <= 1; i++) {
                 ctx.beginPath();
                 ctx.moveTo(i * 18, -halfH - 2);
@@ -985,7 +985,7 @@ export const render_system = {
         if (!recipe) return;
 
         // 元素 type → 颜色映射
-        const PAL = { PINK: '#FF0090', CYAN: '#00E5FF', YELLOW: '#FFD600', WHITE: '#FFFFFF', BLACK: '#0a0a0a' };
+        const PAL = { PINK: '#FF2EA6', CYAN: '#00B4FF', YELLOW: '#FFE94A', WHITE: '#FFFFFF', BLACK: '#1B0B2E' };
         const elemColor = {
             pyro: PAL.PINK, bounce: PAL.PINK, pierce: PAL.WHITE, scatter: PAL.YELLOW,
             cryo: PAL.CYAN, lightning: PAL.YELLOW, laser: PAL.CYAN, wind: PAL.CYAN,
@@ -1070,7 +1070,7 @@ export const render_system = {
     _render_promareWindMatrix(matrix, progress, time) {
         const { rect, type, anchors } = matrix;
         const ctx = this.ctx;
-        const PAL = { PINK: '#FF0090', CYAN: '#00E5FF', YELLOW: '#FFD600', WHITE: '#FFFFFF' };
+        const PAL = { PINK: '#FF2EA6', CYAN: '#00B4FF', YELLOW: '#FFE94A', WHITE: '#FFFFFF' };
         ctx.save();
 
         // 1. 主框：硬 zigzag 折线 anchors → anchors 连成，每段中点 ±2px 垂直偏移
@@ -1207,7 +1207,7 @@ export const render_system = {
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.globalAlpha = progress;
-            ctx.fillStyle = '#0a0a0a';
+            ctx.fillStyle = '#1B0B2E';
             const offs = [[2,0],[-2,0],[0,2],[0,-2]];
             for (const [ox, oy] of offs) ctx.fillText(txt, ox, oy);
             ctx.fillStyle = PAL.YELLOW;
@@ -1242,7 +1242,7 @@ export const render_system = {
             ctx.globalAlpha = progress;
             const txt = 'BURST';
             // BLACK 4 向 stamp
-            ctx.fillStyle = '#0a0a0a';
+            ctx.fillStyle = '#1B0B2E';
             for (const [ox, oy] of [[2,0],[-2,0],[0,2],[0,-2]]) ctx.fillText(txt, cx + ox, cy + oy);
             // YELLOW 主体
             ctx.fillStyle = PAL.YELLOW;

--- a/src/styles/promare_ui.css
+++ b/src/styles/promare_ui.css
@@ -2,7 +2,7 @@
  *
  * 作用域：body.promare-mode 下的所有 UI 元素
  * 设计原则：
- *   - 5 色硬切板：#FF0090 / #00E5FF / #FFD600 / #FFFFFF / #0a0a0a
+ *   - 5 色硬切板：#FF2EA6 / #00B4FF / #FFE94A / #FFFFFF / #1B0B2E
  *   - 对角切边（clip-path 梯形）替代圆角
  *   - 硬边描边 + 内描边假发光，无 box-shadow blur
  *   - Inter Mono / monospace 字体替代 Cinzel 衬线
@@ -14,29 +14,29 @@
 /* ==================== 全局基色覆盖 ==================== */
 
 body.promare-mode {
-    background-color: #0a0a0a !important;
+    background-color: #1B0B2E !important;
     color: #FFFFFF !important;
     font-family: 'Inter Mono', 'Roboto Mono', 'Courier New', monospace !important;
 }
 
 body.promare-mode #game-container,
 body.promare-mode #game-area {
-    background-color: #0a0a0a !important;
+    background-color: #1B0B2E !important;
 }
 
 /* ==================== 顶部状态栏：对角切边 + PINK 左边条 ==================== */
 
 body.promare-mode #unified-top-bar {
     clip-path: polygon(0 0, 100% 0, 95% 100%, 0 100%);
-    border-left: 3px solid #FF0090 !important;
-    background: #0a0a0a !important;
+    border-left: 3px solid #FF2EA6 !important;
+    background: #1B0B2E !important;
     backdrop-filter: none !important;
     box-shadow: none !important;
 }
 
 body.promare-mode #unified-top-bar > * {
     color: #FFFFFF !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
 }
 
 /* ==================== 按钮：梯形切角 ==================== */
@@ -45,9 +45,9 @@ body.promare-mode button,
 body.promare-mode .btn {
     clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
     border-radius: 0 !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     color: #FFFFFF !important;
-    border: 2px solid #FF0090 !important;
+    border: 2px solid #FF2EA6 !important;
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
     text-shadow: none !important;
     box-shadow: none !important;
@@ -56,7 +56,7 @@ body.promare-mode .btn {
 
 body.promare-mode button:hover,
 body.promare-mode .btn:hover {
-    background: #FF0090 !important;
+    background: #FF2EA6 !important;
     color: #FFFFFF !important;
     transform: translateY(-1px);
 }
@@ -71,7 +71,7 @@ body.promare-mode #settings-btn,
 body.promare-mode #speed-btn {
     clip-path: none;
     border: 2px solid #FFFFFF !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
 }
 
 /* ==================== 卡牌：几何边框 + 内描边 ==================== */
@@ -81,9 +81,9 @@ body.promare-mode .relic-card,
 body.promare-mode .selection-card,
 body.promare-mode .shop-card {
     border-radius: 0 !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
-    box-shadow: inset 3px 3px 0 #FF0090, inset -3px -3px 0 #00E5FF !important;
+    box-shadow: inset 3px 3px 0 #FF2EA6, inset -3px -3px 0 #00B4FF !important;
     backdrop-filter: none !important;
     font-family: 'Inter Mono', monospace !important;
 }
@@ -91,8 +91,8 @@ body.promare-mode .shop-card {
 body.promare-mode .rune-card:hover,
 body.promare-mode .relic-card:hover,
 body.promare-mode .selection-card:hover {
-    border-color: #FFD600 !important;
-    box-shadow: inset 3px 3px 0 #FFD600, inset -3px -3px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 3px 3px 0 #FFE94A, inset -3px -3px 0 #FFE94A !important;
 }
 
 /* ==================== 弹窗面板：硬切边框 ==================== */
@@ -102,11 +102,11 @@ body.promare-mode #phase-shop,
 body.promare-mode #phase-relic,
 body.promare-mode .modal-panel,
 body.promare-mode .overlay-panel {
-    background: rgba(10, 10, 10, 0.92) !important;
+    background: rgba(27, 11, 46, 0.92) !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
     backdrop-filter: none !important;
-    box-shadow: 0 0 0 4px #FF0090 !important;
+    box-shadow: 0 0 0 4px #FF2EA6 !important;
 }
 
 /* ==================== 底部弹药/发射器面板 ==================== */
@@ -114,8 +114,8 @@ body.promare-mode .overlay-panel {
 body.promare-mode .bottom-panel,
 body.promare-mode #ammo-bar,
 body.promare-mode #ammo-display {
-    background: #0a0a0a !important;
-    border-top: 2px solid #00E5FF !important;
+    background: #1B0B2E !important;
+    border-top: 2px solid #00B4FF !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
 }
@@ -151,7 +151,7 @@ body.promare-mode .ammo-icon,
 body.promare-mode .rune-icon,
 body.promare-mode .relic-icon {
     position: relative !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
     border-radius: 0 !important;
     box-shadow: none !important;
@@ -211,18 +211,18 @@ body.promare-mode .relic-card.rarity-common {
 }
 body.promare-mode .rune-icon-frame.rarity-rare,
 body.promare-mode .relic-card.rarity-rare {
-    border: 2px solid #00E5FF !important;
-    box-shadow: inset 0 0 0 1px #00E5FF !important;
+    border: 2px solid #00B4FF !important;
+    box-shadow: inset 0 0 0 1px #00B4FF !important;
 }
 body.promare-mode .rune-icon-frame.rarity-epic,
 body.promare-mode .relic-card.rarity-epic {
-    border: 2px solid #FF0090 !important;
-    box-shadow: inset 0 0 0 1px #FF0090, 0 0 0 1px #FF0090 !important;
+    border: 2px solid #FF2EA6 !important;
+    box-shadow: inset 0 0 0 1px #FF2EA6, 0 0 0 1px #FF2EA6 !important;
 }
 body.promare-mode .rune-icon-frame.rarity-legendary,
 body.promare-mode .relic-card.rarity-legendary {
-    border: 2px solid #FFD600 !important;
-    box-shadow: inset 0 0 0 2px #FFD600, 0 0 0 1px #FF0090, 0 0 0 3px #FFD600 !important;
+    border: 2px solid #FFE94A !important;
+    box-shadow: inset 0 0 0 2px #FFE94A, 0 0 0 1px #FF2EA6, 0 0 0 3px #FFE94A !important;
 }
 
 /* SP gauge pulse 流光（gauge-pulse-layer ::before/::after）用 conic-gradient
@@ -234,8 +234,8 @@ body.promare-mode #gauge-shell::after {
 }
 
 body.promare-mode #gauge-shell {
-    background: #0a0a0a !important;
-    border: 2px solid #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FFE94A !important;
     border-radius: 0 !important;
     box-shadow: none !important;
     mask-image: none !important;
@@ -244,7 +244,7 @@ body.promare-mode #gauge-shell {
 
 body.promare-mode #gauge-shell.pulse-active,
 body.promare-mode #gauge-pulse-layer.pulse-active {
-    box-shadow: 0 0 0 2px #FFFFFF, 0 0 0 4px #FFD600 !important;
+    box-shadow: 0 0 0 2px #FFFFFF, 0 0 0 4px #FFE94A !important;
 }
 
 /* select-card::before 渐变光晕（白色 linear-gradient）也关 */
@@ -290,7 +290,7 @@ body.promare-mode .sp-gem::before {
     position: absolute;
     top: 0; left: 0; right: 0; bottom: 0;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
-    background: #FFD600;
+    background: #FFE94A;
     opacity: 0.3;
 }
 body.promare-mode .sp-gem.active::before,
@@ -303,7 +303,7 @@ body.promare-mode .sp-gem-filled::before {
 /* settings / speed 按钮替代：白色 ◯/⚙ 几何 */
 body.promare-mode #settings-btn,
 body.promare-mode #speed-btn {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     clip-path: none !important;
     font-family: 'Inter Mono', monospace !important;
@@ -320,7 +320,7 @@ body.promare-mode #settings-btn::before {
 }
 body.promare-mode #speed-btn::before {
     content: '▶▶';
-    color: #FFD600;
+    color: #FFE94A;
     font-size: 12px;
     letter-spacing: -2px;
 }
@@ -328,14 +328,14 @@ body.promare-mode #speed-btn::before {
 /* 符文槽态：idle / hover / filled — 用 border-color + inset shadow 区分 */
 body.promare-mode .rune-grid-cell {
     /* 已在前面定义为 BLACK + WHITE 边框 + PINK/CYAN 对角阴影 */
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
 }
 
 /* Skip 按钮：清掉位图，用梯形切边按钮 */
 body.promare-mode .skip-btn {
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
-    color: #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
+    color: #FFE94A !important;
     font-family: 'Inter Mono', monospace !important;
     border-radius: 0 !important;
     clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
@@ -347,28 +347,28 @@ body.promare-mode .skip-btn {
    + PINK/CYAN 顶下硬切框。 */
 
 body.promare-mode #round-start-banner {
-    background: rgba(10, 10, 10, 0.7) !important;
+    background: rgba(27, 11, 46, 0.7) !important;
 }
 
 body.promare-mode #round-start-banner-text {
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
     font-weight: 900 !important;
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     letter-spacing: 8px !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     -webkit-background-clip: initial !important;
-    -webkit-text-fill-color: #FFD600 !important;
+    -webkit-text-fill-color: #FFE94A !important;
     /* 4-direction BLACK stamp + 外发光替代 */
     text-shadow:
-        3px 0 0 #0a0a0a,
-        -3px 0 0 #0a0a0a,
-        0 3px 0 #0a0a0a,
-        0 -3px 0 #0a0a0a,
-        4px 4px 0 #FF0090,
-        -4px -4px 0 #00E5FF !important;
+        3px 0 0 #1B0B2E,
+        -3px 0 0 #1B0B2E,
+        0 3px 0 #1B0B2E,
+        0 -3px 0 #1B0B2E,
+        4px 4px 0 #FF2EA6,
+        -4px -4px 0 #00B4FF !important;
     padding: 16px 32px !important;
-    border-top: 3px solid #FF0090;
-    border-bottom: 3px solid #00E5FF;
+    border-top: 3px solid #FF2EA6;
+    border-bottom: 3px solid #00B4FF;
 }
 
 /* 关闭 blur 动画（promare 不要模糊） */
@@ -388,7 +388,7 @@ body.promare-mode .round-banner-glow #round-start-banner-text {
 /* 原版红色径向渐变 — 替换为黑色 + PINK 顶部+底部条纹（拼贴感） */
 
 body.promare-mode #boss-entrance-overlay {
-    background: rgba(10, 10, 10, 0.85) !important;
+    background: rgba(27, 11, 46, 0.85) !important;
 }
 
 body.promare-mode #boss-entrance-overlay.boss-entrance-active::before,
@@ -399,10 +399,10 @@ body.promare-mode #boss-entrance-overlay.boss-entrance-active::after {
     height: 6%;
     background: repeating-linear-gradient(
         135deg,
-        #FF0090 0px,
-        #FF0090 14px,
-        #0a0a0a 14px,
-        #0a0a0a 28px
+        #FF2EA6 0px,
+        #FF2EA6 14px,
+        #1B0B2E 14px,
+        #1B0B2E 28px
     );
 }
 
@@ -417,17 +417,17 @@ body.promare-mode #boss-entrance-overlay.boss-entrance-active::after {
 /* ==================== Combat Message（精英援军入场等）==================== */
 
 body.promare-mode #combat-message > div {
-    background: #0a0a0a !important;
-    color: #FFD600 !important;
-    border: 2px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    color: #FFE94A !important;
+    border: 2px solid #FF2EA6 !important;
     border-radius: 0 !important;
     backdrop-filter: none !important;
-    box-shadow: inset 2px 2px 0 #FFD600 !important;
+    box-shadow: inset 2px 2px 0 #FFE94A !important;
     font-family: 'Inter Mono', monospace !important;
 }
 
 body.promare-mode #combat-message span {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     font-family: 'Inter Mono', monospace !important;
 }
 
@@ -435,16 +435,16 @@ body.promare-mode #combat-message span {
 
 body.promare-mode #phase-game-over,
 body.promare-mode .game-over-overlay {
-    background: rgba(10, 10, 10, 0.96) !important;
+    background: rgba(27, 11, 46, 0.96) !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode .game-over-panel,
 body.promare-mode #game-over-content {
-    background: #0a0a0a !important;
-    border: 3px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 3px solid #FF2EA6 !important;
     border-radius: 0 !important;
-    box-shadow: inset 4px 4px 0 #00E5FF, 0 0 0 4px #FFD600 !important;
+    box-shadow: inset 4px 4px 0 #00B4FF, 0 0 0 4px #FFE94A !important;
     backdrop-filter: none !important;
     padding: 24px !important;
 }
@@ -452,10 +452,10 @@ body.promare-mode #game-over-content {
 body.promare-mode .game-over-title,
 body.promare-mode #game-over-title {
     font-family: 'Inter Mono', monospace !important;
-    color: #FF0090 !important;
+    color: #FF2EA6 !important;
     text-shadow:
-        2px 0 0 #0a0a0a, -2px 0 0 #0a0a0a, 0 2px 0 #0a0a0a, 0 -2px 0 #0a0a0a,
-        3px 3px 0 #FFD600 !important;
+        2px 0 0 #1B0B2E, -2px 0 0 #1B0B2E, 0 2px 0 #1B0B2E, 0 -2px 0 #1B0B2E,
+        3px 3px 0 #FFE94A !important;
     letter-spacing: 6px !important;
 }
 
@@ -463,8 +463,8 @@ body.promare-mode .stat-row,
 body.promare-mode .game-over-stat {
     border-radius: 0 !important;
     border: 1px solid #FFFFFF !important;
-    background: #0a0a0a !important;
-    box-shadow: inset 1px 1px 0 #FF0090 !important;
+    background: #1B0B2E !important;
+    box-shadow: inset 1px 1px 0 #FF2EA6 !important;
     font-family: 'Inter Mono', monospace !important;
     color: #FFFFFF !important;
 }
@@ -472,35 +472,35 @@ body.promare-mode .game-over-stat {
 /* ==================== 真理之书 Truth Book ==================== */
 
 body.promare-mode #phase-truth-book {
-    background: rgba(10, 10, 10, 0.98) !important;
+    background: rgba(27, 11, 46, 0.98) !important;
     backdrop-filter: none !important;
 }
 
 /* 主标题 "真理之書 Liber Veritatis" */
 body.promare-mode #phase-truth-book h2 {
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
-    color: #00E5FF !important;
+    color: #00B4FF !important;
     letter-spacing: 6px !important;
     text-shadow:
-        2px 0 0 #0a0a0a, -2px 0 0 #0a0a0a, 0 2px 0 #0a0a0a, 0 -2px 0 #0a0a0a,
-        3px 3px 0 #FF0090 !important;
+        2px 0 0 #1B0B2E, -2px 0 0 #1B0B2E, 0 2px 0 #1B0B2E, 0 -2px 0 #1B0B2E,
+        3px 3px 0 #FF2EA6 !important;
     filter: none !important;
 }
 
 body.promare-mode #phase-truth-book h2 span {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     font-size: 0.6em !important;
     letter-spacing: 2px !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
 }
 
 /* 列表项 (敌人/属性 entries) */
 body.promare-mode #truth-enemy-list > div,
 body.promare-mode #truth-attr-list > div,
 body.promare-mode .truth-list-item {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 1px solid #FFFFFF !important;
-    border-left: 3px solid #FF0090 !important;
+    border-left: 3px solid #FF2EA6 !important;
     border-radius: 0 !important;
     color: #FFFFFF !important;
     font-family: 'Inter Mono', monospace !important;
@@ -513,22 +513,22 @@ body.promare-mode #truth-enemy-list > div:hover,
 body.promare-mode #truth-attr-list > div:hover,
 body.promare-mode .truth-list-item:hover,
 body.promare-mode .truth-list-item.active {
-    border-left-color: #FFD600 !important;
-    border-color: #FFD600 !important;
+    border-left-color: #FFE94A !important;
+    border-color: #FFE94A !important;
     transform: translateX(2px);
 }
 
 /* 详情面板 */
 body.promare-mode #truth-detail-panel {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 3px 3px 0 #FF0090, inset -3px -3px 0 #00E5FF !important;
+    box-shadow: inset 3px 3px 0 #FF2EA6, inset -3px -3px 0 #00B4FF !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode #truth-empty-state {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     opacity: 0.5;
 }
 
@@ -538,13 +538,13 @@ body.promare-mode #truth-empty-state span {
 
 body.promare-mode #truth-empty-state p {
     font-family: 'Inter Mono', monospace !important;
-    color: #FFD600 !important;
+    color: #FFE94A !important;
 }
 
 /* 顶部标题区（图标 + 名字 + tags） */
 body.promare-mode #truth-content > div:first-child {
-    background: #0a0a0a !important;
-    border-bottom: 2px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border-bottom: 2px solid #FF2EA6 !important;
     backdrop-filter: none !important;
 }
 
@@ -555,8 +555,8 @@ body.promare-mode #truth-item-icon {
 
 /* 名字图标容器 — 强制菱形 */
 body.promare-mode #truth-content > div:first-child > div:first-child > div:first-child {
-    background: #0a0a0a !important;
-    border: 2px solid #00E5FF !important;
+    background: #1B0B2E !important;
+    border: 2px solid #00B4FF !important;
     border-radius: 0 !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
     box-shadow: none !important;
@@ -566,13 +566,13 @@ body.promare-mode #truth-item-name {
     font-family: 'Inter Mono', monospace !important;
     color: #FFFFFF !important;
     letter-spacing: 3px !important;
-    text-shadow: 2px 2px 0 #FF0090 !important;
+    text-shadow: 2px 2px 0 #FF2EA6 !important;
 }
 
 body.promare-mode #truth-item-tags > span {
-    background: #0a0a0a !important;
-    border: 1px solid #FFD600 !important;
-    color: #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 1px solid #FFE94A !important;
+    color: #FFE94A !important;
     border-radius: 0 !important;
     font-family: 'Inter Mono', monospace !important;
 }
@@ -584,20 +584,20 @@ body.promare-mode #truth-item-desc {
 
 /* 演示区 canvas 容器 + simulation matrix 标签 */
 body.promare-mode #truth-content .flex-1 {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
 }
 
 body.promare-mode #truth-content [class*="bg-cyan-950"],
 body.promare-mode #truth-content [class*="bg-slate-"] {
-    background: #0a0a0a !important;
-    border-left-color: #00E5FF !important;
-    color: #00E5FF !important;
+    background: #1B0B2E !important;
+    border-left-color: #00B4FF !important;
+    color: #00B4FF !important;
     border-radius: 0 !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode #truth-sim-time {
-    color: #00E5FF !important;
+    color: #00B4FF !important;
     font-family: 'Inter Mono', monospace !important;
 }
 
@@ -609,18 +609,18 @@ body.promare-mode #truth-demo-log {
 
 /* 关闭按钮 */
 body.promare-mode #phase-truth-book button[onclick*="closeTruthBook"] {
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
-    color: #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
+    color: #FF2EA6 !important;
     border-radius: 0 !important;
     clip-path: none !important;
 }
 
 /* 重置 demo 按钮 */
 body.promare-mode #phase-truth-book button[onclick*="resetDemo"] {
-    background: #0a0a0a !important;
-    border: 1px solid #00E5FF !important;
-    color: #00E5FF !important;
+    background: #1B0B2E !important;
+    border: 1px solid #00B4FF !important;
+    color: #00B4FF !important;
     border-radius: 0 !important;
     clip-path: none !important;
 }
@@ -629,38 +629,38 @@ body.promare-mode #phase-truth-book button[onclick*="resetDemo"] {
 /* run_shop.js 用 inline style 动态生成 DOM，必须用强 !important 覆盖 */
 
 body.promare-mode #run-shop-overlay {
-    background: rgba(10, 10, 10, 0.95) !important;
+    background: rgba(27, 11, 46, 0.95) !important;
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
     color: #FFFFFF !important;
 }
 
 /* 主面板：移除圆角和紫色渐变，用 Promare 5 色硬切 */
 body.promare-mode #run-shop-overlay > div {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 3px 3px 0 #FF0090, inset -3px -3px 0 #00E5FF, 0 0 0 3px #FFD600 !important;
+    box-shadow: inset 3px 3px 0 #FF2EA6, inset -3px -3px 0 #00B4FF, 0 0 0 3px #FFE94A !important;
 }
 
 /* 标题分割线 */
 body.promare-mode #run-shop-overlay > div > div:first-child {
-    border-bottom: 2px solid #FF0090 !important;
+    border-bottom: 2px solid #FF2EA6 !important;
 }
 
 body.promare-mode #run-shop-overlay > div > div:first-child > div:first-child {
-    color: #FFD600 !important;
-    text-shadow: 2px 2px 0 #FF0090 !important;
+    color: #FFE94A !important;
+    text-shadow: 2px 2px 0 #FF2EA6 !important;
     letter-spacing: 4px !important;
 }
 
 /* 持有碎片 + 数字 */
 body.promare-mode #run-shop-overlay span {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
 }
 
 /* 商品卡片 .run-shop-item — 覆盖紫色 rarity 边框 */
 body.promare-mode #run-shop-overlay .run-shop-item {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border-radius: 0 !important;
     box-shadow: inset 1px 1px 0 currentColor !important;
     color: #FFFFFF !important;
@@ -669,18 +669,18 @@ body.promare-mode #run-shop-overlay .run-shop-item {
 /* 稀有度边框颜色映射到 5 色 — inline border-color 用 attribute style 覆盖 */
 body.promare-mode #run-shop-overlay .run-shop-item[style*="rgb(250, 204, 21)"],
 body.promare-mode #run-shop-overlay .run-shop-item[style*="#facc15"] {
-    border-color: #FFD600 !important;
-    color: #FFD600 !important;
+    border-color: #FFE94A !important;
+    color: #FFE94A !important;
 }
 body.promare-mode #run-shop-overlay .run-shop-item[style*="rgb(168, 85, 247)"],
 body.promare-mode #run-shop-overlay .run-shop-item[style*="#a855f7"] {
-    border-color: #FF0090 !important;
-    color: #FF0090 !important;
+    border-color: #FF2EA6 !important;
+    color: #FF2EA6 !important;
 }
 body.promare-mode #run-shop-overlay .run-shop-item[style*="rgb(59, 130, 246)"],
 body.promare-mode #run-shop-overlay .run-shop-item[style*="#3b82f6"] {
-    border-color: #00E5FF !important;
-    color: #00E5FF !important;
+    border-color: #00B4FF !important;
+    color: #00B4FF !important;
 }
 body.promare-mode #run-shop-overlay .run-shop-item[style*="rgb(148, 163, 184)"],
 body.promare-mode #run-shop-overlay .run-shop-item[style*="#94a3b8"] {
@@ -691,7 +691,7 @@ body.promare-mode #run-shop-overlay .run-shop-item[style*="#94a3b8"] {
 /* 商品 hover 反馈 */
 body.promare-mode #run-shop-overlay .run-shop-item:hover {
     transform: translateY(-2px);
-    box-shadow: inset 1px 1px 0 currentColor, 0 0 0 1px #FFD600 !important;
+    box-shadow: inset 1px 1px 0 currentColor, 0 0 0 1px #FFE94A !important;
 }
 
 /* 商品内文字回到白色 */
@@ -702,9 +702,9 @@ body.promare-mode #run-shop-overlay .run-shop-item > div:nth-child(3) {
 
 /* 按钮（刷新 / 离开）梯形切角 */
 body.promare-mode #run-shop-refresh-btn {
-    background: #0a0a0a !important;
-    border: 2px solid #00E5FF !important;
-    color: #00E5FF !important;
+    background: #1B0B2E !important;
+    border: 2px solid #00B4FF !important;
+    color: #00B4FF !important;
     border-radius: 0 !important;
     clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
     font-family: 'Inter Mono', monospace !important;
@@ -712,9 +712,9 @@ body.promare-mode #run-shop-refresh-btn {
 }
 
 body.promare-mode #run-shop-close-btn {
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
-    color: #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
+    color: #FFE94A !important;
     border-radius: 0 !important;
     clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
     font-family: 'Inter Mono', monospace !important;
@@ -724,14 +724,14 @@ body.promare-mode #run-shop-close-btn {
 body.promare-mode #run-shop-refresh-btn:hover,
 body.promare-mode #run-shop-close-btn:hover {
     background: currentColor !important;
-    color: #0a0a0a !important;
+    color: #1B0B2E !important;
 }
 
 /* ==================== 命运时刻 / 遗物选择 (Relic / Fate Moment) ==================== */
 /* #phase-relic 是命运抉择 + 遗物 + 混沌/纯净精华弹窗共用的容器 */
 
 body.promare-mode #phase-relic {
-    background: rgba(10, 10, 10, 0.96) !important;
+    background: rgba(27, 11, 46, 0.96) !important;
     backdrop-filter: none !important;
 }
 
@@ -741,8 +741,8 @@ body.promare-mode #phase-relic h2,
 body.promare-mode #phase-relic h3,
 body.promare-mode #phase-relic > div > div:first-child {
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
-    color: #FFD600 !important;
-    text-shadow: 2px 2px 0 #FF0090, -2px -2px 0 #00E5FF !important;
+    color: #FFE94A !important;
+    text-shadow: 2px 2px 0 #FF2EA6, -2px -2px 0 #00B4FF !important;
     letter-spacing: 4px !important;
     background: none !important;
     -webkit-background-clip: initial !important;
@@ -751,42 +751,42 @@ body.promare-mode #phase-relic > div > div:first-child {
 
 /* .relic-card 容器 — 覆盖 linear-gradient 背景 + 圆角 */
 body.promare-mode .relic-card {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 2px 2px 0 #FF0090, inset -2px -2px 0 #00E5FF !important;
+    box-shadow: inset 2px 2px 0 #FF2EA6, inset -2px -2px 0 #00B4FF !important;
     transition: transform 0.1s, border-color 0.12s !important;
 }
 
 body.promare-mode .relic-card:hover {
-    border-color: #FFD600 !important;
-    box-shadow: inset 2px 2px 0 #FFD600, inset -2px -2px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 2px 2px 0 #FFE94A, inset -2px -2px 0 #FFE94A !important;
     transform: translateY(-3px) !important;
 }
 
 /* 稀有度边框：rare / epic / legendary */
 body.promare-mode .relic-card.rare,
 body.promare-mode .relic-card.rarity-rare {
-    border-color: #00E5FF !important;
-    box-shadow: inset 2px 2px 0 #00E5FF !important;
+    border-color: #00B4FF !important;
+    box-shadow: inset 2px 2px 0 #00B4FF !important;
 }
 
 body.promare-mode .relic-card.epic,
 body.promare-mode .relic-card.rarity-epic {
-    border-color: #FF0090 !important;
-    box-shadow: inset 2px 2px 0 #FF0090, inset -2px -2px 0 #00E5FF !important;
+    border-color: #FF2EA6 !important;
+    box-shadow: inset 2px 2px 0 #FF2EA6, inset -2px -2px 0 #00B4FF !important;
 }
 
 body.promare-mode .relic-card.legendary,
 body.promare-mode .relic-card.rarity-legendary {
-    border: 3px solid #FFD600 !important;
-    box-shadow: inset 2px 2px 0 #FFD600, 0 0 0 2px #FF0090, 0 0 0 4px #FFD600 !important;
+    border: 3px solid #FFE94A !important;
+    box-shadow: inset 2px 2px 0 #FFE94A, 0 0 0 2px #FF2EA6, 0 0 0 4px #FFE94A !important;
     animation: promareLegendaryPulse 1.8s ease-in-out infinite alternate;
 }
 
 @keyframes promareLegendaryPulse {
-    0%   { box-shadow: inset 2px 2px 0 #FFD600, 0 0 0 2px #FF0090, 0 0 0 4px #FFD600; }
-    100% { box-shadow: inset 2px 2px 0 #FFD600, 0 0 0 3px #FF0090, 0 0 0 5px #FFD600; }
+    0%   { box-shadow: inset 2px 2px 0 #FFE94A, 0 0 0 2px #FF2EA6, 0 0 0 4px #FFE94A; }
+    100% { box-shadow: inset 2px 2px 0 #FFE94A, 0 0 0 3px #FF2EA6, 0 0 0 5px #FFE94A; }
 }
 
 /* 关闭传说卡牌的 ::before pseudo (linear-gradient glow) */
@@ -804,25 +804,25 @@ body.promare-mode .relic-icon {
 body.promare-mode .relic-name {
     font-family: 'Inter Mono', monospace !important;
     color: #FFFFFF !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
 }
 
 body.promare-mode .relic-card.legendary .relic-name,
 body.promare-mode .relic-card.rarity-legendary .relic-name {
-    color: #FFD600 !important;
-    text-shadow: 1px 1px 0 #0a0a0a, 2px 2px 0 #FF0090 !important;
+    color: #FFE94A !important;
+    text-shadow: 1px 1px 0 #1B0B2E, 2px 2px 0 #FF2EA6 !important;
 }
 
 body.promare-mode .relic-card.epic .relic-name,
 body.promare-mode .relic-card.rarity-epic .relic-name {
-    color: #FF0090 !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    color: #FF2EA6 !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
 }
 
 body.promare-mode .relic-card.rare .relic-name,
 body.promare-mode .relic-card.rarity-rare .relic-name {
-    color: #00E5FF !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    color: #00B4FF !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
 }
 
 body.promare-mode .relic-desc {
@@ -833,8 +833,8 @@ body.promare-mode .relic-desc {
 
 /* 跳过研磨 / 跳过混沌按钮（命运时刻专用） */
 body.promare-mode #phase-relic button {
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
     color: #FFFFFF !important;
     border-radius: 0 !important;
     clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
@@ -844,47 +844,47 @@ body.promare-mode #phase-relic button {
 }
 
 body.promare-mode #phase-relic button:hover {
-    background: #FF0090 !important;
+    background: #FF2EA6 !important;
     color: #FFFFFF !important;
-    box-shadow: inset 0 0 0 2px #FFD600 !important;
+    box-shadow: inset 0 0 0 2px #FFE94A !important;
 }
 
 /* ==================== 试炼场 / Training Ground ==================== */
 /* 战斗模拟界面：DPS 统计 + 子弹配置 + 敌人词缀编辑 */
 
 body.promare-mode #phase-training {
-    background: rgba(10, 10, 10, 0.95) !important;
+    background: rgba(27, 11, 46, 0.95) !important;
     backdrop-filter: none !important;
 }
 
 /* 顶部状态条：Combat Simulation + DPS */
 body.promare-mode #phase-training [class*="bg-slate-900"][class*="backdrop-blur"] {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     backdrop-filter: none !important;
-    border-bottom: 2px solid #FF0090 !important;
+    border-bottom: 2px solid #FF2EA6 !important;
     border-radius: 0 !important;
 }
 
 body.promare-mode #train-stats {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
     letter-spacing: 2px !important;
 }
 
 /* 红色脉冲点 → YELLOW 闪烁菱形 */
 body.promare-mode #phase-training [class*="bg-red-500"][class*="animate-pulse"] {
-    background: #FFD600 !important;
+    background: #FFE94A !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
     border-radius: 0 !important;
 }
 
 /* 子弹属性控制单元 (.train-attr-grid > div) */
 body.promare-mode #train-attr-grid > div {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 1px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 1px 1px 0 #FF0090 !important;
+    box-shadow: inset 1px 1px 0 #FF2EA6 !important;
 }
 
 body.promare-mode #train-attr-grid > div span:first-child {
@@ -892,26 +892,26 @@ body.promare-mode #train-attr-grid > div span:first-child {
 }
 
 body.promare-mode #train-attr-grid > div span[class*="text-cyan-"] {
-    color: #00E5FF !important;
+    color: #00B4FF !important;
 }
 
 body.promare-mode #train-attr-grid button {
-    background: #0a0a0a !important;
-    border: 1px solid #FFD600 !important;
-    color: #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 1px solid #FFE94A !important;
+    color: #FFE94A !important;
     border-radius: 0 !important;
     clip-path: none !important;
     font-family: 'Inter Mono', monospace !important;
 }
 
 body.promare-mode #train-attr-grid button:hover {
-    background: #FFD600 !important;
-    color: #0a0a0a !important;
+    background: #FFE94A !important;
+    color: #1B0B2E !important;
 }
 
 /* 子弹预览 tag — 元素属性 ATK/BNC/PRC/SCT/PYRO/CRYO/LGT/MULTI/... */
 body.promare-mode #train-bullet-preview span {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border-radius: 0 !important;
     font-family: 'Inter Mono', monospace !important;
 }
@@ -919,41 +919,41 @@ body.promare-mode #train-bullet-preview span {
 /* 按 Tailwind 颜色 family 路由到 5 色 */
 body.promare-mode #train-bullet-preview [class*="purple-"],
 body.promare-mode #train-bullet-preview [class*="orange-"] {
-    border-color: #FF0090 !important;
-    color: #FF0090 !important;
-    background: #0a0a0a !important;
+    border-color: #FF2EA6 !important;
+    color: #FF2EA6 !important;
+    background: #1B0B2E !important;
 }
 body.promare-mode #train-bullet-preview [class*="cyan-"],
 body.promare-mode #train-bullet-preview [class*="green-"] {
-    border-color: #00E5FF !important;
-    color: #00E5FF !important;
-    background: #0a0a0a !important;
+    border-color: #00B4FF !important;
+    color: #00B4FF !important;
+    background: #1B0B2E !important;
 }
 body.promare-mode #train-bullet-preview [class*="yellow-"],
 body.promare-mode #train-bullet-preview [class*="amber-"] {
-    border-color: #FFD600 !important;
-    color: #FFD600 !important;
-    background: #0a0a0a !important;
+    border-color: #FFE94A !important;
+    color: #FFE94A !important;
+    background: #1B0B2E !important;
 }
 body.promare-mode #train-bullet-preview [class*="red-"] {
-    border-color: #FF0090 !important;
-    color: #FF0090 !important;
-    background: #0a0a0a !important;
+    border-color: #FF2EA6 !important;
+    color: #FF2EA6 !important;
+    background: #1B0B2E !important;
 }
 body.promare-mode #train-bullet-preview [class*="blue-"] {
-    border-color: #00E5FF !important;
-    color: #00E5FF !important;
-    background: #0a0a0a !important;
+    border-color: #00B4FF !important;
+    color: #00B4FF !important;
+    background: #1B0B2E !important;
 }
 body.promare-mode #train-bullet-preview [class*="slate-"] {
     border-color: #FFFFFF !important;
     color: #FFFFFF !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
 }
 
 /* 退出按钮 */
 body.promare-mode #phase-training button[onclick*="exit"] {
-    color: #FF0090 !important;
+    color: #FF2EA6 !important;
     font-family: 'Inter Mono', monospace !important;
     font-weight: bold !important;
 }
@@ -961,37 +961,37 @@ body.promare-mode #phase-training button[onclick*="exit"] {
 /* ==================== Round Damage Display（回合伤害浮字）==================== */
 
 body.promare-mode #round-damage-display {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     font-family: 'Inter Mono', monospace !important;
     text-shadow:
-        2px 0 0 #0a0a0a, -2px 0 0 #0a0a0a, 0 2px 0 #0a0a0a, 0 -2px 0 #0a0a0a,
-        3px 3px 0 #FF0090 !important;
+        2px 0 0 #1B0B2E, -2px 0 0 #1B0B2E, 0 2px 0 #1B0B2E, 0 -2px 0 #1B0B2E,
+        3px 3px 0 #FF2EA6 !important;
     filter: none !important;
     letter-spacing: 4px !important;
 }
 
 body.promare-mode #round-damage-val {
     font-family: 'Inter Mono', monospace !important;
-    color: #FFD600 !important;
+    color: #FFE94A !important;
 }
 
 /* ==================== Rune Launcher Float 浮动按钮 ==================== */
 
 body.promare-mode .rune-launcher-float-btn {
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
     border-radius: 0 !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
     box-shadow: none !important;
 }
 
 body.promare-mode .rune-launcher-float-btn:hover {
-    background: #FF0090 !important;
-    border-color: #FFD600 !important;
+    background: #FF2EA6 !important;
+    border-color: #FFE94A !important;
 }
 
 body.promare-mode .rune-launcher-float-btn span {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
 }
 
 /* ==================== 弹药 HUD（当前槽 + 下一发）==================== */
@@ -1002,24 +1002,24 @@ body.promare-mode .ammo-icon {
     border-radius: 0 !important;
     /* 钻石外形 */
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     box-shadow: none !important;
 }
 
 /* 当前发射槽位（高亮）— YELLOW 实心填充 + 白边 */
 body.promare-mode #current-slot .ammo-icon {
-    background: #0a0a0a !important;
-    border: 2px solid #FFD600 !important;
-    box-shadow: 0 0 0 2px #FF0090, inset 2px 2px 0 #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FFE94A !important;
+    box-shadow: 0 0 0 2px #FF2EA6, inset 2px 2px 0 #FFE94A !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
 }
 
 /* 下一发槽位（暗淡）— CYAN 边 + 半透明 */
 body.promare-mode #next-slot .ammo-icon {
     opacity: 0.85 !important;
-    border-color: #00E5FF !important;
-    box-shadow: inset 1px 1px 0 #00E5FF !important;
+    border-color: #00B4FF !important;
+    box-shadow: inset 1px 1px 0 #00B4FF !important;
 }
 
 /* ammo-icon 内部小符号（伪元素小钻石）替代位图 */
@@ -1035,7 +1035,7 @@ body.promare-mode .ammo-icon::after {
 }
 
 body.promare-mode #current-slot .ammo-icon::after {
-    background: #FFD600;
+    background: #FFE94A;
 }
 
 /* 发射 / 滑入动画 — 保留原 keyframes 行为，仅去掉 opacity 渐变（硬切） */
@@ -1060,17 +1060,17 @@ body.promare-mode .slide-in-anim {
 /* ==================== Marble Preview Panel（弹珠预览，研磨阶段顶部）==================== */
 
 body.promare-mode #marble-preview-panel {
-    background: rgba(10, 10, 10, 0.9) !important;
+    background: rgba(27, 11, 46, 0.9) !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 2px 2px 0 #FF0090, inset -2px -2px 0 #00E5FF !important;
+    box-shadow: inset 2px 2px 0 #FF2EA6, inset -2px -2px 0 #00B4FF !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode #preview-marble-ball {
     border-radius: 0 !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     box-shadow: none !important;
 }
@@ -1089,7 +1089,7 @@ body.promare-mode #preview-marble-icon {
 /* 玩家进入游戏的第一个画面，承担"品牌印象" — 必须 100% Promare */
 
 body.promare-mode #phase-meta {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
 }
 
 /* 隐藏主菜单的 indigo/amber 球形 blur 装饰 */
@@ -1102,11 +1102,11 @@ body.promare-mode #phase-meta h1 {
     background: none !important;
     -webkit-background-clip: initial !important;
     -webkit-text-fill-color: initial !important;
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
     text-shadow:
-        2px 0 0 #0a0a0a, -2px 0 0 #0a0a0a, 0 2px 0 #0a0a0a, 0 -2px 0 #0a0a0a,
-        4px 4px 0 #FF0090, -4px -4px 0 #00E5FF !important;
+        2px 0 0 #1B0B2E, -2px 0 0 #1B0B2E, 0 2px 0 #1B0B2E, 0 -2px 0 #1B0B2E,
+        4px 4px 0 #FF2EA6, -4px -4px 0 #00B4FF !important;
     letter-spacing: 4px !important;
     filter: none !important;
 }
@@ -1115,7 +1115,7 @@ body.promare-mode #phase-meta h1 {
 body.promare-mode #phase-meta h1 + p {
     color: #FFFFFF !important;
     font-family: 'Inter Mono', monospace !important;
-    border-top-color: #FF0090 !important;
+    border-top-color: #FF2EA6 !important;
     opacity: 1 !important;
     letter-spacing: 0.5em !important;
 }
@@ -1127,26 +1127,26 @@ body.promare-mode #phase-meta h1 ~ div[class*="absolute"][class*="bg-gradient"] 
 
 /* "开始炼成" 主按钮 .btn-main */
 body.promare-mode #phase-meta .btn-main {
-    background: #0a0a0a !important;
-    border: 3px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 3px solid #FF2EA6 !important;
     border-radius: 0 !important;
     clip-path: polygon(16px 0, 100% 0, calc(100% - 16px) 100%, 0 100%) !important;
-    box-shadow: inset 3px 3px 0 #FFD600, 0 0 0 2px #00E5FF !important;
+    box-shadow: inset 3px 3px 0 #FFE94A, 0 0 0 2px #00B4FF !important;
     transition: transform 0.1s !important;
 }
 
 body.promare-mode #phase-meta .btn-main:hover {
-    background: #FF0090 !important;
+    background: #FF2EA6 !important;
     transform: translateY(-2px) !important;
-    box-shadow: inset 3px 3px 0 #FFD600, 0 0 0 3px #FFD600 !important;
+    box-shadow: inset 3px 3px 0 #FFE94A, 0 0 0 3px #FFE94A !important;
 }
 
 body.promare-mode #phase-meta .btn-main span {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
     font-family: 'Inter Mono', monospace !important;
     background: none !important;
     -webkit-text-fill-color: initial !important;
-    text-shadow: 2px 2px 0 #0a0a0a !important;
+    text-shadow: 2px 2px 0 #1B0B2E !important;
 }
 
 body.promare-mode #phase-meta .btn-main div {
@@ -1161,46 +1161,46 @@ body.promare-mode #phase-meta .btn-main > div[class*="bg-gradient"] {
 
 /* "继续游戏" 按钮 */
 body.promare-mode #phase-meta #meta-continue-btn {
-    background: #0a0a0a !important;
-    border: 2px solid #00E5FF !important;
+    background: #1B0B2E !important;
+    border: 2px solid #00B4FF !important;
     border-radius: 0 !important;
     clip-path: polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%) !important;
-    box-shadow: inset 2px 2px 0 #00E5FF !important;
+    box-shadow: inset 2px 2px 0 #00B4FF !important;
 }
 
 body.promare-mode #phase-meta #meta-continue-btn:hover {
-    background: #00E5FF !important;
+    background: #00B4FF !important;
     transform: translateY(-2px) !important;
 }
 
 body.promare-mode #phase-meta #meta-continue-btn span {
-    color: #00E5FF !important;
+    color: #00B4FF !important;
     font-family: 'Inter Mono', monospace !important;
 }
 
 body.promare-mode #phase-meta #meta-continue-btn:hover span {
-    color: #0a0a0a !important;
+    color: #1B0B2E !important;
 }
 
 /* 3 个底部入口按钮（炼金工坊 / 真理之书 / 试炼场） */
 body.promare-mode #phase-meta .grid > button {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 2px 2px 0 #FF0090, inset -2px -2px 0 #00E5FF !important;
+    box-shadow: inset 2px 2px 0 #FF2EA6, inset -2px -2px 0 #00B4FF !important;
     backdrop-filter: none !important;
     transition: transform 0.1s, border-color 0.12s !important;
 }
 
 body.promare-mode #phase-meta .grid > button:hover {
-    border-color: #FFD600 !important;
-    box-shadow: inset 2px 2px 0 #FFD600, inset -2px -2px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 2px 2px 0 #FFE94A, inset -2px -2px 0 #FFE94A !important;
     transform: translateY(-2px) !important;
 }
 
 /* 圆形 icon 容器 → 菱形 */
 body.promare-mode #phase-meta .grid > button > div:first-child {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border-radius: 0 !important;
     clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
     box-shadow: none !important;
@@ -1217,14 +1217,14 @@ body.promare-mode #phase-meta .grid > button > span:last-child {
 }
 
 body.promare-mode #phase-meta .grid > button:hover > span:last-child {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
 }
 
 /* "重新开始教程" 按钮 */
 body.promare-mode #phase-meta button[onclick*="tutorial_restartFromHome"] {
-    background: #0a0a0a !important;
-    border: 1px solid #FFD600 !important;
-    color: #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 1px solid #FFE94A !important;
+    color: #FFE94A !important;
     border-radius: 0 !important;
     backdrop-filter: none !important;
 }
@@ -1242,7 +1242,7 @@ body.promare-mode h1, body.promare-mode h2, body.promare-mode h3,
 body.promare-mode .title, body.promare-mode .label {
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
     font-weight: bold;
-    text-shadow: 2px 2px 0 #0a0a0a !important;
+    text-shadow: 2px 2px 0 #1B0B2E !important;
     letter-spacing: 0.05em;
 }
 
@@ -1256,22 +1256,22 @@ body.promare-mode * {
 body.promare-mode .sp-gem,
 body.promare-mode .progress-bar {
     border-radius: 0 !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 1px solid #FFFFFF !important;
 }
 
 body.promare-mode .sp-gem.active,
 body.promare-mode .sp-gem-filled {
-    background: #FFD600 !important;
-    border-color: #FFD600 !important;
+    background: #FFE94A !important;
+    border-color: #FFE94A !important;
     box-shadow: none !important;
 }
 
 /* ==================== 战斗信息文本 ==================== */
 
 body.promare-mode #combat-message > div {
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
     border-radius: 0 !important;
     backdrop-filter: none !important;
 }
@@ -1280,9 +1280,9 @@ body.promare-mode #combat-message > div {
 
 body.promare-mode .toast,
 body.promare-mode #toast-container > * {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     color: #FFFFFF !important;
-    border: 2px solid #FFD600 !important;
+    border: 2px solid #FFE94A !important;
     border-radius: 0 !important;
     font-family: 'Inter Mono', monospace !important;
     box-shadow: none !important;
@@ -1311,14 +1311,14 @@ body.promare-mode .backdrop-blur-xl {
     -webkit-backdrop-filter: none !important;
 }
 
-/* bg-slate-* / bg-black/* 全部映射到 #0a0a0a 黑底 */
+/* bg-slate-* / bg-black/* 全部映射到 #1B0B2E 黑底 */
 body.promare-mode [class*="bg-slate-900"],
 body.promare-mode [class*="bg-slate-800"],
 body.promare-mode [class*="bg-slate-700"],
 body.promare-mode [class*="bg-black/"],
 body.promare-mode [class*="bg-gray-9"],
 body.promare-mode [class*="bg-zinc-9"] {
-    background-color: #0a0a0a !important;
+    background-color: #1B0B2E !important;
 }
 
 /* 教程 / 弹窗卡片：把所有 border-*-500 边框统一到 PINK，hover 到 YELLOW */
@@ -1332,7 +1332,7 @@ body.promare-mode [class*="border-emerald-"],
 body.promare-mode [class*="border-cyan-"],
 body.promare-mode [class*="border-pink-"],
 body.promare-mode [class*="border-rose-"] {
-    border-color: #FF0090 !important;
+    border-color: #FF2EA6 !important;
     border-radius: 0 !important;
 }
 
@@ -1346,16 +1346,16 @@ body.promare-mode [class*="text-purple-"],
 body.promare-mode [class*="text-violet-"],
 body.promare-mode [class*="text-pink-"],
 body.promare-mode [class*="text-rose-"],
-body.promare-mode [class*="text-red-"]   { color: #FF0090 !important; }
+body.promare-mode [class*="text-red-"]   { color: #FF2EA6 !important; }
 body.promare-mode [class*="text-blue-"],
 body.promare-mode [class*="text-cyan-"],
 body.promare-mode [class*="text-sky-"],
-body.promare-mode [class*="text-teal-"]  { color: #00E5FF !important; }
+body.promare-mode [class*="text-teal-"]  { color: #00B4FF !important; }
 body.promare-mode [class*="text-amber-"],
 body.promare-mode [class*="text-yellow-"],
-body.promare-mode [class*="text-orange-"]{ color: #FFD600 !important; }
+body.promare-mode [class*="text-orange-"]{ color: #FFE94A !important; }
 body.promare-mode [class*="text-emerald-"],
-body.promare-mode [class*="text-green-"] { color: #00E5FF !important; }
+body.promare-mode [class*="text-green-"] { color: #00B4FF !important; }
 body.promare-mode [class*="text-slate-3"],
 body.promare-mode [class*="text-slate-4"],
 body.promare-mode [class*="text-slate-2"],
@@ -1365,41 +1365,41 @@ body.promare-mode [class*="text-gray-3"]  { color: #FFFFFF !important; }
 body.promare-mode .btn-main {
     clip-path: polygon(10px 0, 100% 0, calc(100% - 10px) 100%, 0 100%) !important;
     border-radius: 0 !important;
-    background: #0a0a0a !important;
-    border: 2px solid #FF0090 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FF2EA6 !important;
     box-shadow: none !important;
     font-family: 'Inter Mono', 'Roboto Mono', monospace !important;
 }
 
 body.promare-mode .btn-main:hover {
-    background: #FF0090 !important;
+    background: #FF2EA6 !important;
     color: #FFFFFF !important;
-    box-shadow: inset 0 0 0 2px #FFD600 !important;
+    box-shadow: inset 0 0 0 2px #FFE94A !important;
 }
 
 /* 教程 step 块：替换 yellow border + amber title 为 promare */
 body.promare-mode #tutorial-step-overlay,
 body.promare-mode .tutorial-step,
 body.promare-mode [id^="tutorial-"] {
-    background: #0a0a0a !important;
-    border: 2px solid #00E5FF !important;
+    background: #1B0B2E !important;
+    border: 2px solid #00B4FF !important;
     border-radius: 0 !important;
     backdrop-filter: none !important;
-    box-shadow: 0 0 0 3px #FF0090 !important;
+    box-shadow: 0 0 0 3px #FF2EA6 !important;
 }
 
 /* 教程进度条 / step 标签 */
 body.promare-mode .tutorial-progress,
 body.promare-mode [class*="text-amber-400"] {
-    color: #FFD600 !important;
+    color: #FFE94A !important;
 }
 
 /* 顶部 stat pill */
 body.promare-mode .stat-pill {
     border-radius: 0 !important;
     clip-path: polygon(6px 0, 100% 0, calc(100% - 6px) 100%, 0 100%);
-    background: #0a0a0a !important;
-    border: 2px solid #FFD600 !important;
+    background: #1B0B2E !important;
+    border: 2px solid #FFE94A !important;
     color: #FFFFFF !important;
     backdrop-filter: none !important;
 }
@@ -1408,37 +1408,37 @@ body.promare-mode .stat-pill {
 /* 战斗前每次都要点开，是高频核心 UI */
 
 body.promare-mode #phase-rune-launcher {
-    background: rgba(10, 10, 10, 0.95) !important;
+    background: rgba(27, 11, 46, 0.95) !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode #rune-launcher-content {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: 0 0 0 3px #FF0090, inset 4px 4px 0 rgba(0, 229, 255, 0.15) !important;
+    box-shadow: 0 0 0 3px #FF2EA6, inset 4px 4px 0 rgba(0, 180, 255, 0.15) !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode .rune-grid-cell {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 1px 1px 0 #FF0090, inset -1px -1px 0 #00E5FF !important;
+    box-shadow: inset 1px 1px 0 #FF2EA6, inset -1px -1px 0 #00B4FF !important;
     backdrop-filter: none !important;
     transition: border-color 0.1s, transform 0.08s !important;
 }
 
 body.promare-mode .rune-grid-cell:hover,
 body.promare-mode .rune-grid-cell[data-state="hover"] {
-    border-color: #FFD600 !important;
-    box-shadow: inset 1px 1px 0 #FFD600, inset -1px -1px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 1px 1px 0 #FFE94A, inset -1px -1px 0 #FFE94A !important;
     transform: translateY(-1px);
 }
 
 body.promare-mode .rune-grid-cell[data-state="filled"] {
-    border-color: #FFD600 !important;
-    box-shadow: inset 2px 2px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 2px 2px 0 #FFE94A !important;
 }
 
 /* 符文图标 → 灰阶高对比，统一视觉 */
@@ -1450,48 +1450,48 @@ body.promare-mode .rune-grid-cell .rune-icon-frame img {
 
 /* 战斗中符文槽 #combat-rune-single-slot */
 body.promare-mode #combat-rune-single-slot {
-    background: #0a0a0a !important;
-    border: 2px solid #00E5FF !important;
+    background: #1B0B2E !important;
+    border: 2px solid #00B4FF !important;
     border-radius: 0 !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode .rune-slot-glow-overlay {
-    background: rgba(255, 214, 0, 0.4) !important; /* YELLOW 充能闪光 */
+    background: rgba(255, 233, 74, 0.4) !important; /* YELLOW 充能闪光 */
     border-radius: 0 !important;
-    box-shadow: inset 0 0 0 2px #FFD600 !important;
+    box-shadow: inset 0 0 0 2px #FFE94A !important;
 }
 
 /* ==================== 商店（shop）==================== */
 
 body.promare-mode #phase-shop {
-    background: rgba(10, 10, 10, 0.95) !important;
+    background: rgba(27, 11, 46, 0.95) !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode .shop-item,
 body.promare-mode .shop-card {
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
     border-radius: 0 !important;
-    box-shadow: inset 2px 2px 0 #FF0090, inset -2px -2px 0 #00E5FF !important;
+    box-shadow: inset 2px 2px 0 #FF2EA6, inset -2px -2px 0 #00B4FF !important;
     transition: border-color 0.12s !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode .shop-item:hover,
 body.promare-mode .shop-card:hover {
-    border-color: #FFD600 !important;
-    box-shadow: inset 2px 2px 0 #FFD600, inset -2px -2px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 2px 2px 0 #FFE94A, inset -2px -2px 0 #FFE94A !important;
 }
 
 /* 价格标签 */
 body.promare-mode .shop-price,
 body.promare-mode .shop-cost {
-    color: #FFD600 !important;
-    background: #0a0a0a !important;
-    border: 1px solid #FFD600 !important;
+    color: #FFE94A !important;
+    background: #1B0B2E !important;
+    border: 1px solid #FFE94A !important;
     border-radius: 0 !important;
     font-family: 'Inter Mono', monospace !important;
     box-shadow: none !important;
@@ -1502,24 +1502,24 @@ body.promare-mode .shop-cost {
 
 body.promare-mode .select-card {
     border-radius: 0 !important;
-    background: #0a0a0a !important;
+    background: #1B0B2E !important;
     border: 2px solid #FFFFFF !important;
-    box-shadow: inset 2px 2px 0 #FF0090, inset -2px -2px 0 #00E5FF !important;
+    box-shadow: inset 2px 2px 0 #FF2EA6, inset -2px -2px 0 #00B4FF !important;
     transition: transform 0.08s, border-color 0.12s !important;
     backdrop-filter: none !important;
 }
 
 body.promare-mode .select-card:hover {
-    border-color: #FFD600 !important;
-    box-shadow: inset 2px 2px 0 #FFD600, inset -2px -2px 0 #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 2px 2px 0 #FFE94A, inset -2px -2px 0 #FFE94A !important;
     transform: translateY(-2px) !important;
 }
 
 /* 选中态 */
 body.promare-mode .select-card.selected,
 body.promare-mode .select-card[data-selected="true"] {
-    border-color: #FFD600 !important;
-    box-shadow: inset 3px 3px 0 #FFD600, inset -3px -3px 0 #FF0090, 0 0 0 3px #FFD600 !important;
+    border-color: #FFE94A !important;
+    box-shadow: inset 3px 3px 0 #FFE94A, inset -3px -3px 0 #FF2EA6, 0 0 0 3px #FFE94A !important;
 }
 
 /* 弹珠球体 → 强制方形 + 硬切菱形剪裁 */
@@ -1539,20 +1539,20 @@ body.promare-mode .select-icon {
 }
 
 /* 类型颜色映射（按 marble-fx-* class 后缀路由）— 元素 family 映射到 5 色 */
-body.promare-mode .select-icon.marble-fx-pyro      { background: #FF0090 !important; }
-body.promare-mode .select-icon.marble-fx-bounce    { background: #FF0090 !important; }
-body.promare-mode .select-icon.marble-fx-explosive { background: #FF0090 !important; }
-body.promare-mode .select-icon.marble-fx-cryo      { background: #00E5FF !important; }
-body.promare-mode .select-icon.marble-fx-wind      { background: #00E5FF !important; }
-body.promare-mode .select-icon.marble-fx-laser     { background: #00E5FF !important; }
-body.promare-mode .select-icon.marble-fx-lightning { background: #FFD600 !important; }
-body.promare-mode .select-icon.marble-fx-scatter   { background: #FFD600 !important; }
-body.promare-mode .select-icon.marble-fx-venom     { background: #FFD600 !important; }
+body.promare-mode .select-icon.marble-fx-pyro      { background: #FF2EA6 !important; }
+body.promare-mode .select-icon.marble-fx-bounce    { background: #FF2EA6 !important; }
+body.promare-mode .select-icon.marble-fx-explosive { background: #FF2EA6 !important; }
+body.promare-mode .select-icon.marble-fx-cryo      { background: #00B4FF !important; }
+body.promare-mode .select-icon.marble-fx-wind      { background: #00B4FF !important; }
+body.promare-mode .select-icon.marble-fx-laser     { background: #00B4FF !important; }
+body.promare-mode .select-icon.marble-fx-lightning { background: #FFE94A !important; }
+body.promare-mode .select-icon.marble-fx-scatter   { background: #FFE94A !important; }
+body.promare-mode .select-icon.marble-fx-venom     { background: #FFE94A !important; }
 body.promare-mode .select-icon.marble-fx-pierce    { background: #FFFFFF !important; }
 body.promare-mode .select-icon.marble-fx-damage    { background: #FFFFFF !important; }
 body.promare-mode .select-icon.marble-fx-flying_sword { background: #FFFFFF !important; }
-body.promare-mode .select-icon.marble-fx-matryoshka { background: #FF0090 !important; }
-body.promare-mode .select-icon.marble-fx-rainbow   { background: #FFD600 !important; }
+body.promare-mode .select-icon.marble-fx-matryoshka { background: #FF2EA6 !important; }
+body.promare-mode .select-icon.marble-fx-rainbow   { background: #FFE94A !important; }
 body.promare-mode .select-icon.marble-fx-white     { background: #FFFFFF !important; }
 
 /* 高光层关闭（不要 shine） */
@@ -1571,32 +1571,26 @@ body.promare-mode .select-card-name {
     font-weight: bold !important;
     color: #FFFFFF !important;
     letter-spacing: 0.05em !important;
-    text-shadow: 1px 1px 0 #0a0a0a !important;
+    text-shadow: 1px 1px 0 #1B0B2E !important;
 }
 
 /* tag 小标签：黄色硬切 */
 body.promare-mode .select-card-tag {
-    background: #0a0a0a !important;
-    color: #FFD600 !important;
-    border: 1px solid #FFD600 !important;
+    background: #1B0B2E !important;
+    color: #FFE94A !important;
+    border: 1px solid #FFE94A !important;
     border-radius: 0 !important;
     font-family: 'Inter Mono', monospace !important;
     box-shadow: none !important;
 }
 
-/* ==================== 故障艺术：色差通道偏移（pyro/lightning 击杀触发）==================== */
-/* promare_explosion.js 在 enemy:killed 时给 body 加 .promare-chromatic class
-   持续 ~150ms 后移除。filter 用 drop-shadow 模拟 RGB 三通道分离。
-   闪电主体粒子本身在 draw 时不参与（粒子用 lighter 混合，filter 仅作用于画布合成层）。
-   @perf-impact: GPU filter，单次 150ms，可忽略。 */
+/* ==================== 色差滤镜：已废弃（F7）==================== */
+/* 原版在 pyro/lightning/scatter/bounce 击杀时给 body 加 .promare-chromatic 触发
+   RGB 三通道偏移。电影《普罗米亚》几乎完全不用色差 —— 它是"模拟廉价镜头"的
+   cinematography 语言，与 Promare 的"平涂硬切"取向相反。
+   promare_explosion.js 的 _triggerChromaticAberration 已改为 no-op，
+   这里保留空选择器只是为了不破坏可能的 transition 链路。 */
 
 body.promare-mode #gameCanvas {
-    transition: filter 0.02s linear;
-}
-
-body.promare-mode.promare-chromatic #gameCanvas {
-    /* 红色偏右 / 蓝色偏左 的经典色差效果 */
-    filter:
-        drop-shadow(2px 0 0 rgba(255, 0, 144, 0.5))
-        drop-shadow(-2px 0 0 rgba(0, 229, 255, 0.5));
+    /* no filter — 击杀冲击感由 hitstop + 粒子碎裂承担 */
 }


### PR DESCRIPTION
## 背景

用户反馈当前的「Promare 视觉模式」**完全不对**。基于电影侧调研（Imaishi/Nakashima/Koyama 访谈 + 色彩分析）的判定是：**形状/色彩 token 都没大错，但 7 项"贯穿特征"在每个特效里都缺席**，导致整体读起来像通用霓虹 / 合成波 / 卡通烟花，而不是 Promare。

完整计划见 `/root/.claude/plans/sequential-tickling-lark.md`。

## 这一 PR（Tier 1）做了什么

把 Promare 的 7 项核心特征注入到粒子引擎 + 后期管线 + 调色板，让所有现存 promare mode 自动继承，而**不依赖**调用方的写法。Tier 2（敌人=方块 + 词条 overlay + 击杀碎成三角）后续 PR。

| 特征 | 改动 | 文件 |
|---|---|---|
| **F1 12fps stutter** | `Particle.update()` 累积 timeScale，每 5 帧才 pop 出位移；初始相位随机化避免群体闪烁 | `particles.js` |
| **F2 两段硬切色块** | `fillStroke_promare` 改 `source-over`（不再 lighter）→ 粒子重叠不再产生白雾 | `promare_shapes.js` |
| **F3 Pop-Hold-Snap** | `_promareLifeVisual()` 替换线性褪色 — r≥0.15 全尺寸全 alpha，r<0.15 snap 缩 + alpha² | `particles.js` |
| **F4 暗调描边** | 新 `PROMARE_OUTLINES` 查找表，PINK→#660F40 / CYAN→#003E5C / YELLOW→#5C5008 / WHITE→深紫；不再统一白描边 | `promare_tokens.js` + `promare_shapes.js` |
| **F5 超大剪影层** | `_spawnBigSilhouette()` 每次 burst 先 pop 出 1 个 3× 尺寸的静止粒子作为构图骨架 | `promare_burst.js` |
| **F6 直线运动** | 所有 promare mode 强制 `gravity=0 / drag=1 / spin=0`，干掉反重力 pyro、反弹 hex、连续 spin star | `particles.js` |
| **F7 深紫底 + 极弱后期** | 调色板更新到电影色：BLACK `#0a0a0a→#1B0B2E`、PINK `#FF0090→#FF2EA6`、CYAN `#00E5FF→#00B4FF`、YELLOW `#FFD600→#FFE94A`；PostFX Bloom strength 1.05→0.35 / threshold 0.42→0.78，色差 + 桶形畸变全关，vignette 各预设清零 | `promare_tokens.js` + `PostFX.js` + `promare_ui.css` |

## 关键设计点

- **PROMARE_MODES Set** 作为"哪些 mode 应用 7 特征"的单一真理源 —— 添加新 mode 时把名字加进去即可
- **向后兼容**：`fillStroke_promare` 签名不变，调用方传白色描边时自动改用查表的暗调；调用方传非白色 strokeColor 时保留作为显式覆盖
- **击杀色差 no-op**：`_triggerChromaticAberration` 改为空函数（保留签名防止删除调用方），CSS `.promare-chromatic` 删除
- **未删除/未迁移的"圆"装饰**（`echo_ring` / Shockwave / radial_spoke / 元素 signature 二次喷发）保留兼容；移除是 Tier 2 范畴

## 验证

本地启动 `npx serve` 后，按计划文档 §5 的 7 项 checklist 逐一目测：

- [ ] F1 60fps 录屏看粒子是否有 12fps stutter（不是平滑流动）
- [ ] F2 截一帧 burst 放大，重叠区不再是白雾
- [ ] F3 慢放粒子消亡，看到末段 snap shrink 而不是 fade
- [ ] F4 粒子描边色是主色暗调（不再统一白）
- [ ] F5 每次 burst 中央有 1 个明显超大三角剪影 ~0.2s
- [ ] F6 粒子轨迹是直线，没有重力 / 反弹 / 涡流
- [ ] F7 截图取色器看底色是 `#1B0B2E` 附近、bloom 不再糊整块

## 后续 Tier（不在本 PR）

- **Tier 2 — 阵营几何语义**：敌人改方块底 + 词条以几何 overlay 贴在方块上 + 击杀=方块被切线劈开碎成三角粒子云；移除所有非高潮时刻的圆（echo_ring / Shockwave / radial_spoke）
- **Tier 3 — 场景与 UI 收尾**：背景从扫描线+网格改为深紫底+静态远景方块剪影；UI 菱形 clip-path 改三角 chevron / 梯形；字体 Inter Mono → 候选 Anton/Bebas Neue


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9w7Q1LFW1einzZ6qVQX3p)_