### PR TITLE
位图资源持久缓存（Service Worker + HTTP 缓存头）

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,12 @@
 详细的改造规划和任务拆分，请参阅：
 - [架构改造规划](docs/refactoring_plan.md)
 - [TODO 任务清单](TODO.md)
+
+## 5. 位图资源缓存（Service Worker）
+
+为避免每次刷新 / 重开页面都重新下载 `assets/` 下的位图（约 283MB PNG），项目引入了两层持久缓存：
+
+- **HTTP 缓存头**（[`serve.json`](serve.json)）：`assets/**` 返回 `max-age=31536000, immutable`，HTML/JS/`sw.js` 返回 `no-cache` 以保证代码可及时更新。
+- **Service Worker**（[`sw.js`](sw.js)）：对 `assets/` 资源采用 **cache-first** 运行时缓存（首次访问后落盘，跨刷新/跨会话秒开，断网也可加载），对代码/HTML 采用 **network-first**。
+
+**调试美术时**：若希望绕过缓存看到最新图片，在 URL 后加 `?nosw`（跳过 SW 注册），或在 DevTools → Application → Service Workers 中 Unregister。**替换同名 PNG 后想让所有客户端更新**：bump `sw.js` 中的 `CACHE_VERSION`。

--- a/index.html
+++ b/index.html
@@ -3543,6 +3543,21 @@
 </div><!-- /#app-wrapper -->
 
 
+<script>
+// ==================== Service Worker 注册（位图资源持久缓存） ====================
+// 首次访问后缓存 assets/ 下的位图，跨刷新/跨会话不再重复下载，并支持离线。
+// 调试美术时在 URL 加 ?nosw 可跳过缓存；详见 sw.js 注释。
+(function registerServiceWorker() {
+    if (!('serviceWorker' in navigator)) return;
+    if (new URLSearchParams(location.search).has('nosw')) return;
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw.js').catch((err) => {
+            console.warn('[SW] 注册失败（不影响游戏运行）:', err && err.message);
+        });
+    });
+})();
+</script>
+
 <script type="module">
 // ==================== 模块化导入 (v2 - EventBus 架构) ====================
 import { Game, audio, eventBus } from './src/core.js';

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,22 @@
+{
+  "headers": [
+    {
+      "source": "assets/**",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "**/*.{html,js,json,ico}",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
+      "source": "sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,105 @@
+/**
+ * sw.js — Echo Alchemist V2 Service Worker
+ *
+ * 目的：让位图资源（assets/ 下的 PNG/JSON 等）在首次访问后持久缓存，
+ * 跨刷新 / 跨会话不再重复下载；并顺带提供离线能力。
+ *
+ * 缓存策略：
+ *   - assets/ 资源        → cache-first（运行时缓存，命中即返回，未命中再下载并写入缓存）
+ *   - 导航 / *.js / HTML  → network-first（保证代码可更新），失败时回退缓存（离线可玩）
+ *   - 跨域请求（CDN/字体）→ 不拦截，直接走网络
+ *
+ * 改美术或想强制所有客户端刷新资源时：bump 下方 CACHE_VERSION 即可。
+ * 调试美术不想被缓存挡住时：访问页面时加 ?nosw（注册脚本会跳过 SW），
+ * 或在 DevTools → Application → Service Workers 里 Unregister。
+ */
+
+const CACHE_VERSION = 'v1';
+const ASSET_CACHE = `echo-alchemist-assets-${CACHE_VERSION}`;
+const CORE_CACHE = `echo-alchemist-core-${CACHE_VERSION}`;
+
+// install 阶段只预缓存极少量核心文件，绝不预缓存庞大的 assets/。
+const CORE_ASSETS = [
+    './',
+    './index.html',
+    './src/core.js',
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CORE_CACHE)
+            .then((cache) => cache.addAll(CORE_ASSETS).catch(() => {}))
+            .then(() => self.skipWaiting())
+    );
+});
+
+self.addEventListener('activate', (event) => {
+    const keep = new Set([ASSET_CACHE, CORE_CACHE]);
+    event.waitUntil(
+        caches.keys()
+            .then((names) => Promise.all(
+                names.filter((n) => !keep.has(n)).map((n) => caches.delete(n))
+            ))
+            .then(() => self.clients.claim())
+    );
+});
+
+/** 判断是否为 assets/ 下的位图/资源请求 */
+function isAssetRequest(url) {
+    return url.pathname.includes('/assets/');
+}
+
+/** cache-first：命中缓存直接返回；否则下载后写入缓存。 */
+async function cacheFirst(request) {
+    const cache = await caches.open(ASSET_CACHE);
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    const response = await fetch(request);
+    // 仅缓存成功的、可缓存的响应（含 opaque 兜底由上层 same-origin 保证）
+    if (response && response.ok) {
+        cache.put(request, response.clone());
+    }
+    return response;
+}
+
+/** network-first：优先网络（拿到最新代码），失败回退缓存（离线可玩）。 */
+async function networkFirst(request) {
+    const cache = await caches.open(CORE_CACHE);
+    try {
+        const response = await fetch(request);
+        if (response && response.ok) {
+            cache.put(request, response.clone());
+        }
+        return response;
+    } catch (err) {
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        throw err;
+    }
+}
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+
+    // 只处理 GET
+    if (request.method !== 'GET') return;
+
+    const url = new URL(request.url);
+
+    // 跨域请求（Tailwind CDN、Google Fonts 等）直接放行，不拦截
+    if (url.origin !== self.location.origin) return;
+
+    if (isAssetRequest(url)) {
+        event.respondWith(cacheFirst(request));
+        return;
+    }
+
+    // 导航请求、JS、HTML 等 → network-first
+    if (request.mode === 'navigate' || url.pathname.endsWith('.js') || url.pathname.endsWith('.html')) {
+        event.respondWith(networkFirst(request));
+        return;
+    }
+
+    // 其余 same-origin 资源（如 favicon）→ cache-first 兜底，减少重复请求
+    event.respondWith(cacheFirst(request));
+});


### PR DESCRIPTION
## 背景

游戏的位图资源（`assets/` 下 326 个 PNG，约 283MB）本身已是本地文件并提交到 git，但**没有任何持久缓存**：内存层 Map 只在单次会话有效，开发用的 `serve_nocache.py` 又强制 `no-store`，导致**每次刷新 / 重开页面都会重新下载全部图片**。

本 PR 引入两层持久缓存，让首次访问后图片秒开、跨刷新/跨会话不再重下，并顺带支持离线。

## 改动

- **新增 `sw.js`（Service Worker）**：对 `assets/` 资源 **cache-first** 运行时缓存（不在 install 阶段预缓存庞大 assets），对代码/HTML **network-first**（保证代码可更新 + 离线回退）；跨域 CDN/字体不拦截。版本通过 `CACHE_VERSION` 控制失效。
- **新增 `serve.json`**：`assets/**` → `max-age=31536000, immutable`；HTML/JS/JSON/`sw.js` → `no-cache`（保证代码与 SW 自身可及时更新）。
- **`index.html`**：入口处新增 SW 注册脚本，带 `?nosw` 调试开关，注册失败不影响游戏启动。
- **`README.md`**：补充缓存机制与调试说明。

> 现有内存缓存（`sprite_renderer.js` / `bitmap_icons.js`）保持不变，与 SW 互补。

## 已验证

- `sw.js` 语法校验通过、`serve.json` 合法 JSON。
- 通过 `serve` 实测响应头：PNG → `public, max-age=31536000, immutable`；`/`、`src/*.js`、`sw.js`、`assets/*.json` → `no-cache`。

## 待人工浏览器验证

- DevTools Network：刷新后 `assets/*.png` 来源显示 `(ServiceWorker)`、Size≈0。
- Application → Cache Storage 含 `echo-alchemist-assets-v1`；勾选 Offline 仍可加载。
- `?nosw` 跳过 SW；bump `CACHE_VERSION` 后旧缓存被清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A92hgqkJ3PrumEPAiM89Wv)_