### PR TITLE
fix: 修复持续特效（火焰/子弹拖尾等）在屏幕上残留不消失

### DIFF
--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -967,6 +967,20 @@ class Enemy {
         }
     }
 
+    /**
+     * [持续特效清理] 销毁附着在本敌人身上的所有持续元素视觉特效，
+     * 释放其 PixiJS 显示对象，防止敌人离场（被吞噬 / Boss 落点清除 /
+     * 阶段切换 / 关卡重置等非 HP 死亡路径）后火焰等特效 Sprite 残留在屏幕上。
+     *
+     * 幂等：各 destroy() 内部以 _pixi 是否存在为守卫，可安全重复调用。
+     */
+    releasePersistentEffects() {
+        if (this._burnEffect) { this._burnEffect.destroy(); this._burnEffect = null; }
+        if (this._electrocuteEffect) { this._electrocuteEffect.destroy(); this._electrocuteEffect = null; }
+        if (this._venomEffect) { this._venomEffect.destroy(); this._venomEffect = null; }
+        if (this._windMarkEffect) { this._windMarkEffect.destroy(); this._windMarkEffect = null; }
+    }
+
     addSwordCrack(relPos, angle) {
         // 限制裂纹数量，防止过多导致性能问题
         if (this.swordCracks.length > 5) this.swordCracks.shift();
@@ -8362,12 +8376,8 @@ class Enemy {
         const killed = this.hp <= 0;
         if (killed) {
             this.active = false;
-            // [BurnEffect] 死亡时销毁持续燃烧特效，释放 PixiJS 资源
-            if (this._burnEffect) { this._burnEffect.destroy(); this._burnEffect = null; }
-            // [ElementEffects] 死亡时销毁所有持续元素特效
-            if (this._electrocuteEffect) { this._electrocuteEffect.destroy(); this._electrocuteEffect = null; }
-            if (this._venomEffect) { this._venomEffect.destroy(); this._venomEffect = null; }
-            if (this._windMarkEffect) { this._windMarkEffect.destroy(); this._windMarkEffect = null; }
+            // [ElementEffects] 死亡时销毁所有持续元素特效（燃烧/电弧/毒液/风场），释放 PixiJS 资源
+            this.releasePersistentEffects();
 
             // --- [B2] Boss 专属死亡爆炸粒子 ---
             if (this.type === 'boss' && this.bossType && typeof game !== 'undefined') {

--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -261,6 +261,8 @@ class Projectile {
                 if (distToCenter >= innerRadius && distToCenter <= outerRadius) {
                     // 子弹进入缺口区域，触发吞噬效果
                     this.active = false;
+                    // [拖尾残留修复] 吞噬走非 destroy() 路径，立即释放拖尾 GPU 精灵，防止拖尾留在场上
+                    this.releasePixiResources();
                     if (typeof game !== 'undefined') {
                         // 吞噬特效：紫色冲击波 + 粒子散射
                         game.spawn_createShockwave(this.pos.x, this.pos.y, '#a855f7');
@@ -891,13 +893,16 @@ class Projectile {
         }
     }
 
-    destroy(spawnCallback) {
-        // [新属性] 超载爆炸（在标记 destroyed 之前以便其它系统可读 chargeCount）
-        try { this._detonateOvercharge(); } catch (e) { /* 防御性：销毁路径不应抛错 */ }
-
-        this.active = false;
-        this.destroyed = true;
-
+    /**
+     * [拖尾残留修复] 释放本子弹占用的所有 PixiJS GPU 资源（拖尾精灵 + 弹道光照精灵），
+     * 无任何游戏逻辑副作用，可在销毁 / 失活 / 阶段切换 / 重置等任意路径安全调用。
+     *
+     * 子弹经非常规路径离场（被吞噬 / 阶段切换 / 关卡重置 / 调试清场）时若不释放，
+     * 其拖尾 Sprite 会孤立残留在 ParticleContainer 上，表现为拖尾永久留在场上不消失。
+     *
+     * 幂等：以数组 / 引用是否存在为守卫，可安全重复调用。
+     */
+    releasePixiResources() {
         // [Trail V2] 释放拖尾 GPU 精灵回池
         if (this._trailV2Sprites) {
             for (const s of this._trailV2Sprites) pixiReleaseParticleSprite(s);
@@ -909,6 +914,17 @@ class Projectile {
             this._bulletGlowSprite.destroy();
             this._bulletGlowSprite = null;
         }
+    }
+
+    destroy(spawnCallback) {
+        // [新属性] 超载爆炸（在标记 destroyed 之前以便其它系统可读 chargeCount）
+        try { this._detonateOvercharge(); } catch (e) { /* 防御性：销毁路径不应抛错 */ }
+
+        this.active = false;
+        this.destroyed = true;
+
+        // [拖尾残留修复] 释放拖尾 / 光照 GPU 精灵
+        this.releasePixiResources();
 
         // [修改重点]：允许套娃子弹触发嵌套逻辑，即使它是 Copy (散射出来的)
         // 之前的逻辑是 !this.isCopy，这会阻止散射子弹裂变

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -2930,6 +2930,11 @@ phase_gathering_getRandomPegType() {
                         activeEnemies++;
                     }
                     if (Math.abs(e.pos.y - e.dropTargetY) > 1) anyEnemyMoving = true;
+                } else if (e._burnEffect || e._electrocuteEffect || e._venomEffect || e._windMarkEffect) {
+                    // [持续特效残留修复] 敌人因非 HP 死亡路径（被吞噬 / Boss 落点清除等）失活，
+                    // 其燃烧/电弧/毒液/风场等持续特效不会再被 update 清理。此处兜底销毁，
+                    // 防止火焰等 PixiJS Sprite 永久残留在屏幕上。
+                    if (typeof e.releasePersistentEffects === 'function') e.releasePersistentEffects();
                 }
             });
 

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -3041,8 +3041,11 @@ phase_gathering_getRandomPegType() {
                             }
                         }
                         this.projectiles.splice(i, 1);
-                    } 
-                } 
+                    } else if (!p.active) {
+                        // [拖尾残留修复] 子弹经非 destroy() 路径失活（如被吞噬），从数组移除避免长期滞留
+                        this.projectiles.splice(i, 1);
+                    }
+                }
             }
 
             // 更新和绘制 FireWaves

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -19,7 +19,7 @@ import { audio } from './audio.js';
 import { loot_calcRuneDrop } from './loot_system.js';
 import { RUNE_DB } from './rune_config.js';
 import { pixiTick, pixiResize, pixiSetVisibility } from './render/pixi_bridge.js';
-import { pixiCleanupAllEffects } from './render/pixi_effect_adapter.js';
+import { pixiCleanupAllEffects, fireWave_pixiDestroy, greedyWheelEffect_pixiDestroy } from './render/pixi_effect_adapter.js';
 import { eventBus, EVENT_TYPES } from './event_bus.js';
 import { calcCombatLauncherGeometryToTarget } from './utils/emitter_geometry.js';
 import { getBossDisplayName, getBossPreviewInfo, getBossShortName } from './utils/boss_schedule_utils.js';
@@ -2371,6 +2371,23 @@ export const game_system = {
      * @description 清除所有现存的投射物和爆发队列。
      */
     data_clearProjectiles() {
+        // [拖尾/特效残留修复] 清空数组前释放各自的 PixiJS GPU 资源，
+        // 否则子弹拖尾、火焰波、贪婪转盘等 Sprite 会孤立残留在场上不消失。
+        if (Array.isArray(this.projectiles)) {
+            for (const p of this.projectiles) {
+                if (p && typeof p.releasePixiResources === 'function') p.releasePixiResources();
+            }
+        }
+        if (Array.isArray(this.fireWaves)) {
+            for (const fw of this.fireWaves) {
+                if (fw && fw._pixi) { fireWave_pixiDestroy(fw._pixi); fw._pixi = null; }
+            }
+        }
+        if (Array.isArray(this.greedyWheelEffects)) {
+            for (const gw of this.greedyWheelEffects) {
+                if (gw && gw._pixi) { greedyWheelEffect_pixiDestroy(gw._pixi); gw._pixi = null; }
+            }
+        }
         this.sonSwords = [];
         this.projectiles = [];
         this.burstQueue = [];

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -2105,6 +2105,17 @@ export function pixiCleanupAllEffects(game) {
         }
     }
 
+    // --- enemies 数组：销毁附着在敌人身上的持续元素特效（燃烧/电弧/毒液/风场）---
+    // 这些特效不在全局特效数组中，而是挂在 enemy._burnEffect 等字段上，由 enemy 自身管理生命周期。
+    // 阶段切换 / 关卡重置时若不一并清理，其 PixiJS Sprite 会在效果容器上孤立残留（如火焰特效不消失）。
+    if (Array.isArray(game.enemies)) {
+        for (const e of game.enemies) {
+            if (e && typeof e.releasePersistentEffects === 'function') {
+                e.releasePersistentEffects();
+            }
+        }
+    }
+
     // energyOrbs：用 !active 判定移除
     if (Array.isArray(game.energyOrbs)) {
         for (const orb of game.energyOrbs) {

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -2116,6 +2116,17 @@ export function pixiCleanupAllEffects(game) {
         }
     }
 
+    // --- projectiles 数组：释放子弹拖尾 / 弹道光照 GPU 精灵 ---
+    // 子弹拖尾的 Trail V2 Sprite 与光照 Sprite 由 projectile 自身管理；阶段切换 / 重置时
+    // 若不释放，拖尾 Sprite 会孤立残留在 ParticleContainer 上（拖尾留在场上不消失）。
+    if (Array.isArray(game.projectiles)) {
+        for (const p of game.projectiles) {
+            if (p && typeof p.releasePixiResources === 'function') {
+                p.releasePixiResources();
+            }
+        }
+    }
+
     // energyOrbs：用 !active 判定移除
     if (Array.isArray(game.energyOrbs)) {
         for (const orb of game.energyOrbs) {

--- a/src/systems.js
+++ b/src/systems.js
@@ -4136,6 +4136,8 @@ class TrainingGround {
     }
 
     clearEnemies() {
+        // [持续特效残留修复] 清空敌人前先销毁其燃烧/电弧/毒液/风场等持续特效，防止 PixiJS Sprite 残留
+        pixiCleanupAllEffects(this.game);
         this.game.enemies = [];
         this.game.projectiles = [];
         this.game.particles = [];


### PR DESCRIPTION
## 问题

两类**持续/拖尾特效经常在屏幕上留下一部分，不会消失**：
1. 火焰等持续元素特效（敌人身上的燃烧/电弧/毒液/风场）
2. 子弹拖尾

## 共同根因

这些特效的 PixiJS Sprite 挂在全局容器 / `ParticleContainer` 上，**只在「常规离场路径」释放**（HP 死亡、温度回落、子弹正常 `destroy()`）。一旦目标经**其他路径离场**，释放函数从不触发，Sprite 就孤立残留在屏幕上。

> 注：PixiJS 7.4.2 中 `DisplayObject.destroy()` 本身会从父容器移除，所以问题不是 `destroy` 实现有缺陷，而是**根本没被调用**。

## 修复 A — 火焰等持续元素特效

特效（`BurnEffect`/`ElectrocuteEffect`/`VenomEffect`/`WindMarkEffect`）漏释放的路径：被吞噬、Boss 落点清除、**阶段切换/关卡重置（每回合发生，故"经常"）**。

| 文件 | 改动 |
|---|---|
| `entities/enemy.js` | 新增幂等 `releasePersistentEffects()`；死亡路径复用 |
| `game_phase.js` | 主战斗循环兜底：敌人失活（非 HP 死亡）时释放 |
| `render/pixi_effect_adapter.js` | `pixiCleanupAllEffects()` 遍历 `enemies` 一并清理 |
| `systems.js` | 调试 `clearEnemies()` 清空前先清理 |

## 修复 B — 子弹拖尾

拖尾的 Trail V2 / 弹道光照 GPU 精灵漏释放的路径：
- **被吞噬**：`projectile.js` 直接 `active=false` 后 `return`，不走 `destroy()`；主循环又仅按 `destroyed` 回收 → 拖尾精灵从不释放、子弹永久滞留数组
- **阶段切换 / 关卡重置 / 调试清场**：`projectiles=[]` 直接丢引用

| 文件 | 改动 |
|---|---|
| `entities/projectile.js` | 新增无副作用、幂等的 `releasePixiResources()`；`destroy()` 复用；吞噬路径立即释放 |
| `game_phase.js` | 主子弹循环：失活（非 destroy）子弹也从数组移除 |
| `game_system.js` | `data_clearProjectiles()` 清空前释放拖尾，并销毁 `fireWaves`/`greedyWheelEffects` 的 `_pixi` |
| `render/pixi_effect_adapter.js` | `pixiCleanupAllEffects()` 遍历 `projectiles` 释放拖尾 |

## 设计

所有释放方法均**幂等**（以 `_pixi`/精灵引用是否存在为守卫），多处兜底叠加安全；`releasePixiResources()` 无任何游戏逻辑副作用，可在任意路径调用。

## 验证

- 全部改动文件 `node --check` 通过
- 独立逻辑脚本模拟"中途失活 + 阶段切换清理 + 幂等重调"三场景，断言全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)