### PR TITLE
feat(boss): 破绽槽上限随累积满并恢复后 +25%

### DIFF
--- a/docs/boss_system_design.md
+++ b/docs/boss_system_design.md
@@ -115,6 +115,20 @@
 
 ## 4. Boss 移动间隔系统（已实现）
 
+### 4.0 破绽槽上限恢复增长（已实现）
+
+Boss 每次**累积满破绽**（破绽进度达到 `breakThreshold` 触发暴露），并在**暴露回合耗尽后从暴露中恢复**时，破绽槽上限按比例**永久增长 +25%**（按 `1.25` 复利叠加）。意图是惩罚反复打同一破绽循环、鼓励玩家在窗口内打出更高收益，避免无限循环刷暴露。
+
+**配置层**（`CONFIG.balance.bossVulnerability`）：
+- `breakThresholdGrowthOnRecover`：每次恢复后的上限增长比例（默认 `0.25`）。
+- `maxThresholdGrowthMult`：累计增长倍率封顶（默认 `4`，即最多 4×；`<=1` 视为不封顶）。
+
+**运行时状态**（每个 Boss 实体）：
+- `_bossVulnerabilityThresholdMult`：累计增长倍率（初始 `1`），`combat_getBossVulnerabilityProfile` 计算 `breakThreshold` 时按此放大；按命中（hits）与按伤害（damage）两种累积模式都生效。
+- `_bossVulnerabilityPendingThresholdGrowth`：本轮已触发破绽、等待恢复时结算的增长标记。
+
+**触发时机**：`combat_updateBossVulnerabilityProgress` 触发破绽时置 pending 标记；`_consumeBossVulnerabilityExposedTurn` 在暴露回合归零（恢复）且 pending 为真时调用 `_growBossVulnerabilityThreshold` 结算 +25% 并清除标记。两个字段均纳入存档。
+
 ### 4.1 设计原则
 
 Boss 不再每回合必定移动，而是根据其设定在常规模式下按固定间隔移动，狂暴模式下每回合必定移动。

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -1520,9 +1520,12 @@ export const combat_system = {
             const resolvedMode = mode || 'hits';
             const baseHitThreshold = Math.max(1, hitThreshold || mech.breakThreshold || 3);
             const baseDamageRatio = Math.max(0.01, damageRatio || mech.baseDamageRatio || 0.10);
-            const breakThreshold = resolvedMode === 'damage'
+            const baseBreakThreshold = resolvedMode === 'damage'
                 ? Math.max(1, Math.ceil((boss.maxHp || 1) * (baseDamageRatio + scaleSteps * (mech.damageRatioRoundBonus || 0))))
                 : Math.max(1, Math.ceil(baseHitThreshold + scaleSteps * (mech.hitThresholdRoundBonus || 0)));
+            // 每次累积满破绽并从暴露中恢复后，破绽槽上限按 _bossVulnerabilityThresholdMult 永久放大（+25%/次）。
+            const growthMult = Math.max(1, boss._bossVulnerabilityThresholdMult || 1);
+            const breakThreshold = Math.max(1, Math.ceil(baseBreakThreshold * growthMult));
             return {
                 attrs,
                 label,
@@ -1641,6 +1644,8 @@ export const combat_system = {
                 ouroboros: 'rotation_node'
             })[enemy.bossType] || 'core';
             enemy._bossVulnerabilityBreakTimer = Math.max(enemy._bossVulnerabilityBreakTimer || 0, 34);
+            // 标记本次破绽待恢复增长：Boss 从暴露中恢复时把破绽槽上限再 +25%。
+            enemy._bossVulnerabilityPendingThresholdGrowth = true;
             if (mech.enrageDelayOnBreak && !enemy.berserked) {
                 enemy._bossVulnerabilitySuppressedEnrage = true;
             }

--- a/src/config.js
+++ b/src/config.js
@@ -886,7 +886,11 @@ const CONFIG = {
             hitThresholdRoundBonus: 1,
             damageRatioRoundBonus: 0.015,
             maxRoundScaleSteps: 6,
-            enrageDelayOnBreak: true
+            enrageDelayOnBreak: true,
+            // Boss 每次累积满破绽并从暴露中恢复后，破绽槽上限按比例永久增长（+25%）。
+            breakThresholdGrowthOnRecover: 0.25,
+            // 破绽槽上限累计增长倍率上限（防止长局无限膨胀）；<=1 视为不封顶。
+            maxThresholdGrowthMult: 4
         },
         /** Boss 进场冲击波效果配置 */
         bossEntranceShockwave: {

--- a/src/entities/enemy.js
+++ b/src/entities/enemy.js
@@ -408,6 +408,8 @@ class Enemy {
         this._carrierCooldown = 0;
         this._bossVulnerabilityProgress = 0;
         this._bossVulnerabilityThreshold = 0;
+        this._bossVulnerabilityThresholdMult = 1; // 每次累积满破绽并恢复后 *=(1+growth)，破绽槽上限永久增长
+        this._bossVulnerabilityPendingThresholdGrowth = false; // 破绽已触发、等待恢复时结算上限增长
         this._bossVulnerabilityMode = null;
         this._bossVulnerabilityVisualAttrs = [];
         this._bossVulnerabilityVisualRatio = 0;
@@ -1561,6 +1563,11 @@ class Enemy {
         this._bossVulnerabilityExposedHits = 0;
         this._bossVulnerabilityRecoverTimer = Math.max(this._bossVulnerabilityRecoverTimer || 0, 32);
         this._bossVulnerabilityVisualRatio = 0;
+        // 完全恢复（暴露回合耗尽）且本轮确实累积满过破绽时，破绽槽上限永久 +25%。
+        if (this._bossVulnerabilityExposedTurns <= 0 && this._bossVulnerabilityPendingThresholdGrowth) {
+            this._growBossVulnerabilityThreshold(game);
+            this._bossVulnerabilityPendingThresholdGrowth = false;
+        }
         this.actionPhase = 'idle';
         this.telegraphTimer = 0;
         this.telegraphIntent = null;
@@ -1575,6 +1582,26 @@ class Enemy {
             game.spawn_createShockwave(this.pos.x, this.pos.y, '#facc15');
         }
         return true;
+    }
+
+    // Boss 每次累积满破绽并从暴露中恢复后，破绽槽上限按配置比例（默认 +25%）永久增长。
+    _growBossVulnerabilityThreshold(game = null) {
+        if (this.type !== 'boss') return;
+        const mech = CONFIG.balance.bossVulnerability || {};
+        const growth = Math.max(0, mech.breakThresholdGrowthOnRecover || 0);
+        if (growth <= 0) return;
+        const cap = mech.maxThresholdGrowthMult || 0;
+        let mult = (this._bossVulnerabilityThresholdMult || 1) * (1 + growth);
+        if (cap > 1) mult = Math.min(cap, mult);
+        if (mult <= (this._bossVulnerabilityThresholdMult || 1)) return; // 已到上限，无需再涨
+        this._bossVulnerabilityThresholdMult = mult;
+        // 同步刷新展示用阈值，HUD 立即反映新的破绽槽上限（下一次命中会按 profile 精确重算）。
+        if (this._bossVulnerabilityThreshold > 0) {
+            this._bossVulnerabilityThreshold = Math.max(1, Math.ceil(this._bossVulnerabilityThreshold * (1 + growth)));
+        }
+        if (game && typeof game.spawn_createFloatingText === 'function') {
+            game.spawn_createFloatingText(this.pos.x, this.pos.y - 60, '破绽槽强化', '#fbbf24', 13);
+        }
     }
 
     _getRadiantAegisTargets(game) {

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -2846,6 +2846,8 @@ export const game_system = {
                     _bossVulnerabilitySuppressedEnrage: e._bossVulnerabilitySuppressedEnrage || false,
                     _bossVulnerabilityMode: e._bossVulnerabilityMode,
                     _bossVulnerabilityThreshold: e._bossVulnerabilityThreshold || 0,
+                    _bossVulnerabilityThresholdMult: e._bossVulnerabilityThresholdMult || 1,
+                    _bossVulnerabilityPendingThresholdGrowth: e._bossVulnerabilityPendingThresholdGrowth || false,
                     _bossVulnerabilityBreakTimer: e._bossVulnerabilityBreakTimer || 0,
                     _bossVulnerabilityRecoverTimer: e._bossVulnerabilityRecoverTimer || 0,
                 };
@@ -3312,6 +3314,8 @@ export const game_system = {
                 e._bossVulnerabilitySuppressedEnrage = d._bossVulnerabilitySuppressedEnrage || false;
                 e._bossVulnerabilityMode = d._bossVulnerabilityMode;
                 e._bossVulnerabilityThreshold = d._bossVulnerabilityThreshold || 0;
+                e._bossVulnerabilityThresholdMult = d._bossVulnerabilityThresholdMult || 1;
+                e._bossVulnerabilityPendingThresholdGrowth = d._bossVulnerabilityPendingThresholdGrowth || false;
                 e._bossVulnerabilityBreakTimer = d._bossVulnerabilityBreakTimer || 0;
                 e._bossVulnerabilityRecoverTimer = d._bossVulnerabilityRecoverTimer || 0;
                 e.justSpawned = false; // 恢复时不播放入场动画

--- a/tests/validate_boss_vulnerability.mjs
+++ b/tests/validate_boss_vulnerability.mjs
@@ -177,6 +177,18 @@ check(mechanic?.exposedDamageMult > 1, 'bossVulnerability.exposedDamageMult > 1'
 check(mechanic?.roundScalingStep > 0, 'bossVulnerability.roundScalingStep 合法');
 check(mechanic?.hitThresholdRoundBonus > 0, '命中次数阈值会随回合提高');
 check(mechanic?.damageRatioRoundBonus > 0, '伤害阈值会随回合提高');
+check(mechanic?.breakThresholdGrowthOnRecover > 0, '破绽槽上限恢复增长比例已配置（+25%）');
+check(combatSource.includes('_bossVulnerabilityThresholdMult'), '破绽槽上限按累计增长倍率放大');
+check(combatSource.includes('_bossVulnerabilityPendingThresholdGrowth'), '破绽触发会标记待结算的上限增长');
+check(enemySource.includes('_growBossVulnerabilityThreshold'), '恢复时调用破绽槽上限增长结算');
+check(
+    /_bossVulnerabilityExposedTurns\s*<=\s*0\s*&&\s*this\._bossVulnerabilityPendingThresholdGrowth/.test(enemySource),
+    '仅在暴露回合耗尽且本轮累积满破绽时才增长上限'
+);
+check(
+    gameSystemSource.includes('_bossVulnerabilityThresholdMult') && gameSystemSource.includes('_bossVulnerabilityPendingThresholdGrowth'),
+    '存档保留 Boss 破绽槽上限增长倍率与待结算标记'
+);
 check(Array.isArray(bossConfigs.ouroboros?.vulnerability?.rotationAttrs), 'Ouroboros 使用动态轮转破绽谱');
 check((bossConfigs.ouroboros?.vulnerability?.rotationAttrs || []).length === 6, 'Ouroboros 动态破绽谱覆盖六附体');
 check(bossConfigs.viridis?.vulnerability?.attrs?.includes('pyro') && bossConfigs.viridis?.vulnerability?.attrs?.includes('venom'), 'Viridis 破绽谱使用火焰/毒素反制孢甲');

--- a/tests/validate_boss_vulnerability_threshold_growth.mjs
+++ b/tests/validate_boss_vulnerability_threshold_growth.mjs
@@ -1,0 +1,164 @@
+/**
+ * validate_boss_vulnerability_threshold_growth.mjs
+ * 运行时锁定：Boss 每次累积满破绽并从暴露中恢复后，破绽槽上限 +25%。
+ *
+ * - 通过 combat_system.combat_getBossVulnerabilityProfile 验证 breakThreshold 随
+ *   _bossVulnerabilityThresholdMult 放大。
+ * - 通过 Enemy.prototype._consumeBossVulnerabilityExposedTurn 验证恢复时上限增长结算，
+ *   且封顶 maxThresholdGrowthMult 后不再增长。
+ *
+ * Usage: node tests/validate_boss_vulnerability_threshold_growth.mjs
+ */
+
+function installBrowserStubs() {
+    const context2d = {
+        save() {}, restore() {}, clearRect() {}, fillRect() {}, strokeRect() {},
+        beginPath() {}, closePath() {}, arc() {}, moveTo() {}, lineTo() {},
+        quadraticCurveTo() {}, bezierCurveTo() {}, fill() {}, stroke() {},
+        translate() {}, rotate() {}, scale() {}, drawImage() {},
+        createLinearGradient() { return { addColorStop() {} }; },
+        createRadialGradient() { return { addColorStop() {} }; },
+        measureText(text) { return { width: String(text || '').length * 8 }; },
+        setTransform() {}, fillText() {}, strokeText() {},
+    };
+    globalThis.OffscreenCanvas = class {
+        constructor(width, height) { this.width = width; this.height = height; }
+        getContext() { return context2d; }
+    };
+    globalThis.HTMLCanvasElement = class {};
+    globalThis.Image = class {
+        set src(value) { this._src = value; if (typeof this.onload === 'function') queueMicrotask(() => this.onload()); }
+        get src() { return this._src; }
+    };
+    globalThis.document = {
+        createElement() {
+            return { width: 0, height: 0, style: {}, classList: { add() {}, remove() {}, toggle() {} }, appendChild() {}, remove() {}, setAttribute() {}, getContext() { return context2d; } };
+        },
+        getElementById() {
+            return { innerText: '', textContent: '', style: {}, classList: { add() {}, remove() {}, toggle() {} }, appendChild() {}, remove() {} };
+        },
+        body: { appendChild() {} },
+    };
+    globalThis.window = globalThis;
+    globalThis.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+}
+
+installBrowserStubs();
+
+const [{ CONFIG }, { combat_system }, { Enemy }] = await Promise.all([
+    import('../src/config.js'),
+    import('../src/combat_system.js'),
+    import('../src/entities.js'),
+]);
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function check(condition, message) {
+    if (condition) {
+        passed++;
+        console.log(`  PASS ${message}`);
+    } else {
+        failed++;
+        failures.push(message);
+        console.error(`  FAIL ${message}`);
+    }
+}
+
+console.log('Boss vulnerability threshold growth runtime validation\n');
+
+const mech = CONFIG.balance.bossVulnerability;
+const growth = mech.breakThresholdGrowthOnRecover;
+check(growth === 0.25, 'breakThresholdGrowthOnRecover 默认 +25%');
+
+// --- profile.breakThreshold 随 _bossVulnerabilityThresholdMult 放大 ---
+const ctx = {
+    round: 1,
+    combat_getBossVulnerabilityProfile: combat_system.combat_getBossVulnerabilityProfile,
+    combat_getProjectileVulnerabilityAttrs: combat_system.combat_getProjectileVulnerabilityAttrs
+};
+
+// ignis 使用 hits 模式，便于精确比对整数阈值。
+const baseBoss = { type: 'boss', bossType: 'ignis', maxHp: 1000, _bossVulnerabilityThresholdMult: 1 };
+const baseProfile = ctx.combat_getBossVulnerabilityProfile(baseBoss);
+check(!!baseProfile && baseProfile.breakThreshold > 0, 'ignis 破绽 profile 可解析');
+const baseThreshold = baseProfile.breakThreshold;
+
+const grownProfile = ctx.combat_getBossVulnerabilityProfile({ ...baseBoss, _bossVulnerabilityThresholdMult: 1.25 });
+check(
+    grownProfile.breakThreshold === Math.max(1, Math.ceil(baseThreshold * 1.25)),
+    `1.25x 倍率使 breakThreshold 由 ${baseThreshold} 增长为 ${grownProfile.breakThreshold}`
+);
+
+// damage 模式（如 viridis）同样随倍率放大。
+const dmgBoss = { type: 'boss', bossType: 'viridis', maxHp: 2000, _bossVulnerabilityThresholdMult: 1 };
+const dmgBaseProfile = ctx.combat_getBossVulnerabilityProfile(dmgBoss);
+const dmgGrown = ctx.combat_getBossVulnerabilityProfile({ ...dmgBoss, _bossVulnerabilityThresholdMult: 1.25 });
+check(
+    dmgBaseProfile.mode === 'damage' && dmgGrown.breakThreshold > dmgBaseProfile.breakThreshold,
+    'damage 模式 Boss 的破绽槽上限同样随倍率增长'
+);
+
+// --- 恢复结算：累积满破绽后从暴露恢复，倍率 +25% 且 pending 清零 ---
+function makeExposedBoss(overrides = {}) {
+    // 挂在 Enemy.prototype 上，以便复用 _consumeBossVulnerabilityExposedTurn / _growBossVulnerabilityThreshold。
+    return Object.assign(Object.create(Enemy.prototype), {
+        type: 'boss',
+        bossType: 'ignis',
+        pos: { x: 0, y: 0 },
+        _bossVulnerabilityExposedTurns: 1,
+        _bossVulnerabilityThresholdMult: 1,
+        _bossVulnerabilityThreshold: 4,
+        _bossVulnerabilityPendingThresholdGrowth: true,
+        ...overrides
+    });
+}
+
+const recoverBoss = makeExposedBoss();
+recoverBoss._consumeBossVulnerabilityExposedTurn(null);
+check(recoverBoss._bossVulnerabilityExposedTurns === 0, '消费暴露回合后归零（进入恢复）');
+check(
+    Math.abs(recoverBoss._bossVulnerabilityThresholdMult - 1.25) < 1e-9,
+    '从暴露恢复后破绽槽上限倍率变为 1.25（+25%）'
+);
+check(recoverBoss._bossVulnerabilityPendingThresholdGrowth === false, '结算后清除 pending 增长标记');
+check(recoverBoss._bossVulnerabilityThreshold === 5, '展示阈值 4 同步增长为 ceil(4*1.25)=5');
+
+// 没有 pending（未累积满破绽就被动消费暴露）则不增长。
+const noPending = makeExposedBoss({ _bossVulnerabilityPendingThresholdGrowth: false });
+noPending._consumeBossVulnerabilityExposedTurn(null);
+check(noPending._bossVulnerabilityThresholdMult === 1, '未累积满破绽时不增长上限');
+
+// 多次恢复复利增长：1 -> 1.25 -> 1.5625 -> 1.953125
+const chain = makeExposedBoss();
+const seen = [];
+for (let i = 0; i < 3; i++) {
+    chain._bossVulnerabilityExposedTurns = 1;
+    chain._bossVulnerabilityPendingThresholdGrowth = true;
+    chain._consumeBossVulnerabilityExposedTurn(null);
+    seen.push(Number(chain._bossVulnerabilityThresholdMult.toFixed(6)));
+}
+check(
+    seen[0] === 1.25 && seen[1] === 1.5625 && Math.abs(seen[2] - 1.953125) < 1e-9,
+    `多次恢复按 +25% 复利增长：${seen.join(' → ')}`
+);
+
+// 封顶：达到 maxThresholdGrowthMult 后不再增长。
+const cap = mech.maxThresholdGrowthMult;
+if (cap > 1) {
+    const capped = makeExposedBoss({ _bossVulnerabilityThresholdMult: cap });
+    capped._bossVulnerabilityExposedTurns = 1;
+    capped._bossVulnerabilityPendingThresholdGrowth = true;
+    capped._consumeBossVulnerabilityExposedTurn(null);
+    check(capped._bossVulnerabilityThresholdMult <= cap, `破绽槽上限增长封顶于 ${cap}x`);
+}
+
+const total = passed + failed;
+console.log(`\nResult: ${passed}/${total} passed`);
+if (failures.length > 0) {
+    console.log('Failures:');
+    failures.forEach(item => console.log(`  - ${item}`));
+}
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## 需求

> boss 每次累积满破绽，并从中恢复后，破绽槽上限 +25%

## 实现

Boss 每次**累积满破绽**（破绽进度达到 `breakThreshold` 触发暴露），并在**暴露回合耗尽、从暴露中恢复后**，破绽槽上限按比例**永久增长 +25%**（`1.25` 复利叠加）。按命中（hits）与按伤害（damage）两种累积模式都生效，并封顶于 `maxThresholdGrowthMult`（默认 4×）以防长局无限膨胀。

设计意图：惩罚反复刷同一破绽循环，鼓励玩家在暴露窗口内打出更高收益。

### 改动点

| 文件 | 改动 |
|------|------|
| `src/config.js` | 新增 `bossVulnerability.breakThresholdGrowthOnRecover`(0.25) 与 `maxThresholdGrowthMult`(4) |
| `src/combat_system.js` | `combat_getBossVulnerabilityProfile` 计算的 `breakThreshold` 按 `_bossVulnerabilityThresholdMult` 放大；触发破绽时标记 `_bossVulnerabilityPendingThresholdGrowth` |
| `src/entities/enemy.js` | 初始化新运行时字段；`_consumeBossVulnerabilityExposedTurn` 恢复时结算增长；新增 `_growBossVulnerabilityThreshold` 助手 |
| `src/game_system.js` | 存档读写保留增长倍率与待结算标记 |
| `docs/boss_system_design.md` | 记录新机制（§4.0） |
| `tests/` | 静态断言扩展 + 新增运行时增长/封顶/存档校验 |

### 状态流转

1. 破绽进度累积满 `breakThreshold` → 触发暴露，置 `_bossVulnerabilityPendingThresholdGrowth = true`
2. 暴露回合耗尽（`_consumeBossVulnerabilityExposedTurn` 将暴露回合减到 0）→ 进入恢复，结算 `_bossVulnerabilityThresholdMult *= 1.25`、清除 pending、HUD 阈值同步刷新
3. 下次 `combat_getBossVulnerabilityProfile` 按新倍率精确重算上限

## 测试

- `tests/validate_boss_vulnerability.mjs`：109/109 通过（含新增静态断言）
- `tests/validate_boss_vulnerability_threshold_growth.mjs`（新增运行时测试）：11/11 通过
  - profile 阈值随倍率放大（hits + damage 两种模式）
  - 恢复时 +25% 结算、pending 清零、展示阈值同步、复利增长、封顶
- 其余 validate 套件回归通过；`validate_phase_contracts.mjs` 的 2 项 launcher 视觉失败为既有问题（与本次改动无关，已 stash 验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brhd5DEd8iC1XrtemhjCYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brhd5DEd8iC1XrtemhjCYL)_