### PR TITLE
fix: restore truncated JSDoc comment breaking particles.js

### DIFF
--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -1873,6 +1873,9 @@ class WindMarkEffect {
 
     get active() { return this.timer > 0; }
 }
+
+/**
+ * IceWave - 冰冻状态死亡时的冰晶爆炸波
  * 表现为蓝白色冰晶碎片扩散环 + 冰雾扩散
  */
 class IceWave {


### PR DESCRIPTION
## Problem

The browser threw a fatal parse error that broke the entire effects module:

```
src/effects/particles.js:1876 Uncaught SyntaxError: Unexpected token '*'
```

## Root cause

The JSDoc comment block above `class IceWave` was truncated — its opening `/**` and the first description line were dropped, leaving a dangling comment tail directly after the previous class's closing brace:

```js
}
 * 表现为蓝白色冰晶碎片扩散环 + 冰雾扩散   // ← parser reads bare '*' here
 */
class IceWave {
```

With no comment context, the parser hit the bare `*` and aborted, which prevented `particles.js` from loading at all. This matches the partial-read file-truncation pattern documented in `CLAUDE.md` (introduced in commit `9305a2d`).

## Fix

Restored the two missing lines (verified against git history) so the comment is well-formed again:

```js
/**
 * IceWave - 冰冻状态死亡时的冰晶爆炸波
 * 表现为蓝白色冰晶碎片扩散环 + 冰雾扩散
 */
class IceWave {
```

## Verification

- `node --check src/effects/particles.js` → passes
- Swept **all** JS files under `src/`, `tools/`, `scripts/`, and `sw.js` (including every other file touched by `9305a2d`) → all parse cleanly; this was the only corrupted file.

> Note: the separate `cdn.tailwindcss.com should not be used in production` console message is a non-blocking dev-mode warning, not an error, and is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuzZgiV4acgx5ymZskKqU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuzZgiV4acgx5ymZskKqU1)_