### PR TITLE
克制化开炮特效

### DIFF
--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -3272,17 +3272,17 @@ class MuzzleFlashV2 {
         this.intensity = Math.max(0.5, intensity);
         this.charged = intensity > 1.3;
 
-        // 生命周期（秒）
-        this.maxLife = this.charged ? 0.9 : 0.7;
+        // 生命周期（秒）— 克制化，缩短余烬拖尾
+        this.maxLife = this.charged ? 0.65 : 0.5;
         this.life = this.maxLife;
-        this.flashPhase = this.charged ? 0.21 : 0.15;  // 高光持续时间（秒）
+        this.flashPhase = this.charged ? 0.16 : 0.12;  // 高光持续时间（秒）
 
-        // 火星粒子数据（物理模拟）
-        const sparkCount = Math.round(8 * this.intensity);
+        // 火星粒子数据（物理模拟）— 克制：减少火星数量与初速
+        const sparkCount = Math.round(5 * this.intensity);
         this.sparks = [];
         for (let i = 0; i < sparkCount; i++) {
             const spread = (Math.random() - 0.5) * 0.9;  // ±25°
-            const speed = 100 + Math.random() * 200;
+            const speed = 70 + Math.random() * 130;
             this.sparks.push({
                 x: 0, y: 0,
                 vx: Math.cos(angle + spread) * speed,
@@ -3393,20 +3393,20 @@ class FiringBurst {
         this.elementColor = elementColor || '#fef3c7';
         this.intensity = Math.max(0.5, intensity);
 
-        this.maxLife = 0.4;
+        this.maxLife = 0.3;
         this.life = this.maxLife;
 
-        // 扩散环参数
+        // 扩散环参数 — 克制：收小最大半径
         this.ringRadius = 10;
-        this.ringMaxRadius = 80 * this.intensity;
+        this.ringMaxRadius = 52 * this.intensity;
         this.ringWidth = 4;
 
-        // 碎片粒子
-        const debrisCount = Math.round(6 * this.intensity);
+        // 碎片粒子 — 克制：减少碎片数量与初速
+        const debrisCount = Math.round(4 * this.intensity);
         this.debris = [];
         for (let i = 0; i < debrisCount; i++) {
             const spread = (Math.random() - 0.5) * 1.4;  // ±40°
-            const speed = 200 + Math.random() * 300;
+            const speed = 140 + Math.random() * 180;
             this.debris.push({
                 x: 0, y: 0,
                 vx: Math.cos(angle + spread) * speed,

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -1305,15 +1305,15 @@ export function muzzleFlashV2_pixiSync(mf, pixi) {
 
     // ── 核心光球 ──
     if (progress < 0.3) {
-        // 膨胀阶段
+        // 膨胀阶段（克制：收小核心光球）
         const t = progress / 0.3;
-        const s = (0.3 + 0.9 * t) * mf.intensity;
+        const s = (0.25 + 0.55 * t) * mf.intensity;
         coreSprite.scale.set(s);
-        coreSprite.alpha = 0.8 + 0.2 * t;
+        coreSprite.alpha = 0.7 + 0.15 * t;
     } else {
         // 衰减阶段
         const t = (progress - 0.3) / 0.7;
-        const s = 1.2 * mf.intensity * (1 - t * 0.6);
+        const s = 0.8 * mf.intensity * (1 - t * 0.6);
         coreSprite.scale.set(Math.max(0.05, s));
         coreSprite.alpha = Math.max(0, 1.0 - t);
         // tint 渐变：白热 → 元素色 → 暗红（简化为 alpha 衰减）
@@ -1327,8 +1327,8 @@ export function muzzleFlashV2_pixiSync(mf, pixi) {
         const flashEnd = mf.flashPhase / mf.maxLife;
         if (progress < flashEnd) {
             const t = progress / flashEnd;
-            flareSprite.scale.set(0.5 + 1.5 * t * mf.intensity, 0.8 + 0.4 * t);
-            flareSprite.alpha = Math.max(0, 1.0 - t * 0.9);
+            flareSprite.scale.set(0.4 + 1.0 * t * mf.intensity, 0.7 + 0.3 * t);
+            flareSprite.alpha = Math.max(0, 0.85 - t * 0.85);
             flareSprite.rotation = mf.angle;
         } else {
             flareSprite.alpha = 0;
@@ -1405,8 +1405,8 @@ export function firingBurst_pixiSync(fb, pixi) {
 
     // 方向冲击锥（前 30% 生命周期）
     if (progress < 0.3) {
-        const coneAlpha = alpha * (1 - progress / 0.3) * 0.6;
-        const dist = 60 * fb.intensity * (progress / 0.3);
+        const coneAlpha = alpha * (1 - progress / 0.3) * 0.45;
+        const dist = 40 * fb.intensity * (progress / 0.3);
         const cos1 = Math.cos(fb.angle - 0.26), sin1 = Math.sin(fb.angle - 0.26);
         const cos2 = Math.cos(fb.angle + 0.26), sin2 = Math.sin(fb.angle + 0.26);
         // 外辉光

--- a/src/render_system.js
+++ b/src/render_system.js
@@ -856,8 +856,8 @@ export const render_system = {
             const coolFade = Math.pow(1 - coolT, 1.5);         // 余烬淡出曲线
             const heatColor = lerpColor('#fff4d6', elementColor, Math.min(1, coolT * 1.8));
             const emberColor = lerpColor(heatColor, '#1a1206', Math.max(0, coolT - 0.45) * 1.5);
-            const glowR = (20 + 16 * intensity) * (0.55 + 0.6 * coolFade);
-            const coolAlpha = coolFade * (0.34 + 0.16 * intensity);
+            const glowR = (14 + 11 * intensity) * (0.55 + 0.6 * coolFade);
+            const coolAlpha = coolFade * (0.24 + 0.12 * intensity);
             if (coolAlpha > 0.012) {
                 ctx.save();
                 ctx.translate(muzzleX, muzzleY);
@@ -891,9 +891,9 @@ export const render_system = {
                     Math.floor(t * EMITTER_MUZZLE_FLASH_SRCS.length)
                 );
                 const flashImg = getUiBitmap(EMITTER_MUZZLE_FLASH_SRCS[frameIndex]);
-                const baseFlash = 78 + 46 * intensity;          // 大幅放大（原仅 34~42px）
+                const baseFlash = 52 + 28 * intensity;          // 克制化（原 78+46*intensity，过于浮夸）
                 const flashSize = baseFlash * (0.72 + 0.42 * ease);
-                const flashAlpha = Math.min(0.95, (1 - t) * (0.6 + 0.34 * intensity));
+                const flashAlpha = Math.min(0.85, (1 - t) * (0.5 + 0.28 * intensity));
 
                 ctx.save();
                 ctx.translate(muzzleX, muzzleY);
@@ -948,11 +948,11 @@ export const render_system = {
                 fx._v2Spawned = true;
                 // 开炮屏幕震动（开幕齐射更强烈）
                 if (fx.charged) {
-                    if (typeof this.triggerScreenShake === 'function') this.triggerScreenShake(3);
-                    if (typeof this.triggerScreenShakeAdvanced === 'function') this.triggerScreenShakeAdvanced(2, 8);
+                    if (typeof this.triggerScreenShake === 'function') this.triggerScreenShake(1.5);
+                    if (typeof this.triggerScreenShakeAdvanced === 'function') this.triggerScreenShakeAdvanced(1, 5);
                 }
-                // 开炮边缘闪光标记
-                this._fireFlashFrames = fx.charged ? 4 : 2;
+                // 开炮边缘闪光标记（克制：齐射 2 帧 / 普通 1 帧）
+                this._fireFlashFrames = fx.charged ? 2 : 1;
             }
         }
 
@@ -1004,7 +1004,7 @@ export const render_system = {
 
         // ── [开炮 VFX 增强] 开炮边缘闪光（Canvas 2D 全屏叠加） ──
         if (this._fireFlashFrames > 0) {
-            const flashAlpha = (this._fireFlashFrames / 4) * 0.08;
+            const flashAlpha = (this._fireFlashFrames / 2) * 0.045;
             ctx.save();
             // 抵消 translate(cx, cy) 以覆盖全屏
             ctx.translate(-cx, -cy);


### PR DESCRIPTION
## 背景

开炮（枪口火光 / 冲击波 / 屏幕反馈）特效此前过于浮夸，喧宾夺主。本 PR 在保留「开炮爆发感」的前提下，将各视觉层整体克制约 30–40%。

## 改动

涉及三层渲染路径，保持一致：

**`src/render_system.js`（Canvas 2D 基础火光 + 屏幕反馈）**
- 枪口火光基础尺寸 `78 + 46*intensity` → `52 + 28*intensity`，降低 `flashAlpha` 上限（0.95→0.85）
- 缩小冷却热辉半径与不透明度
- 齐射屏幕震动 `triggerScreenShake(3)` → `1.5`、`(2, 8)` → `(1, 5)`
- 开炮边缘闪光帧数 `4/2` → `2/1`，全屏叠加 alpha `0.08` → `0.045`

**`src/effects/particles.js`**
- `MuzzleFlashV2`：生命周期 `0.9/0.7` → `0.65/0.5`，火星数 `8*i` → `5*i`，初速降低
- `FiringBurst`：生命 `0.4` → `0.3`，扩散环最大半径 `80*i` → `52*i`，碎片数 `6*i` → `4*i`，初速降低

**`src/render/pixi_effect_adapter.js`（PixiJS 主渲染路径）**
- 核心光球膨胀/衰减缩放、方向光锥缩放、冲击锥距离同步收小

## 说明

`config.js` 中的 `muzzleFlashV2` / `firingScreenShake` 等开关目前在运行时未被读取（全代码库仅 `config.js` 出现），故未将其作为调参入口；真正生效的数值均在上述三个文件内。

## 验证
- `node --check` 三个改动文件均通过
- 无测试断言这些具体数值（已检索 `tests/`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAPMhtp8ujw5W7iGoCzuwj)_