### PR TITLE
feat(launcher): 装填上膛动画 + 敌人回合发射器常驻充能

### DIFF
--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -3413,6 +3413,10 @@ phase_gathering_getRandomPegType() {
         const playerTurnFinished = _roundAmmoClear && !this.isVisualEffectActive;
 
         if (playerTurnFinished && !this.gameOver) {
+            // [enemy-turn-launcher] 玩家本回合弹药已打完 / 敌人行动期间：发射器不再直接消失，
+            // 而是留在原位，循环播放“充能装填下一轮弹药”的动画。必须在所有 return 之前绘制，
+            // 才能覆盖敌人扫描波 / 移动 / 结算等所有提前返回的分支。
+            this.render_combat_launcher(timeScale, entityShiftX, entityShiftY, true);
             // [in-wall-clear-lottery] 抽奖暂停期间禁止启动敌人回合，等待玩家关闭老虎机覆盖层
             if (this._inWallClearLotteryActive) return;
             // [回合开始横幅保护] 横幅期间不触发敌人行动，避免与上一回合结束时的敌人行动重复
@@ -3485,18 +3489,40 @@ phase_gathering_getRandomPegType() {
             return;
         }
 
-        // --- 修改开始：调整层级，先画轨道，再画炮台 ---
+        // [launcher-render] 正常玩家回合：在帧末绘制发射器（含瞄准 / 蓄力 / 装填动画）。
+        this.render_combat_launcher(timeScale, entityShiftX, entityShiftY, false);
+
+        // --- [新增] 手机偏移提示强化：绘制边缘泛光 ---
+        this.drawTiltVignette(this.ctx, this.boardTilt.current);
+        // [移除] 删除底部倾斜指示条调用，设计上不够简洁且在战斗阶段会被结算 UI 遮挡
+        // this.drawTiltIndicator(this.ctx, this.boardTilt.current);
+
+    },
+
+    /**
+     * @method render_combat_launcher
+     * @description 绘制战斗发射器（底座 + 炮管 + 下一发信号）。从 phase_combat_update 抽出，
+     *   以便在「玩家正常回合」与「敌人行动回合」两种情形下复用同一套绘制逻辑。
+     * @param {number} timeScale 当前帧时间缩放
+     * @param {number} entityShiftX 实体层视差偏移 X
+     * @param {number} entityShiftY 实体层视差偏移 Y
+     * @param {boolean} idle  true=敌人行动/弹药打完的待机态：炮口回正，循环播放充能装填动画，
+     *                        不渲染可交互的下一发信号；false=玩家可操作的正常态。
+     */
+    render_combat_launcher(timeScale, entityShiftX, entityShiftY, idle = false) {
+        // --- 调整层级，先画轨道，再画炮台 ---
         this.ctx.save();
         // 应用与实体层相同的视差偏移
         this.ctx.translate(entityShiftX, entityShiftY);
 
         // [emitter-anchor] startPos/portPos 均为炮台旋转圆心；muzzle 仅供美术炮管效果使用。
-        let launcherGeometry = this.pendingFireVelocity
+        let launcherGeometry = (this.pendingFireVelocity && !idle)
             ? calcCombatLauncherGeometry(this.width, this.height, this.pendingFireVelocity)
             : calcCombatLauncherGeometry(this.width, this.height);
         const startPos = launcherGeometry.base;
         let portPos = launcherGeometry.port;
-        let nextAmmo = this.ammoQueue.length > 0 ? this.ammoQueue[0] : null;
+        // 待机态强制炮口回正、不读取队列里的下一发（敌人回合不展示可交互信息）。
+        let nextAmmo = (!idle && this.ammoQueue.length > 0) ? this.ammoQueue[0] : null;
         let previewRotation = launcherGeometry.aimRotation;
         let deformation = {x: 1, y: 1};
         if (nextAmmo && this.isDragging) {
@@ -3508,7 +3534,7 @@ phase_gathering_getRandomPegType() {
                 deformation = {x: 1.15, y: 0.85};
             }
         }
-        const returningAfterShot = !this.isDragging && !this.pendingFireVelocity && !this.isChargingShot
+        const returningAfterShot = !idle && !this.isDragging && !this.pendingFireVelocity && !this.isChargingShot
             && (this._launcherReturnDelay || 0) > 0
             && Number.isFinite(this._launcherShotAimRotation);
         if (returningAfterShot) {
@@ -3518,14 +3544,50 @@ phase_gathering_getRandomPegType() {
         if (!Number.isFinite(this._launcherAimRotation)) {
             this._launcherAimRotation = previewRotation;
         }
-        const rotationStep = (this.isDragging || this.pendingFireVelocity || this.isChargingShot)
+        const rotationStep = (!idle && (this.isDragging || this.pendingFireVelocity || this.isChargingShot))
             ? 0.34 * Math.max(0.25, timeScale || 1)
             : 0.055 * Math.max(0.25, timeScale || 1);
         this._launcherAimRotation = rotateTowards(this._launcherAimRotation, previewRotation, rotationStep);
         previewRotation = this._launcherAimRotation;
+
+        // [enemy-turn idle] 敌人行动回合：用时间驱动的循环充能脉冲，
+        // 复用炮管蓄力发光层，表现为发射器持续“吸能 / 充能装填下一轮弹药”。
+        let baseIsCharging = this.isChargingShot;
+        let baseChargeProgress = this.chargeProgress;
+        if (idle) {
+            const tt = Date.now() / 1000;
+            const loopPulse = (Math.sin(tt * 2.2) + 1) / 2; // 0~1 平滑循环
+            baseIsCharging = true;
+            baseChargeProgress = 0.2 + loopPulse * 0.7;      // 0.2~0.9 之间呼吸式蓄能
+        }
+
         // [bitmap-emitter] 优先使用 emitter_base.png + emitter_charging_*.png 渲染发射器底座；
         // 位图未加载时 fallback 到原始 arc 椭圆。
-        this.render_combat_launcherEmitterBase(this.ctx, startPos.x, startPos.y, this.isChargingShot, this.chargeProgress, this.isReloading ? this.reloadProgress : 0, previewRotation);
+        this.render_combat_launcherEmitterBase(this.ctx, startPos.x, startPos.y, baseIsCharging, baseChargeProgress, this.isReloading ? this.reloadProgress : 0, previewRotation);
+
+        if (idle) {
+            // 弹膛处搏动的能量核心：预示下一轮弹药正在装填成形。
+            const tt = Date.now() / 1000;
+            const corePulse = 0.4 + 0.6 * ((Math.sin(tt * 3.2) + 1) / 2);
+            const coreR = 22 + corePulse * 8;
+            const quality = this.perfQualityLevel || 'high';
+            this.ctx.save();
+            this.ctx.globalCompositeOperation = 'screen';
+            if (quality !== 'low') {
+                const grad = this.ctx.createRadialGradient(portPos.x, portPos.y, 0, portPos.x, portPos.y, coreR);
+                grad.addColorStop(0, `rgba(186, 245, 255, ${0.6 * corePulse})`);
+                grad.addColorStop(0.45, `rgba(56, 189, 248, ${0.3 * corePulse})`);
+                grad.addColorStop(1, 'rgba(56, 189, 248, 0)');
+                this.ctx.fillStyle = grad;
+            } else {
+                this.ctx.globalAlpha = 0.32 * corePulse;
+                this.ctx.fillStyle = '#38bdf8';
+            }
+            this.ctx.beginPath();
+            this.ctx.arc(portPos.x, portPos.y, coreR, 0, Math.PI * 2);
+            this.ctx.fill();
+            this.ctx.restore();
+        }
 
         if (nextAmmo) {
             const params = Projectile.calculateVisualParams(nextAmmo, false);
@@ -3551,12 +3613,6 @@ phase_gathering_getRandomPegType() {
 
         }
         this.ctx.restore();
-
-        // --- [新增] 手机偏移提示强化：绘制边缘泛光 ---
-        this.drawTiltVignette(this.ctx, this.boardTilt.current);
-        // [移除] 删除底部倾斜指示条调用，设计上不够简洁且在战斗阶段会被结算 UI 遮挡
-        // this.drawTiltIndicator(this.ctx, this.boardTilt.current);
-        
     },
 
 /**

--- a/src/render_system.js
+++ b/src/render_system.js
@@ -569,6 +569,11 @@ export const render_system = {
         const chargeProgress = Math.max(0, Math.min(1, visual.chargeProgress || 0));
         const reloadProgress = Math.max(0, Math.min(1, visual.reloadProgress || 0));
         const recoilY = visual.isReloading ? Math.sin(reloadProgress * Math.PI) * 4 * bodyScale : 0;
+        // [reload-reveal] 发射后下一发弹药信息的“装填成形”进度：reloadProgress 0→1 期间
+        // 整组信号（读数 / 弹仓 / 弹药本体）随之淡入，而不是瞬间出现。easeOutCubic 让收尾更顺。
+        const revealT = visual.isReloading
+            ? (1 - Math.pow(1 - reloadProgress, 3))
+            : 1;
         const chamberX = 0;
         const chamberY = 7 * bodyScale + recoilY;
         const magazine = {
@@ -586,6 +591,7 @@ export const render_system = {
 
         const drawDamageReadout = () => {
             ctx.save();
+            ctx.globalAlpha *= revealT;
             const value = String(profile.damage);
             const maxValueWidth = 23 * bodyScale;
             let valueSize = 10 * bodyScale;
@@ -612,7 +618,7 @@ export const render_system = {
 
         const drawBurstReadout = () => {
             ctx.save();
-            ctx.globalAlpha = 0.96;
+            ctx.globalAlpha = 0.96 * revealT;
             ctx.fillStyle = '#fef3c7';
             ctx.font = `bold ${8 * bodyScale}px Cinzel`;
             ctx.textAlign = 'center';
@@ -647,17 +653,17 @@ export const render_system = {
                 }
                 if (smallIcon) {
                     const iconSize = 9.8 * bodyScale;
-                    ctx.globalAlpha = 0.96;
+                    ctx.globalAlpha = 0.96 * revealT;
                     ctx.drawImage(smallIcon, x - iconSize / 2, magazine.y - iconSize / 2, iconSize, iconSize);
                 } else {
                     ctx.fillStyle = color;
-                    ctx.globalAlpha = 0.92;
+                    ctx.globalAlpha = 0.92 * revealT;
                     ctx.beginPath();
                     ctx.arc(x, magazine.y, 4.2 * bodyScale, 0, Math.PI * 2);
                     ctx.fill();
                 }
                 ctx.shadowBlur = 0;
-                ctx.globalAlpha = 1;
+                ctx.globalAlpha = revealT;
                 ctx.font = `bold ${5.3 * bodyScale}px Cinzel`;
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'middle';
@@ -677,18 +683,35 @@ export const render_system = {
             const params = visual.params || Projectile.calculateVisualParams(recipe, false);
             const deformation = visual.deformation || { x: 1, y: 1 };
             const rotation = Number.isFinite(visual.previewRotation) ? visual.previewRotation : -Math.PI / 2;
-            const projectileRadius = Math.max(7, Math.min(12 * bodyScale, params.radius * 0.82 * (1 + chargeProgress * 0.16)));
+            let projectileRadius = Math.max(7, Math.min(12 * bodyScale, params.radius * 0.82 * (1 + chargeProgress * 0.16)));
+
+            // [reload-load-in] 装填阶段：弹药从弹仓方向带轻微过冲地“弹入”弹膛并放大成形，
+            // 而不是发射后瞬间满尺寸出现。
+            let loadRiseY = 0;
+            if (visual.isReloading) {
+                const t = reloadProgress;
+                // easeOutBack：带一点回弹过冲，强化“咔哒装填到位”的手感
+                const c1 = 1.70158;
+                const c3 = c1 + 1;
+                const back = 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+                projectileRadius *= Math.max(0.05, back);
+                // 前 80% 内从下方（弹仓）升入弹膛
+                loadRiseY = (1 - Math.min(1, t / 0.8)) * 18 * bodyScale;
+            }
+
+            ctx.save();
+            ctx.globalAlpha *= revealT;
             Projectile.drawVisuals(
                 ctx,
                 chamberX,
-                chamberY,
+                chamberY + loadRiseY,
                 projectileRadius,
                 recipe,
                 rotation,
                 params.intensity,
                 deformation
             );
-
+            ctx.restore();
         };
 
         drawLoadedProjectile();


### PR DESCRIPTION
## 背景

两个发射器表现问题：

1. **子弹发射后，下一发子弹的信息立刻“弹出”显示在发射器上**，缺少装填上膛的过程感。
2. **敌人行动回合发射器直接消失**，希望它依旧在场并播放“充能装填下一轮弹药”的动画。

## 改动

### 1. 装填上膛动画（发射后下一发）
`render_combat_launcherSignal`（`src/render_system.js`）：
- 弹药本体在 `reloadProgress` 0→1 期间用 **easeOutBack** 从弹仓方向升入弹膛并放大成形（带轻微回弹过冲，强化“咔哒到位”手感），不再瞬间满尺寸出现。
- 伤害读数 / 连射读数 / 属性弹仓随 **easeOutCubic** 的 `revealT` 一并淡入，整组“下一发信息”随装填进度成形。
- 复用既有的 `isReloading` / `reloadProgress` 状态机（发射后已置位），未引入新状态。

### 2. 敌人回合发射器常驻 + 充能动画
`src/game_phase.js`：
- 将原先内联在 `phase_combat_update` 帧末的发射器绘制逻辑抽出为可复用方法 **`render_combat_launcher(timeScale, shiftX, shiftY, idle)`**。
- 在 `playerTurnFinished && !gameOver` 分支的**所有提前 `return` 之前**，以 `idle=true` 调用一次 —— 覆盖敌人扫描波 / 移动 / 结算等全部返回分支，保证敌人回合每帧都绘制发射器。
- `idle` 待机态表现：炮口回正、复用炮管蓄力发光层做**呼吸式循环充能**，并在弹膛处叠加**搏动能量核心**（低画质降级为单色 arc），表现为“持续充能装填下一轮弹药”。
- 正常玩家回合仍在帧末以 `idle=false` 绘制；因 `playerTurnFinished` 分支必定 `return`，两条路径互斥，无重复绘制。

## 测试
- `node --check` 两个改动文件均通过。
- `node tests/validate_phase_contracts.mjs`：**154/156**，与改动前 clean tree 完全一致（2 个失败为既有用例，与本次改动无关）。

> 注：受沙箱挂载层影响，未能在本环境实机渲染验证视觉效果，建议本地 `npm start` 跑一局确认动画手感。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HpgMby3bnKJthqrq7bupv

---
_Generated by [Claude Code](https://claude.ai/code/session_019HpgMby3bnKJthqrq7bupv)_