### PR TITLE
fix(vfx): 穿透切割特效改为锥形刀痕

### DIFF
--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -408,7 +408,7 @@ class PierceCutEffect {
         this.age = 0;
         this.duration = this.quality === 'low' ? 14 : 18;
         this.active = true;
-        this.cutWidth = 5 + Math.random() * 2;
+        this.cutWidth = 4 + Math.random() * 1.5;
         this.edgeSeed = Math.random() * Math.PI * 2;
         const chipCount = this.quality === 'low' ? 3 : (this.quality === 'medium' ? 5 : 7);
         this.chips = Array.from({ length: chipCount }, (_, i) => ({
@@ -450,46 +450,44 @@ class PierceCutEffect {
         ctx.globalCompositeOperation = isLow ? 'source-over' : 'lighter';
         ctx.lineCap = 'round';
 
+        // 锥形切口：沿轴填充柳叶/纺锤形（两端尖、中段宽），呈现锐利刀痕而非均匀光带。
+        const fillSpindle = (maxHalfW, style, alpha, power, bias) => {
+            if (alpha <= 0 || maxHalfW <= 0) return;
+            const N = 18;
+            ctx.globalAlpha = alpha;
+            ctx.fillStyle = style;
+            ctx.beginPath();
+            for (let i = 0; i <= N; i++) { // 上缘 左→右
+                const u = -1 + 2 * i / N;
+                const lx = u * halfL;
+                const w = maxHalfW * Math.pow(Math.max(0, 1 - u * u), power);
+                if (i === 0) ctx.moveTo(lx, bias - w); else ctx.lineTo(lx, bias - w);
+            }
+            for (let i = N; i >= 0; i--) { // 下缘 右→左
+                const u = -1 + 2 * i / N;
+                const lx = u * halfL;
+                const w = maxHalfW * Math.pow(Math.max(0, 1 - u * u), power);
+                ctx.lineTo(lx, bias + w);
+            }
+            ctx.closePath();
+            ctx.fill();
+        };
+
+        const cw = this.cutWidth;
+        const slitAlpha = Math.min(1, this.life * 1.35);
+
         if (!isLow) {
-            ctx.globalAlpha = this.life * 0.42;
-            ctx.strokeStyle = withAlpha(this.color, 0.85);
-            ctx.lineWidth = this.cutWidth * (1.8 + 0.4 * this.life);
+            // 1. 外层热辉光（柔和锥形）
             ctx.shadowColor = this.color;
-            ctx.shadowBlur = _sb(14);
-            ctx.beginPath();
-            ctx.moveTo(-halfL - 6, -open * 0.35);
-            ctx.quadraticCurveTo(-halfL * 0.18, -open * 1.25, halfL + 6, -open * 0.5);
-            ctx.stroke();
-            ctx.beginPath();
-            ctx.moveTo(-halfL - 6, open * 0.35);
-            ctx.quadraticCurveTo(halfL * 0.18, open * 1.25, halfL + 6, open * 0.5);
-            ctx.stroke();
+            ctx.shadowBlur = _sb(12);
+            fillSpindle(cw * 1.25, this.color, this.life * 0.16, 0.5, 0);
             ctx.shadowBlur = 0;
         }
-
-        const slitAlpha = Math.min(1, this.life * 1.35);
-        const slit = ctx.createLinearGradient(-halfL, 0, halfL, 0);
-        slit.addColorStop(0, 'rgba(255,255,255,0)');
-        slit.addColorStop(0.22, withAlpha(this.color, 0.78 * slitAlpha));
-        slit.addColorStop(0.5, `rgba(255,255,255,${slitAlpha})`);
-        slit.addColorStop(0.78, withAlpha(this.color, 0.78 * slitAlpha));
-        slit.addColorStop(1, 'rgba(255,255,255,0)');
-        ctx.globalAlpha = 0.95;
-        ctx.strokeStyle = slit;
-        ctx.lineWidth = Math.max(1.2, this.cutWidth * this.life);
-        ctx.beginPath();
-        ctx.moveTo(-halfL, 0);
-        ctx.lineTo(halfL, 0);
-        ctx.stroke();
-
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.globalAlpha = this.life * 0.78;
-        ctx.strokeStyle = withAlpha('#1f0f16', isLow ? 0.46 : 0.62);
-        ctx.lineWidth = Math.max(1, this.cutWidth * 0.42);
-        ctx.beginPath();
-        ctx.moveTo(-halfL * 0.72, 0);
-        ctx.lineTo(halfL * 0.72, 0);
-        ctx.stroke();
+        // 2. 上下两唇：沿轴张开，营造「被劈开」的张口
+        fillSpindle(cw * 0.5, this.color, this.life * 0.5, 0.7, -open * 0.5);
+        fillSpindle(cw * 0.5, this.color, this.life * 0.5, 0.7, open * 0.5);
+        // 3. 核心白热切口：极细、两端尖锐
+        fillSpindle(Math.max(0.6, cw * 0.3 * (0.55 + 0.45 * this.life)), '#ffffff', slitAlpha, 1.0, 0);
 
         ctx.globalCompositeOperation = isLow ? 'source-over' : 'lighter';
         const tickCount = isLow ? 2 : 4;

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -692,24 +692,42 @@ export function pierceCutEffect_pixiSync(pce, pixi) {
     const rx = (lx, ly) => pce.x + lx * cos - ly * sin;
     const ry = (lx, ly) => pce.y + lx * sin + ly * cos;
 
-    // 辉光边缘（双层替代 shadowBlur）
-    gfx.lineStyle(pce.cutWidth * 3.6, color, pce.life * 0.18);
-    gfx.moveTo(rx(-halfL - 6, -open * 0.35), ry(-halfL - 6, -open * 0.35));
-    gfx.lineTo(rx(halfL + 6, -open * 0.5), ry(halfL + 6, -open * 0.5));
-    gfx.moveTo(rx(-halfL - 6, open * 0.35), ry(-halfL - 6, open * 0.35));
-    gfx.lineTo(rx(halfL + 6, open * 0.5), ry(halfL + 6, open * 0.5));
+    // 锥形切口：沿切割轴采样填充一个柳叶/纺锤形——两端收成尖、中段最宽。
+    // 这样切口才有「锐利的刀痕」感，而不是均匀粗细的光带。
+    // power 越大尖端越锐利；bias 让切口整体偏离轴线（用于上下两唇张开）。
+    const fillSpindle = (maxHalfW, colorHex, alpha, power, bias) => {
+        if (alpha <= 0 || maxHalfW <= 0) return;
+        const N = 18;
+        gfx.beginFill(colorHex, alpha);
+        let started = false;
+        for (let i = 0; i <= N; i++) { // 上缘 左→右
+            const u = -1 + 2 * i / N;
+            const lx = u * halfL;
+            const w = maxHalfW * Math.pow(Math.max(0, 1 - u * u), power);
+            const px = rx(lx, bias - w), py = ry(lx, bias - w);
+            if (!started) { gfx.moveTo(px, py); started = true; }
+            else gfx.lineTo(px, py);
+        }
+        for (let i = N; i >= 0; i--) { // 下缘 右→左
+            const u = -1 + 2 * i / N;
+            const lx = u * halfL;
+            const w = maxHalfW * Math.pow(Math.max(0, 1 - u * u), power);
+            gfx.lineTo(rx(lx, bias + w), ry(lx, bias + w));
+        }
+        gfx.closePath();
+        gfx.endFill();
+    };
 
-    gfx.lineStyle(pce.cutWidth * 1.8, color, pce.life * 0.42);
-    gfx.moveTo(rx(-halfL - 6, -open * 0.35), ry(-halfL - 6, -open * 0.35));
-    gfx.lineTo(rx(halfL + 6, -open * 0.5), ry(halfL + 6, -open * 0.5));
-    gfx.moveTo(rx(-halfL - 6, open * 0.35), ry(-halfL - 6, open * 0.35));
-    gfx.lineTo(rx(halfL + 6, open * 0.5), ry(halfL + 6, open * 0.5));
-
-    // 核心裂缝线
+    const cw = pce.cutWidth;
     const slitAlpha = Math.min(1, pce.life * 1.35);
-    gfx.lineStyle(Math.max(1.2, pce.cutWidth * pce.life), 0xFFFFFF, slitAlpha);
-    gfx.moveTo(rx(-halfL, 0), ry(-halfL, 0));
-    gfx.lineTo(rx(halfL, 0), ry(halfL, 0));
+
+    // 1. 外层热辉光（柔和锥形，替代 shadowBlur）
+    fillSpindle(cw * 1.25, color, pce.life * 0.16, 0.5, 0);
+    // 2. 上下两唇：沿轴张开，营造「被劈开」的张口
+    fillSpindle(cw * 0.5, color, pce.life * 0.5, 0.7, -open * 0.5);
+    fillSpindle(cw * 0.5, color, pce.life * 0.5, 0.7, open * 0.5);
+    // 3. 核心白热切口：极细、两端尖锐
+    fillSpindle(Math.max(0.6, cw * 0.3 * (0.55 + 0.45 * pce.life)), 0xFFFFFF, slitAlpha, 1.0, 0);
 
     // 碎片三角形
     for (const chip of pce.chips) {


### PR DESCRIPTION
## 问题
穿透伤害的「热切」特效太粗，且**粗细均匀**——核心切口和辉光都是等宽的直线描边，看起来像一根粗光带，完全没有「切割 / 刀痕」的感觉。

## 根因
`PierceCutEffect` 的两条渲染路径都用 `lineStyle` / `ctx.stroke` 画**等宽**直线：
- Pixi（实际渲染）：辉光描边宽 `cutWidth * 3.6`（≈18~25px），核心切口 `cutWidth * life` 均匀粗细。
- Canvas（回退）：同理用 quadraticCurve + 渐变直线描边。

等宽圆头描边天然就是「光带」造型，无法呈现刀痕两端收尖的锐利感。

## 改动
把切口改为沿切割轴**填充柳叶 / 纺锤形多边形**（两端收成尖、中段最宽），分三层叠加：
1. 外层热辉光（柔和锥形，替代 shadowBlur）
2. 上下两唇——沿轴张开，营造「被劈开」的张口
3. 极细白热核心切口（两端尖锐）

同时把基础 `cutWidth` 从 `5~7` 收窄到 `4~5.5`。Pixi 实际渲染与 Canvas 回退路径**同步**修改，行为一致。

## 验证
- `node --check` 两个文件均通过。
- 仅改特效几何造型，未触碰伤害 / 触发逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjPibrvDFsytVd5TneyK1t)_