### PR TITLE
feat(boss): 狂暴瞬间立刻触发一次自身行动（不移动）

### DIFF
--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -4149,6 +4149,12 @@ export const combat_system = {
                 boss._berserkedRotation = true;
                 break;
         }
+
+        // [狂暴即时行动] 进入狂暴的瞬间，令 Boss 自身立刻额外触发一次行动。
+        // 仅 Boss 本体行动（不触发其他敌人），且不进行移动/跳跃——只结算其词条效果。
+        if (typeof boss.triggerImmediateAction === 'function') {
+            boss.triggerImmediateAction(this);
+        }
     },
 
     // ============================================================

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -3030,7 +3030,9 @@ class Enemy {
     }
 
     // --- [核心修改] 第二步：执行动作 (Execute Action) ---
-    executeTurnAction(game) {
+    // options.skipMove=true 时只结算词条行动，不进行移动/跳跃（用于狂暴即时反击等场景）
+    executeTurnAction(game, options = {}) {
+        const skipMove = !!options.skipMove;
         if (this._consumeBossVulnerabilityExposedTurn(game)) return;
 
         // @section:enemy_action_audio - 敌人行动音效分发：regen/split/freeze 按词缀类型路由
@@ -3203,6 +3205,15 @@ class Enemy {
             }
         }
 
+        // [skipMove] 仅结算词条行动、跳过所有移动/跳跃与移动冷却逻辑
+        // 用于 Boss 进入狂暴时的「立刻行动但不移动」即时反击
+        if (skipMove) {
+            this.hasActedThisTurn = true;
+            this._overloadDamageThisTurn = 0;
+            this._overloadBonusThisTurn = 0;
+            return;
+        }
+
         // --- [改动] 移动与跳跃：移出循环，始终只执行一次 ---
         // [Boss 移动冷却逻辑]
         // 狂暴模式下：每回合必定移动（_moveCooldown 始终为 0）
@@ -3291,6 +3302,28 @@ class Enemy {
         this.hasActedThisTurn = true;
         this._overloadDamageThisTurn = 0;
         this._overloadBonusThisTurn = 0;
+    }
+
+    /**
+     * @method triggerImmediateAction
+     * @description 立刻触发一次自身行动（仅本敌人，不移动、不影响其他敌人）。
+     *   用于 Boss 进入狂暴时的即时反击：只结算自身词条行动一次，
+     *   不进行移动/跳跃。冻结状态下不触发。
+     *   注意：此方法在玩家战斗阶段调用，所设置的 hasActedThisTurn 会在
+     *   phase_enemy_startLogic 中被重置，因此不影响 Boss 后续敌人回合的正常行动。
+     * @param {Object} game - 游戏主对象
+     */
+    triggerImmediateAction(game) {
+        if (!this.active) return;
+        if (this.isFrozenCurrentTurn) return;
+        // 清除可能残留的「狂暴」动作标记，确保本次只行动一次（不被 actionName==='狂暴' 翻倍）
+        const prevActionName = this.actionName;
+        const prevActionIcon = this.actionIcon;
+        this.actionName = '';
+        this.actionIcon = '';
+        this.executeTurnAction(game, { skipMove: true });
+        this.actionName = prevActionName;
+        this.actionIcon = prevActionIcon;
     }
 
     performTurnActionAndMove(game) {


### PR DESCRIPTION
## 需求

> boss 进入狂暴状态时，令其立刻触发一次行动（不触发其他敌人行动，而是 boss 自己行动，但不移动）。

## 改动

当 Boss HP 跌破狂暴阈值进入狂暴阶段时，在应用完狂暴效果后，**让 Boss 本体立刻额外触发一次自身行动**作为即时反击：

- ✅ 仅 **Boss 本体**结算一次词条行动 —— 不会触发其他敌人的行动
- ✅ **不移动 / 不跳跃**，也不消耗移动冷却 —— 只结算 Boss 自身的词条效果
- ✅ 冻结 / 失活状态下不触发

## 实现细节

| 文件 | 改动 |
|---|---|
| `src/entities/enemy.js` | `executeTurnAction` 新增 `options.skipMove`：仅结算词条行动后提前返回，跳过全部移动/跳跃与移动冷却逻辑 |
| `src/entities/enemy.js` | 新增 `Enemy.triggerImmediateAction(game)`：清除残留的「狂暴」动作标记以确保只行动一次（不被 `actionName==='狂暴'` 翻倍），再以 `skipMove` 调用 `executeTurnAction` |
| `src/combat_system.js` | `combat_triggerBossEnrage` 在应用完各 Boss 类型的狂暴效果后，调用 `boss.triggerImmediateAction(this)` |

### 关于 `hasActedThisTurn`

狂暴触发发生在玩家战斗阶段（伤害结算后的 `combat_checkBossPhaseChange`）。`executeTurnAction` 末尾会置 `hasActedThisTurn = true`，但该标记会在随后的 `phase_enemy_startLogic` 中被统一重置，因此**不影响 Boss 在后续敌人回合的正常行动**——狂暴瞬间这次是「额外」的一次行动。

## 验证

- `node --check` 通过（两个文件均无语法错误）
- 静态校验确认 `skipMove` 提前返回位于移动逻辑（`_doMove`）之前、helper 与调用均已正确接入

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2fmJL954NJmBNHDsoNKmE)_