### PR TITLE
fix: 修复子弹拖尾相对子弹横向偏移（锚点未居中）

### DIFF
--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -1136,6 +1136,10 @@ class Projectile {
         while (this._trailV2Sprites.length < visibleSpan) {
             const s = pixiAcquireParticleSprite('trail');
             if (!s) break;
+            // [拖尾居中修复] 精灵来自共享池，默认锚点为 (0,0)，且可能残留上次使用者
+            // （beam=0.5,1 / flare=0.05,0.5 等）的锚点。拖尾段以「段中点」定位并绕锚点旋转，
+            // 必须将锚点重置为中心 (0.5,0.5)，否则 64×16 纹理会从角部绘制，导致拖尾相对子弹偏移。
+            s.anchor.set(0.5);
             this._trailV2Sprites.push(s);
         }
 


### PR DESCRIPTION
## 问题

子弹的尾迹和子弹没有居中，尾迹起点偏左。

## 根因

`src/entities/projectile.js` 的 `_drawTrailV2()`（Trail V2 GPU 批渲染路径）从共享精灵池 `pixiAcquireParticleSprite('trail')` 获取拖尾段精灵，但**从未设置精灵锚点**：

- `PIXI.Sprite` 默认锚点是 `(0, 0)`（左上角）；
- 池中复用的精灵还可能残留上一次使用者的锚点（如 beam 的 `(0.5, 1)`、muzzle flare 的 `(0.05, 0.5)`）。

拖尾段以「段中点」为坐标定位，并绕锚点对齐运动方向旋转。锚点不在中心时，64×16 的拖尾纹理会从角部开始绘制，叠加旋转后表现为拖尾相对子弹**横向偏移**——即「尾迹起点偏左、与子弹不居中」。

同文件中的子弹环境光照精灵 `_bulletGlowSprite` 已正确调用 `anchor.set(0.5)`，唯独拖尾路径遗漏。

## 修复

在获取拖尾段精灵后调用 `s.anchor.set(0.5)`，将锚点重置为中心，使段中点与精灵中心对齐，旋转围绕中心进行。与子弹光照精灵处理一致。

改动仅 1 处，无行为副作用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8k7p8gGnHRKC92uMMiqD2)_