### PR TITLE
feat(fx): 为剧毒火焰 DoT 击杀新增专属死亡特效

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -861,6 +861,36 @@ class SoundManager {
                 noise.stop(now + 0.25);
                 break;
             }
+            // @section:effect_venom_death - venom_death：剧毒火焰溶解死亡，低频咕噜下滑 + 高通腐蚀噪声嘶嘶
+            case 'venom_death': {
+                // 低频咕噜（溶解感）：三角波下滑
+                const osc = this.ctx.createOscillator();
+                const gain = this.ctx.createGain();
+                osc.type = 'triangle';
+                osc.frequency.setValueAtTime(220, now);
+                osc.frequency.exponentialRampToValueAtTime(60, now + 0.35);
+                gain.gain.setValueAtTime(0.07, now);
+                gain.gain.exponentialRampToValueAtTime(0.001, now + 0.38);
+                osc.connect(gain);
+                gain.connect(this.sfxGain);
+                osc.start(now);
+                osc.stop(now + 0.4);
+                // 腐蚀嘶嘶声（高通白噪声）
+                const noise = this.ctx.createBufferSource();
+                noise.buffer = this.noiseBuffer;
+                const nFilter = this.ctx.createBiquadFilter();
+                nFilter.type = 'highpass';
+                nFilter.frequency.setValueAtTime(1400, now);
+                const noiseGain = this.ctx.createGain();
+                noiseGain.gain.setValueAtTime(0.06, now);
+                noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+                noise.connect(nFilter);
+                nFilter.connect(noiseGain);
+                noiseGain.connect(this.sfxGain);
+                noise.start(now);
+                noise.stop(now + 0.32);
+                break;
+            }
             default:
                 this.playTone(400, 'sine', 0.08, 0.1);
         }

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -4171,10 +4171,17 @@ export const combat_system = {
      * @param {Enemy} enemy - 死亡的敌人实例
      * @param {string} shotId - 弹丸射击 ID
      */
-    _triggerDeathFX(enemy, shotId) {
+    _triggerDeathFX(enemy, shotId, options = {}) {
         const x = enemy.pos.x;
         const y = enemy.pos.y;
         const tier = enemy.type; // 'normal' | 'elite' | 'boss'
+
+        // [剧毒火焰死亡] 毒素 DoT 击杀走专属死亡特效（绿色毒焰溶解），区别于普通/精英/Boss 死亡
+        if (options && options.cause === 'venom') {
+            this._triggerVenomDeathFX(enemy, x, y, tier);
+            return;
+        }
+
         const isFrozen = enemy.temp <= -80;  // 冰冻状态门槛
         const isBurning = enemy.temp >= 100; // 燃烧状态门槛
 
@@ -4323,6 +4330,62 @@ export const combat_system = {
                     p.size = 5 + Math.random() * 4;
                 }
             }
+        }
+    },
+
+    // ============================================================
+    // [剧毒火焰死亡] 毒素 DoT 击杀专属死亡特效
+    // 主题：绿色毒焰溶解 —— 毒气云膨胀 + 上升毒焰舌 + 酸液气泡 + 飞溅毒滴，
+    // 区别于冰冻碎裂 / 燃烧爆炸 / 分级内爆。按敌人等级缩放强度。
+    // ============================================================
+    _triggerVenomDeathFX(enemy, x, y, tier) {
+        if (!this.deathExplosions) this.deathExplosions = [];
+        const _deBudget = CONFIG.performance[this.perfQualityLevel || 'high'];
+        // Boss 死亡稀有且重要，不受上限约束；精英/普通受 deathExplosionLimit 约束
+        if (tier === 'boss' || this.deathExplosions.length < _deBudget.deathExplosionLimit) {
+            this.deathExplosions.push(new DeathExplosion(x, y, tier, 'venom'));
+        }
+
+        // 毒雾扩散粒子（向上漂浮的腐蚀烟雾）
+        const mistCount = tier === 'boss' ? 14 : (tier === 'elite' ? 9 : 5);
+        for (let i = 0; i < mistCount; i++) {
+            const p = this.spawn_createParticle(
+                x + (Math.random() - 0.5) * 18,
+                y + (Math.random() - 0.5) * 14,
+                i % 2 ? 'rgba(132,204,22,0.5)' : 'rgba(101,163,13,0.45)',
+                'mist'
+            );
+            if (p) {
+                p.vel = new Vec2((Math.random() - 0.5) * 0.6, -0.3 - Math.random() * 0.5);
+                p.size = 6 + Math.random() * 6;
+            }
+        }
+
+        // 飞溅毒液粒子（四散的酸液滴）
+        const splashCount = tier === 'boss' ? 12 : (tier === 'elite' ? 7 : 4);
+        for (let i = 0; i < splashCount; i++) {
+            const p = this.spawn_createParticle(x, y, i % 2 ? '#84cc16' : '#bef264', 'venom');
+            if (p) {
+                const a = Math.random() * Math.PI * 2;
+                const sp = 1.2 + Math.random() * 2.4;
+                p.vel = new Vec2(Math.cos(a) * sp, Math.sin(a) * sp - 1);
+            }
+        }
+
+        // 腐蚀冲击波
+        if (typeof this.spawn_createShockwave === 'function') {
+            this.spawn_createShockwave(x, y, '#84cc16');
+        }
+
+        // 击杀震动（毒焰溶解较柔，震幅低于爆炸）
+        if (typeof this.triggerScreenShake === 'function') {
+            this.triggerScreenShake(tier === 'boss' ? 10 : (tier === 'elite' ? 5 : 2.5));
+        }
+
+        // 音效 + 浮动文字
+        if (audio && typeof audio.playEffect === 'function') audio.playEffect('venom_death');
+        if (typeof this.spawn_createFloatingText === 'function') {
+            this.spawn_createFloatingText(x, y - 26, '☠️ 溶解!', '#84cc16');
         }
     },
 };

--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -1960,12 +1960,20 @@ class DeathExplosion {
      * @param {number} y
      * @param {'normal'|'elite'|'boss'} tier - 敌人等级
      */
-    constructor(x, y, tier = 'normal') {
+    constructor(x, y, tier = 'normal', variant = 'default') {
         this.x = x;
         this.y = y;
         this.tier = tier;
+        this.variant = variant;
         this.life = 1.0;
         this.timer = 0;
+
+        // [剧毒火焰死亡] 毒焰溶解专属死亡：绿色毒气云 + 上升毒焰舌 + 酸液气泡 + 飞溅毒滴
+        if (variant === 'venom') {
+            this._initVenom(tier);
+            this._pixi = null;
+            return;
+        }
 
         if (tier === 'boss') {
             // Boss：先膨胀挥扎，再猛烈内爆塑陷
@@ -2057,7 +2065,81 @@ class DeathExplosion {
         this._pixi = null; // [PixiJS 迁移]
     }
 
+    // [剧毒火焰死亡] 初始化毒焰溶解死亡的几何参数（按敌人等级缩放）
+    _initVenom(tier) {
+        const scale = tier === 'boss' ? 1.8 : (tier === 'elite' ? 1.3 : 1.0);
+        this.scale = scale;
+        this.decay = tier === 'boss' ? 0.013 : (tier === 'elite' ? 0.019 : 0.025);
+        // 毒气云：先膨胀后消散
+        this.gasRadius = 5 * scale;
+        this.gasMaxRadius = 30 + (tier === 'boss' ? 42 : (tier === 'elite' ? 18 : 0));
+        // 腐蚀核：溶解收缩的躯体残影
+        this.coreRadius = 15 * scale;
+        // 上升的毒焰舌
+        const flameCount = tier === 'boss' ? 9 : (tier === 'elite' ? 6 : 4);
+        this.flames = Array.from({ length: flameCount }, () => ({
+            ox: (Math.random() - 0.5) * 22 * scale,
+            phase: Math.random() * Math.PI * 2,
+            sway: (3 + Math.random() * 4) * scale,
+            height: (16 + Math.random() * 20) * scale,
+            width: (4 + Math.random() * 4) * scale,
+            speed: 0.7 + Math.random() * 0.6,
+            rise: 0,
+            life: 0.85 + Math.random() * 0.15,
+            bright: Math.random() < 0.4,
+        }));
+        // 酸液气泡：向外漂移后破裂
+        const bubbleCount = tier === 'boss' ? 16 : (tier === 'elite' ? 10 : 6);
+        this.bubbles = Array.from({ length: bubbleCount }, () => ({
+            angle: Math.random() * Math.PI * 2,
+            dist: (4 + Math.random() * 10) * scale,
+            speed: 0.3 + Math.random() * 0.7,
+            size: (1.6 + Math.random() * 2.6) * scale,
+            wobble: Math.random() * Math.PI * 2,
+            popAt: 0.25 + Math.random() * 0.45, // life 低于此阈值时破裂消失
+        }));
+        // 飞溅毒液滴：抛物线四散
+        const dropCount = tier === 'boss' ? 14 : (tier === 'elite' ? 9 : 5);
+        this.droplets = Array.from({ length: dropCount }, () => {
+            const a = Math.random() * Math.PI * 2;
+            const sp = (1.2 + Math.random() * 2.6) * (0.7 + scale * 0.3);
+            return {
+                x: 0, y: 0,
+                vx: Math.cos(a) * sp,
+                vy: Math.sin(a) * sp - 1.4,
+                size: (1.5 + Math.random() * 2.4) * scale,
+                gravity: 0.10 + Math.random() * 0.07,
+                bright: Math.random() < 0.5,
+                alpha: 0.7 + Math.random() * 0.3,
+            };
+        });
+    }
+
+    // [剧毒火焰死亡] 推进毒焰溶解死亡动画
+    _updateVenom(timeScale) {
+        this.timer += timeScale;
+        this.life -= this.decay * timeScale;
+        if (this.gasRadius < this.gasMaxRadius) {
+            this.gasRadius += (this.gasMaxRadius / 14) * timeScale;
+        }
+        this.coreRadius = Math.max(0, this.coreRadius - 0.45 * timeScale);
+        for (const f of this.flames) {
+            f.rise += f.speed * timeScale;
+            f.phase += 0.22 * timeScale;
+        }
+        for (const b of this.bubbles) {
+            b.dist += b.speed * timeScale;
+            b.wobble += 0.3 * timeScale;
+        }
+        for (const d of this.droplets) {
+            d.x += d.vx * timeScale;
+            d.y += d.vy * timeScale;
+            d.vy += d.gravity * timeScale;
+        }
+    }
+
     update(timeScale) {
+        if (this.variant === 'venom') { this._updateVenom(timeScale); return; }
         this.timer += timeScale;
         this.life -= this.decay * timeScale;
 
@@ -2116,6 +2198,7 @@ class DeathExplosion {
             if (!this._pixi) this._pixi = deathExplosion_pixiCreate(this);
             if (this._pixi) { deathExplosion_pixiSync(this, this._pixi); return; }
         }
+        if (this.variant === 'venom') { this._drawVenom(ctx); return; }
         ctx.save();
         const quality = (typeof game !== 'undefined' && game.perfQualityLevel) || 'high';
         const isLow = quality === 'low';
@@ -2291,6 +2374,100 @@ class DeathExplosion {
             ctx.fillStyle = s.color;
             ctx.beginPath();
             ctx.arc(sx, sy, s.size, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.restore();
+    }
+
+    // [剧毒火焰死亡] Canvas 绘制毒焰溶解死亡
+    _drawVenom(ctx) {
+        const life = Math.max(0, this.life);
+        const quality = (typeof game !== 'undefined' && game.perfQualityLevel) || 'high';
+        const isLow = quality === 'low';
+        ctx.save();
+
+        // ---- 1. 毒气云：径向绿黄渐变（加亮混合）----
+        if (this.gasRadius > 0) {
+            ctx.globalCompositeOperation = 'lighter';
+            ctx.globalAlpha = life * 0.5;
+            const grad = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, this.gasRadius);
+            grad.addColorStop(0, 'rgba(190,242,100,0.9)');
+            grad.addColorStop(0.45, 'rgba(132,204,22,0.5)');
+            grad.addColorStop(1, 'rgba(101,163,13,0)');
+            ctx.fillStyle = grad;
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, this.gasRadius, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        // ---- 2. 腐蚀核：暗绿溶解残影（正常混合，先于焰舌画）----
+        if (this.coreRadius > 0) {
+            ctx.globalCompositeOperation = 'source-over';
+            ctx.globalAlpha = life * 0.7;
+            const cGrad = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, this.coreRadius);
+            cGrad.addColorStop(0, 'rgba(54,83,20,0.9)');
+            cGrad.addColorStop(0.7, 'rgba(63,98,18,0.5)');
+            cGrad.addColorStop(1, 'rgba(63,98,18,0)');
+            ctx.fillStyle = cGrad;
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, this.coreRadius, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        // ---- 3. 上升的毒焰舌 ----
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.lineCap = 'round';
+        for (const f of this.flames) {
+            const fa = life * f.life;
+            if (fa <= 0.02) continue;
+            const baseX = this.x + f.ox + Math.sin(f.phase) * f.sway * 0.4;
+            const baseY = this.y - f.rise;
+            const tipX = baseX + Math.sin(f.phase * 1.6) * f.sway;
+            const tipY = baseY - f.height;
+            const midX = (baseX + tipX) / 2 + Math.sin(f.phase * 1.2) * f.sway * 0.5;
+            const midY = (baseY + tipY) / 2;
+            ctx.globalAlpha = fa * 0.85;
+            const fGrad = ctx.createLinearGradient(baseX, baseY, tipX, tipY);
+            fGrad.addColorStop(0, f.bright ? 'rgba(217,249,157,0.9)' : 'rgba(132,204,22,0.85)');
+            fGrad.addColorStop(0.5, 'rgba(101,163,13,0.6)');
+            fGrad.addColorStop(1, 'rgba(101,163,13,0)');
+            ctx.strokeStyle = fGrad;
+            ctx.lineWidth = f.width;
+            if (!isLow) { ctx.shadowColor = '#84cc16'; ctx.shadowBlur = _sb(6); }
+            ctx.beginPath();
+            ctx.moveTo(baseX, baseY);
+            ctx.quadraticCurveTo(midX, midY, tipX, tipY);
+            ctx.stroke();
+            ctx.shadowBlur = 0;
+        }
+
+        // ---- 4. 酸液气泡（漂移 + 破裂）----
+        for (const b of this.bubbles) {
+            if (this.life < b.popAt) continue; // 破裂后不再绘制
+            const bx = this.x + Math.cos(b.angle) * b.dist + Math.sin(b.wobble) * 2;
+            const by = this.y + Math.sin(b.angle) * b.dist - b.dist * 0.15;
+            ctx.globalAlpha = life * 0.55;
+            ctx.fillStyle = 'rgba(190,242,100,0.6)';
+            ctx.beginPath();
+            ctx.arc(bx, by, b.size, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.globalAlpha = life * 0.85;
+            ctx.strokeStyle = 'rgba(217,249,157,0.8)';
+            ctx.lineWidth = 0.8;
+            ctx.beginPath();
+            ctx.arc(bx, by, b.size, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+
+        // ---- 5. 飞溅毒液滴 ----
+        for (const d of this.droplets) {
+            ctx.globalAlpha = life * d.alpha;
+            ctx.fillStyle = d.bright ? '#bef264' : '#84cc16';
+            ctx.beginPath();
+            ctx.arc(this.x + d.x, this.y + d.y, d.size, 0, Math.PI * 2);
             ctx.fill();
         }
 

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -1866,9 +1866,17 @@ phase_gathering_getRandomPegType() {
                     // bypassShield=true 让毒素 DoT 不受护盾减伤
                     const r = e.takeDamage(dmg, null, true);
                     if (r && this.combat_recordDamage) this.combat_recordDamage(r.actualDamage, 'pyro', 'main');
-                    if (this.spawn_createFloatingText) this.spawn_createFloatingText(e.pos.x, e.pos.y - 30, `☠️${dmg}`, '#84cc16');
-                    if (this.spawn_createParticle) {
-                        for (let i = 0; i < 3; i++) this.spawn_createParticle(e.pos.x, e.pos.y, '#84cc16', 'mist');
+                    if (r && r.killed) {
+                        // [剧毒火焰死亡] 毒素 DoT 击杀：触发专属毒焰溶解死亡特效
+                        // （此前 DoT 击杀不经过击中-死亡路径，故无任何死亡表现）
+                        if (typeof this._triggerDeathFX === 'function') {
+                            this._triggerDeathFX(e, null, { cause: 'venom' });
+                        }
+                    } else {
+                        if (this.spawn_createFloatingText) this.spawn_createFloatingText(e.pos.x, e.pos.y - 30, `☠️${dmg}`, '#84cc16');
+                        if (this.spawn_createParticle) {
+                            for (let i = 0; i < 3; i++) this.spawn_createParticle(e.pos.x, e.pos.y, '#84cc16', 'mist');
+                        }
                     }
                 }
             }

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -503,6 +503,9 @@ export function deathExplosion_pixiSync(de, pixi) {
     gfx.clear();
     if (de.life <= 0) return;
 
+    // [剧毒火焰死亡] 毒焰溶解专属渲染
+    if (de.variant === 'venom') { deathExplosion_pixiSyncVenom(de, gfx); return; }
+
     const t = Math.min(1, de.timer / (1 / de.decay));
 
     // 1. Boss 膨胀阶段
@@ -594,6 +597,74 @@ export function deathExplosion_pixiSync(de, pixi) {
         const sAlpha = s.alpha * distRatio * Math.max(0, de.life);
         gfx.beginFill(pixiCssColor(s.color), Math.max(0, sAlpha));
         gfx.drawCircle(sx, sy, s.size);
+        gfx.endFill();
+    }
+}
+
+// [剧毒火焰死亡] PixiJS 渲染毒焰溶解死亡（gfx 为 ADD 混合）
+function deathExplosion_pixiSyncVenom(de, gfx) {
+    const life = Math.max(0, de.life);
+
+    // 1. 毒气云（多层叠加近似径向渐变）
+    if (de.gasRadius > 0) {
+        gfx.beginFill(0x84CC16, life * 0.16);
+        gfx.drawCircle(de.x, de.y, de.gasRadius);
+        gfx.endFill();
+        gfx.beginFill(0xBEF264, life * 0.18);
+        gfx.drawCircle(de.x, de.y, de.gasRadius * 0.6);
+        gfx.endFill();
+        gfx.beginFill(0xD9F99D, life * 0.22);
+        gfx.drawCircle(de.x, de.y, de.gasRadius * 0.3);
+        gfx.endFill();
+    }
+
+    // 2. 腐蚀核（柔和暗绿）
+    if (de.coreRadius > 0) {
+        gfx.beginFill(0x365314, life * 0.3);
+        gfx.drawCircle(de.x, de.y, de.coreRadius);
+        gfx.endFill();
+        gfx.beginFill(0x3F6212, life * 0.25);
+        gfx.drawCircle(de.x, de.y, de.coreRadius * 0.55);
+        gfx.endFill();
+    }
+
+    // 3. 上升的毒焰舌（二次贝塞尔曲线 + 外辉光）
+    for (const f of de.flames) {
+        const fa = life * f.life;
+        if (fa <= 0.03) continue;
+        const baseX = de.x + f.ox + Math.sin(f.phase) * f.sway * 0.4;
+        const baseY = de.y - f.rise;
+        const tipX = baseX + Math.sin(f.phase * 1.6) * f.sway;
+        const tipY = baseY - f.height;
+        const midX = (baseX + tipX) / 2 + Math.sin(f.phase * 1.2) * f.sway * 0.5;
+        const midY = (baseY + tipY) / 2;
+        const col = f.bright ? 0xD9F99D : 0x84CC16;
+        gfx.lineStyle(f.width * 2.2, 0x84CC16, fa * 0.3);
+        gfx.moveTo(baseX, baseY);
+        gfx.quadraticCurveTo(midX, midY, tipX, tipY);
+        gfx.lineStyle(f.width, col, fa * 0.85);
+        gfx.moveTo(baseX, baseY);
+        gfx.quadraticCurveTo(midX, midY, tipX, tipY);
+    }
+    gfx.lineStyle(0);
+
+    // 4. 酸液气泡
+    for (const b of de.bubbles) {
+        if (de.life < b.popAt) continue;
+        const bx = de.x + Math.cos(b.angle) * b.dist + Math.sin(b.wobble) * 2;
+        const by = de.y + Math.sin(b.angle) * b.dist - b.dist * 0.15;
+        gfx.beginFill(0xBEF264, life * 0.5);
+        gfx.drawCircle(bx, by, b.size);
+        gfx.endFill();
+        gfx.lineStyle(0.8, 0xD9F99D, life * 0.8);
+        gfx.drawCircle(bx, by, b.size);
+        gfx.lineStyle(0);
+    }
+
+    // 5. 飞溅毒液滴
+    for (const d of de.droplets) {
+        gfx.beginFill(d.bright ? 0xBEF264 : 0x84CC16, life * d.alpha);
+        gfx.drawCircle(de.x + d.x, de.y + d.y, d.size);
         gfx.endFill();
     }
 }


### PR DESCRIPTION
## 背景

敌人因**毒素 DoT（剧毒火焰 buff）**死亡时完全没有任何死亡表现。

根因：毒素 DoT 在回合结算 `phase_enemy_processTurn` 中直接 `takeDamage` 击杀敌人，**不经过击中-死亡路径**（`combat_system` 里调用 `_triggerDeathFX` 的那条线），因此既不触发分级死亡特效，也没有任何粒子/音效。

本次用新的渲染引擎（`DeathExplosion` / PixiJS）为这种死亡**专门设计**了毒焰溶解死亡特效。

## 改动

| 文件 | 说明 |
|---|---|
| `src/effects/particles.js` | `DeathExplosion` 新增 `'venom'` 变体：毒气云膨胀 + 上升毒焰舌（二次贝塞尔曲线）+ 酸液气泡漂移破裂 + 飞溅毒滴抛物线 + 暗绿腐蚀核溶解。按 `normal` / `elite` / `boss` 三档缩放。Canvas 与 PixiJS 双路径渲染。 |
| `src/render/pixi_effect_adapter.js` | `deathExplosion_pixiSync` 新增毒焰溶解的 PixiJS 渲染分支 `deathExplosion_pixiSyncVenom`。 |
| `src/combat_system.js` | `_triggerDeathFX(enemy, shotId, options)` 增加 `options.cause === 'venom'` 分发到新方法 `_triggerVenomDeathFX`：毒雾粒子 + 飞溅毒液 + 腐蚀冲击波 + 击杀震动 + 音效 + 浮动文字「☠️ 溶解!」，受 `deathExplosionLimit` 性能预算约束（Boss 不限）。 |
| `src/game_phase.js` | 毒素 DoT 结算检测 `r.killed`，击杀时触发 `_triggerDeathFX(e, null, { cause: 'venom' })`；非击杀仍保留原 tick 文本与粒子。 |
| `src/audio.js` | 新增 `venom_death` 音效（低频三角波咕噜下滑 + 高通白噪声腐蚀嘶嘶声）。 |

## 设计

- **主题色**：毒绿系（`#84cc16` / `#bef264` / `#d9f99d` / `#365314`），区别于冰冻碎裂（青蓝）、燃烧爆炸（橙红）、分级内爆（紫/灰）。
- **分级缩放**：粒子数、毒气云半径、震幅均按敌人等级递增。
- **性能**：复用现有 `deathExplosionLimit` 预算与 `low` 画质降级（关闭 shadowBlur）。

## 验证

- 5 个改动文件 `node --check` 全部通过。
- 毒焰几何推进数学独立验证无 NaN / 异常。
- `tests/validate_phase_contracts.mjs`：154/156（2 个失败为 launcher 炮管渲染，与本次改动无关，改前即存在）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2ykztSjAHyiGD1eiLreCE)_