### PR TITLE
feat(skills): 技能来源扩展（基础/词条/遗物/商店，6→19）+ 技能装配编辑器

### DIFF
--- a/.cursor/rules/runeword_index.md
+++ b/.cursor/rules/runeword_index.md
@@ -11,11 +11,11 @@
 |---|---|---|---|---|
 | `runeword_meltdown` | 熔毁 | `rune_pyro_1` × 2 + `rune_pyro_2` | 火焰燃烧伤害与过热爆炸最终伤害提升 | 熔毁新星 |
 | `runeword_absolute_zero` | 绝对零度 | `rune_cryo_1` × 2 + `rune_cryo_2` | 冰冻状态下每次物理伤害令该敌人本回合受到的所有伤害加深 | 冰牢封印 |
-| `runeword_frost_nova` | 冰霜新星 | `rune_cryo_1` × 1 + `rune_bounce_1` × 1 + `rune_cryo_2` × 1 | 弹珠每弹跳数次释放冰霜新星，造成冰属性伤害并降温 | — |
+| `runeword_frost_nova` | 冰霜新星 | `rune_cryo_1` × 1 + `rune_bounce_1` × 1 + `rune_cryo_2` × 1 | 弹珠每弹跳数次释放冰霜新星，造成冰属性伤害并降温 | 冰霜新星 |
 | `runeword_thunderstorm` | 雷暴之语 | `rune_lightning_1` × 2 + `rune_lightning_2` | 闪电链的伤害衰减系数提升 | 雷神降临 |
 | `runeword_thunder_scatter` | 雷霆散射 | `rune_lightning_1` × 1 + `rune_scatter_1` × 1 + `rune_lightning_2` × 1 | 每次成功触发闪电链时，有概率额外释放一条同属性闪电链 | — |
 | `runeword_kinetic_surge` | 动能激增 | `rune_bounce_1` × 2 + `rune_bounce_2` | 本次发射的弹珠，后续每次弹射伤害固定增加 | 动能爆发 |
-| `runeword_irradiation` | 照射 | `rune_laser_1` × 2 + `rune_laser_2` | 激光变为持续照射，累积照射同一敌人伤害加深 | — |
+| `runeword_irradiation` | 照射 | `rune_laser_1` × 2 + `rune_laser_2` | 激光变为持续照射，累积照射同一敌人伤害加深 | 辐照领域 |
 
 ### 1.2 复合机制词条（6 个）
 
@@ -52,6 +52,26 @@
 | `runeword_mass_collapse` | 质量坍缩 | `rune_bounce_1` × 2 + `rune_pyro_1` × 1 | 强制获得爆炸属性（范围减半）；只清空所有散射层数（连射保留），每清空 1 层散射爆炸范围 +10% |
 | `runeword_kinetic_decay` | 动能衰变 | `rune_bounce_1` × 2 + `rune_pierce_1` × 1 | 子弹初始获得 25% 伤害加成；每次命中后加成乘以 (1 - 7%) 衰减（最低衰减至 0%） |
 | `runeword_echo_shot` | 回响射击 | `rune_scatter_1` × 2 + `rune_bounce_1` × 1 | 子弹首次击中敌人时，有 25% 概率按原角度额外发射一颗单发子弹 |
+
+## 1.6 技能系统总览（技能来源扩展）
+
+> **数据来源**：`src/config.js` → `SKILL_DB`（共 19 个技能）。
+> **核心入口**：`combat_recomputeActiveSkills()`（`src/combat_system.js`）—— 统一把四类来源
+> 求并集写入 `this.activeSkills`，并维护 `skill_point` 槽与技能栏/SP 面板显隐。
+> 任意来源变化（放符文 / 拾遗物 / 商店买 / 局开始）都应调用它。
+
+技能效果分发：原 6 个走 `combat_activateSkill` 的 if/else 链；新增 13 个集中在
+`combat_activateSkillExtended(skill, p, method)`（同文件），由前者末尾兜底调用。
+
+| 来源 (`source`) | 解锁条件 | 数量 | 技能 |
+|---|---|---|---|
+| `base` | 每局常驻（保证 SP 永远有去处） | 2 | 奥术飞弹、蓄能填装 |
+| `runeword` | 对应 `unlockRuneword` 词条激活 | 11 | 冰牢封印/雷神降临/动能爆发/熔毁新星/剑刃雨/棱光炮（原）+ 冰霜新星/辐照领域/炎光剑舞/静电力场/精准齐射（新） |
+| `relic` | 拥有 `unlockRelic` 遗物（`effect:'unlock_skill'`） | 3 | 引力坍缩(`relic_gravity_core`)、时滞冻结(`relic_chrono_shard`)、不死鸟祝福(`relic_phoenix_feather`) |
+| `shop` | 局内商店购买（写入 `purchasedSkillIds`，`shopPrice` 定价） | 3 | 陨石轰击、棱镜超载、财富打击 |
+
+状态字段：`activeSkills`（运行时并集，不持久化）、`purchasedSkillIds`（持久化于局存档）、
+`_activeRunewordIds`（由 `ui_updateRuneGrid` 写入的当前激活词条集合）。
 
 ## 2. 词条 effectId 与实现位置速查
 

--- a/.cursor/rules/runeword_index.md
+++ b/.cursor/rules/runeword_index.md
@@ -56,12 +56,14 @@
 ## 1.6 技能系统总览（技能来源扩展）
 
 > **数据来源**：`src/config.js` → `SKILL_DB`（共 19 个技能）。
-> **核心入口**：`combat_recomputeActiveSkills()`（`src/combat_system.js`）—— 统一把四类来源
-> 求并集写入 `this.activeSkills`，并维护 `skill_point` 槽与技能栏/SP 面板显隐。
-> 任意来源变化（放符文 / 拾遗物 / 商店买 / 局开始）都应调用它。
+> **核心入口**：`combat_recomputeActiveSkills(opts)`（`src/combat_system.js`）—— 计算四类来源
+> 并集（技能池 `unlockedSkills`）→ 维护装配（`equippedSkillIds`，≤4）→ 推导 `activeSkills`（技能栏内容）
+> → 维护 `skill_point` 槽与技能栏/SP/编辑器入口显隐。任意来源变化（放符文/拾遗物/商店买/局开始）都应调用它。
 
 技能效果分发：原 6 个走 `combat_activateSkill` 的 if/else 链；新增 13 个集中在
 `combat_activateSkillExtended(skill, p, method)`（同文件），由前者末尾兜底调用。
+
+### 技能来源（4 类，共 19 个）
 
 | 来源 (`source`) | 解锁条件 | 数量 | 技能 |
 |---|---|---|---|
@@ -70,8 +72,14 @@
 | `relic` | 拥有 `unlockRelic` 遗物（`effect:'unlock_skill'`） | 3 | 引力坍缩(`relic_gravity_core`)、时滞冻结(`relic_chrono_shard`)、不死鸟祝福(`relic_phoenix_feather`) |
 | `shop` | 局内商店购买（写入 `purchasedSkillIds`，`shopPrice` 定价） | 3 | 陨石轰击、棱镜超载、财富打击 |
 
-状态字段：`activeSkills`（运行时并集，不持久化）、`purchasedSkillIds`（持久化于局存档）、
-`_activeRunewordIds`（由 `ui_updateRuneGrid` 写入的当前激活词条集合）。
+### 技能装配（loadout）
+
+- **技能池 `unlockedSkills`**：四类来源并集，可超过 4 个。**装备 `equippedSkillIds`**：玩家选择进入战斗技能栏的子集（≤ `CONFIG.gameplay.maxEquippedSkills`，默认 4，受锁定的 2×2 布局约束）。`activeSkills` = 池中已装备项（按装备顺序），即技能栏渲染/可释放的内容。
+- **自动装备**：新解锁技能若有空位则自动装备；满 4 个时进池不装备，并**强制弹出技能编辑器**（`ui_openSkillEditor({forced:true})`）让玩家取舍。
+- **卸下可重装**：编辑器里「卸下」的技能仍留在池中，可随时重装；用 `_seenSkillIds`（上次池快照）避免把手动卸下的技能反复自动装回。词条技能随符文重排动态增减，离开池时自动从装备中剔除。
+- **编辑器 UI**：`src/ui/rune_launcher.js` 的 `ui_openSkillEditor / ui_closeSkillEditor / ui_renderSkillEditor / ui_toggleEquipSkill`；DOM 为 `index.html#skill-editor-overlay` + 顶栏入口 `#skill-editor-open-btn`；样式在 `src/styles/bitmap_ui.css`。入口按钮随时可开。
+
+状态字段（均持久化于局存档）：`equippedSkillIds`、`purchasedSkillIds`、`_seenSkillIds`、`_activeRunewordIds`；`unlockedSkills`/`activeSkills` 为运行时派生不持久化。
 
 ## 2. 词条 effectId 与实现位置速查
 

--- a/.cursor/rules/runeword_index.md
+++ b/.cursor/rules/runeword_index.md
@@ -81,6 +81,11 @@
 
 状态字段（均持久化于局存档）：`equippedSkillIds`、`purchasedSkillIds`、`_seenSkillIds`、`_activeRunewordIds`；`unlockedSkills`/`activeSkills` 为运行时派生不持久化。
 
+### 技能图鉴（真理之书内）
+
+- 真理之书（`TruthBook`）新增「主动技能」分类（`TRUTH_BOOK_CATEGORIES` 的 `skill`）。
+- 条目由 `buildSkillCodexEntries()`（`src/systems.js`）从 `SKILL_DB` 动态生成，与 `core` 条目同构（纯说明 + 日志循环演示，无敌人 setup）。每条展示：图标、名称、SP 消耗、来源/解锁条件标签、效果描述。新增/修改技能会自动出现在图鉴，无需手动维护。
+
 ## 2. 词条 effectId 与实现位置速查
 
 | effectId | 词条名称 | 主要实现位置 | 关键状态字段 |

--- a/index.html
+++ b/index.html
@@ -4864,6 +4864,7 @@
                 <div id="combat-status-note" class="combat-status-note">等待战斗开始</div>
             </div>
             <div id="sp-panel" class="flex flex-wrap gap-2 pointer-events-none transition-opacity duration-300"></div>
+            <button id="skill-editor-open-btn" type="button" class="skill-editor-open-btn pointer-events-auto" style="display:none;">✎ 技能</button>
         </div>
 
         <!-- 中间：战斗阶段保持空场，技能充能已下沉到底部技能舱 -->
@@ -5355,6 +5356,21 @@
 
 
 
+    </div>
+
+    <!-- [技能装配系统] 技能编辑器 overlay -->
+    <div id="skill-editor-overlay" class="skill-editor-overlay" style="display:none;">
+        <div class="skill-editor-modal">
+            <div class="skill-editor-header">
+                <div class="skill-editor-titles">
+                    <h3 class="skill-editor-title">技能装配</h3>
+                    <span id="skill-editor-count" class="skill-editor-count">已装备 0/4</span>
+                </div>
+                <button id="skill-editor-close-btn" type="button" class="skill-editor-close-btn" aria-label="关闭">✕</button>
+            </div>
+            <div id="skill-editor-hint" class="skill-editor-hint" style="display:none;"></div>
+            <div id="skill-editor-body" class="skill-editor-body"></div>
+        </div>
     </div>
 
     <!-- Phase: Truth Book (Encyclopedia) -->

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -336,71 +336,102 @@ export const combat_system = {
     },
 
     /**
-     * combat_recomputeActiveSkills - 统一重算「当前局内已解锁技能列表」
+     * combat_recomputeActiveSkills - 重算技能池并维护装配（loadout）
      *
-     * [技能来源扩展] activeSkills 现在是四类来源的并集：
-     *   1. 基础技能 (source:'base')              —— 每局常驻，保证 SP 永远有去处
-     *   2. 词条解锁 (unlockRuneword 命中激活词条)  —— 由 ui_updateRuneGrid 写入 this._activeRunewordIds
-     *   3. 遗物解锁 (unlockRelic 命中 ownedRelics)
-     *   4. 商店购买 (技能 id 命中 purchasedSkillIds)
+     * [技能装配系统] 区分两层：
+     *   - this.unlockedSkills：四类来源（基础/词条/遗物/商店）的并集 = 玩家已解锁的「技能池」，可超过 4 个。
+     *   - this.equippedSkillIds：玩家选择装备到战斗技能栏的子集（≤ maxEquippedSkills，默认 4）。
+     *   - this.activeSkills：池中 id ∈ equippedSkillIds 的技能（按装备顺序），即技能栏实际渲染/可释放的列表。
      *
-     * 任何来源发生变化（放置符文 / 拾取遗物 / 商店购买 / 局开始）都应调用本方法。
-     * 同时负责维护 skill_point 槽的增删与技能栏 / SP 面板的显隐刷新。
+     * 装配规则：
+     *   - 新解锁的技能若有空位 → 自动装备；若已满 4 个 → 进入池但不装备，并触发技能编辑器强制弹出。
+     *   - 玩家在编辑器里「卸下」的技能仍留在池中（不丢失），可随时重新装备。
+     *   - 词条技能随符文重排动态增减；离开池的技能会自动从装配中剔除。
+     *   - 通过 this._seenSkillIds 记录上次池快照，避免把玩家手动卸下的技能反复自动装回。
      *
-     * @returns {boolean} activeSkills 是否发生了变化
+     * 任何来源变化（放符文 / 拾遗物 / 商店购买 / 局开始）都应调用本方法。
+     *
+     * @param {object} [opts]
+     * @param {boolean} [opts.allowEditorPopup=true] 是否允许在装备已满又有新解锁时自动弹出编辑器
+     * @returns {boolean} 装配后的 activeSkills 是否发生变化
      */
-    combat_recomputeActiveSkills() {
+    combat_recomputeActiveSkills(opts = {}) {
+        const allowEditorPopup = opts.allowEditorPopup !== false;
         const rwIds = this._activeRunewordIds instanceof Set ? this._activeRunewordIds : new Set();
         const owned = Array.isArray(this.ownedRelics) ? this.ownedRelics : [];
         const purchased = Array.isArray(this.purchasedSkillIds) ? this.purchasedSkillIds : [];
 
-        const result = [];
+        // —— 1. 计算技能池（四类来源并集） ——
+        const pool = [];
         for (const sk of SKILL_DB) {
             if (!sk || !sk.id) continue;
             let unlocked = false;
             if (sk.source === 'base') unlocked = true;
             else if (sk.unlockRuneword && rwIds.has(sk.unlockRuneword)) unlocked = true;
             else if (sk.unlockRelic && owned.includes(sk.unlockRelic)) unlocked = true;
-            // 商店购买可解锁任意被标记为 shop 的技能（也允许作为兜底解锁路径）
+            // 商店购买可解锁任意被标记的技能（也作为兜底解锁路径）
             if (!unlocked && purchased.includes(sk.id)) unlocked = true;
-            if (unlocked) result.push(sk);
+            if (unlocked) pool.push(sk);
         }
-
-        // [技能来源扩展] 显示优先级：战斗技能栏受锁定的 2×2（4 格）布局限制，
-        // 让玩家「主动投入」获得的技能（商店/遗物/词条）优先占据有限的可见槽，
-        // 常驻的基础技能作为兜底排在最后（数量超 4 时才会被挤出可见区）。
+        // 自动装备时的优先级：商店 > 遗物 > 词条 > 基础（让主动投入的技能优先占位）
         const sourceRank = { shop: 0, relic: 1, runeword: 2, base: 3 };
-        result.sort((a, b) => (sourceRank[a.source] ?? 2) - (sourceRank[b.source] ?? 2));
+        pool.sort((a, b) => (sourceRank[a.source] ?? 2) - (sourceRank[b.source] ?? 2));
+        this.unlockedSkills = pool;
+        const poolIds = new Set(pool.map(s => s.id));
 
+        // —— 2. 装配维护 ——
+        const cap = (CONFIG.gameplay && CONFIG.gameplay.maxEquippedSkills) || 4;
+        if (!Array.isArray(this.equippedSkillIds)) this.equippedSkillIds = [];
+        // 2a. 剔除已离开池的技能（如撤下符文导致词条技能消失）
+        this.equippedSkillIds = this.equippedSkillIds.filter(id => poolIds.has(id));
+        // 2b. 自动装备「本次新出现」的技能（相对上次池快照），尊重玩家手动卸下的选择
+        const prevSeen = this._seenSkillIds instanceof Set ? this._seenSkillIds : new Set();
+        const equippedSet = new Set(this.equippedSkillIds);
+        let overflowNewCount = 0;
+        for (const sk of pool) {
+            if (prevSeen.has(sk.id) || equippedSet.has(sk.id)) continue; // 旧技能或已装备的不处理
+            if (this.equippedSkillIds.length < cap) {
+                this.equippedSkillIds.push(sk.id);
+                equippedSet.add(sk.id);
+            } else {
+                overflowNewCount++; // 装备已满，新技能进池但需玩家手动取舍
+            }
+        }
+        this._seenSkillIds = new Set(poolIds);
+
+        // —— 3. 由装配推导 activeSkills（技能栏实际内容，按装备顺序） ——
+        const result = this.equippedSkillIds
+            .map(id => pool.find(s => s.id === id))
+            .filter(Boolean);
         const prev = Array.isArray(this.activeSkills) ? this.activeSkills : [];
         const changed = prev.length !== result.length || result.some((s, i) => (prev[i] && prev[i].id) !== s.id);
         this.activeSkills = result;
 
-        // —— 维护 skill_point 槽：仅当有任意已解锁技能时才保留 ——
+        // —— 4. 维护 skill_point 槽：只要技能池非空就保留 ——
         if (!Array.isArray(this.unlockedSlots)) this.unlockedSlots = [];
-        const hasSkills = result.length > 0;
-        if (hasSkills && !this.unlockedSlots.includes('skill_point')) {
+        const hasPool = pool.length > 0;
+        if (hasPool && !this.unlockedSlots.includes('skill_point')) {
             this.unlockedSlots.push('skill_point');
             if ((this.slotCount || 0) < this.unlockedSlots.length) {
                 this.slotCount = this.unlockedSlots.length;
             }
-        } else if (!hasSkills && this.unlockedSlots.includes('skill_point')) {
+        } else if (!hasPool && this.unlockedSlots.includes('skill_point')) {
             this.unlockedSlots = this.unlockedSlots.filter(t => t !== 'skill_point');
             this.slotCount = Math.max(1, this.unlockedSlots.length);
         }
 
-        // —— 刷新技能栏 / SP 面板（DOM 与 UI 在不可用时安全跳过）——
+        // —— 5. 刷新技能栏 / SP 面板 / 编辑器入口（DOM 不可用时安全跳过） ——
         if (this.ui && typeof this.ui.updateSkillBar === 'function') {
             this.ui.updateSkillBar(this.skillPoints || 0, this.activeSkills);
         }
         if (typeof document !== 'undefined') {
             const skillBar = document.getElementById('skill-bar');
             if (skillBar) {
-                skillBar.style.display = (this.phase === 'combat' && hasSkills) ? 'flex' : 'none';
+                skillBar.style.display = (this.phase === 'combat' && this.activeSkills.length > 0) ? 'flex' : 'none';
             }
             const spPanel = document.getElementById('sp-panel');
             if (spPanel) {
-                if ((this.phase === 'gathering' || this.phase === 'combat') && hasSkills) {
+                if ((this.phase === 'gathering' || this.phase === 'combat') && hasPool) {
                     spPanel.style.opacity = '1';
                     spPanel.style.pointerEvents = 'auto';
                 } else {
@@ -408,6 +439,30 @@ export const combat_system = {
                     spPanel.style.pointerEvents = 'none';
                 }
             }
+            // 编辑器入口按钮：技能池非空且处于 gathering/combat 阶段时显示
+            const editBtn = document.getElementById('skill-editor-open-btn');
+            if (editBtn) {
+                const show = hasPool && (this.phase === 'gathering' || this.phase === 'combat');
+                editBtn.style.display = show ? 'inline-flex' : 'none';
+                editBtn.textContent = `✎ 技能 ${this.equippedSkillIds.length}/${cap}`;
+                if (editBtn.dataset.bound !== 'true') {
+                    editBtn.dataset.bound = 'true';
+                    editBtn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        if (typeof this.ui_openSkillEditor === 'function') this.ui_openSkillEditor();
+                    });
+                }
+            }
+            // 编辑器若正开着，同步刷新内容
+            if (typeof this.ui_renderSkillEditor === 'function') {
+                const ov = document.getElementById('skill-editor-overlay');
+                if (ov && ov.classList.contains('is-open')) this.ui_renderSkillEditor();
+            }
+        }
+
+        // —— 6. 新解锁但装备已满 → 强制弹出技能编辑器让玩家取舍 ——
+        if (overflowNewCount > 0 && allowEditorPopup && typeof this.ui_openSkillEditor === 'function') {
+            this.ui_openSkillEditor({ forced: true });
         }
 
         return changed;

--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -328,6 +328,327 @@ export const combat_system = {
                 showToast('無彈藥可強化');
             }
         }
+
+        // ==================== [技能来源扩展] 新增技能（基础/词条/遗物/商店）统一分发 ====================
+        else if (typeof this.combat_activateSkillExtended === 'function') {
+            this.combat_activateSkillExtended(skill, p, method);
+        }
+    },
+
+    /**
+     * combat_recomputeActiveSkills - 统一重算「当前局内已解锁技能列表」
+     *
+     * [技能来源扩展] activeSkills 现在是四类来源的并集：
+     *   1. 基础技能 (source:'base')              —— 每局常驻，保证 SP 永远有去处
+     *   2. 词条解锁 (unlockRuneword 命中激活词条)  —— 由 ui_updateRuneGrid 写入 this._activeRunewordIds
+     *   3. 遗物解锁 (unlockRelic 命中 ownedRelics)
+     *   4. 商店购买 (技能 id 命中 purchasedSkillIds)
+     *
+     * 任何来源发生变化（放置符文 / 拾取遗物 / 商店购买 / 局开始）都应调用本方法。
+     * 同时负责维护 skill_point 槽的增删与技能栏 / SP 面板的显隐刷新。
+     *
+     * @returns {boolean} activeSkills 是否发生了变化
+     */
+    combat_recomputeActiveSkills() {
+        const rwIds = this._activeRunewordIds instanceof Set ? this._activeRunewordIds : new Set();
+        const owned = Array.isArray(this.ownedRelics) ? this.ownedRelics : [];
+        const purchased = Array.isArray(this.purchasedSkillIds) ? this.purchasedSkillIds : [];
+
+        const result = [];
+        for (const sk of SKILL_DB) {
+            if (!sk || !sk.id) continue;
+            let unlocked = false;
+            if (sk.source === 'base') unlocked = true;
+            else if (sk.unlockRuneword && rwIds.has(sk.unlockRuneword)) unlocked = true;
+            else if (sk.unlockRelic && owned.includes(sk.unlockRelic)) unlocked = true;
+            // 商店购买可解锁任意被标记为 shop 的技能（也允许作为兜底解锁路径）
+            if (!unlocked && purchased.includes(sk.id)) unlocked = true;
+            if (unlocked) result.push(sk);
+        }
+
+        // [技能来源扩展] 显示优先级：战斗技能栏受锁定的 2×2（4 格）布局限制，
+        // 让玩家「主动投入」获得的技能（商店/遗物/词条）优先占据有限的可见槽，
+        // 常驻的基础技能作为兜底排在最后（数量超 4 时才会被挤出可见区）。
+        const sourceRank = { shop: 0, relic: 1, runeword: 2, base: 3 };
+        result.sort((a, b) => (sourceRank[a.source] ?? 2) - (sourceRank[b.source] ?? 2));
+
+        const prev = Array.isArray(this.activeSkills) ? this.activeSkills : [];
+        const changed = prev.length !== result.length || result.some((s, i) => (prev[i] && prev[i].id) !== s.id);
+        this.activeSkills = result;
+
+        // —— 维护 skill_point 槽：仅当有任意已解锁技能时才保留 ——
+        if (!Array.isArray(this.unlockedSlots)) this.unlockedSlots = [];
+        const hasSkills = result.length > 0;
+        if (hasSkills && !this.unlockedSlots.includes('skill_point')) {
+            this.unlockedSlots.push('skill_point');
+            if ((this.slotCount || 0) < this.unlockedSlots.length) {
+                this.slotCount = this.unlockedSlots.length;
+            }
+        } else if (!hasSkills && this.unlockedSlots.includes('skill_point')) {
+            this.unlockedSlots = this.unlockedSlots.filter(t => t !== 'skill_point');
+            this.slotCount = Math.max(1, this.unlockedSlots.length);
+        }
+
+        // —— 刷新技能栏 / SP 面板（DOM 与 UI 在不可用时安全跳过）——
+        if (this.ui && typeof this.ui.updateSkillBar === 'function') {
+            this.ui.updateSkillBar(this.skillPoints || 0, this.activeSkills);
+        }
+        if (typeof document !== 'undefined') {
+            const skillBar = document.getElementById('skill-bar');
+            if (skillBar) {
+                skillBar.style.display = (this.phase === 'combat' && hasSkills) ? 'flex' : 'none';
+            }
+            const spPanel = document.getElementById('sp-panel');
+            if (spPanel) {
+                if ((this.phase === 'gathering' || this.phase === 'combat') && hasSkills) {
+                    spPanel.style.opacity = '1';
+                    spPanel.style.pointerEvents = 'auto';
+                } else {
+                    spPanel.style.opacity = '0';
+                    spPanel.style.pointerEvents = 'none';
+                }
+            }
+        }
+
+        return changed;
+    },
+
+    /**
+     * combat_activateSkillExtended - 新增技能的效果分发器
+     *
+     * [技能来源扩展] 与既有 combat_activateSkill 的 if/else 链分离，集中实现新技能，
+     * 避免单个方法过长。调用前 combat_activateSkill 已扣除 SP 并播放通用反馈。
+     * 若技能因「无弹药 / 无敌人」无法生效，本方法负责返还 SP。
+     *
+     * @param {object} skill - SKILL_DB 条目
+     * @param {object} p     - skill.params 快捷引用
+     * @param {string} method - skill.methodId
+     */
+    combat_activateSkillExtended(skill, p, method) {
+        const refund = (msg) => {
+            this.skillPoints += skill.cost;
+            this.ui.updateSkillPoints(this.skillPoints);
+            this.ui.updateSkillBar(this.skillPoints, this.activeSkills);
+            if (msg) showToast(msg);
+        };
+        const activeEnemies = () => this.enemies.filter(e => e.active);
+        const dealTo = (e, dmg, color) => {
+            const r = e.takeDamage(dmg);
+            const hp = r.hpDamage ?? r.actualDamage ?? 0;
+            this.combat_recordDamage(hp, 'skill', 'main', this._currentDamageShotId);
+            if (hp > 0) this.spawn_createFloatingText(e.pos.x, e.pos.y, `-${Math.ceil(hp)}`, color || '#fff');
+            if (r.killed) this.spawn_addScore(e.maxHp, e);
+            return r;
+        };
+
+        // ---------- 基础技能 ----------
+        if (method === 'skill_arcane_missiles') {
+            const targets = activeEnemies().sort((a, b) => b.pos.y - a.pos.y).slice(0, p.targetCount);
+            if (targets.length === 0) { refund('沒有敵人可攻擊'); return; }
+            const dmg = this.round * p.roundMult;
+            targets.forEach((e, i) => {
+                const startX = e.pos.x + (Math.random() - 0.5) * 40;
+                this.spawn_createParticle(startX, Math.max(20, e.pos.y - 60), p.particleColor, 'spark');
+                dealTo(e, dmg, p.particleColor);
+            });
+            this.spawn_createFloatingText(this.width / 2, this.height / 2, '奧術飛彈!', p.particleColor);
+            try { audio.playPowerup(2); } catch (e2) {}
+        }
+
+        else if (method === 'skill_kinetic_charge') {
+            if (this.ammoQueue.length === 0) { refund('無彈藥可強化'); return; }
+            const a = this.ammoQueue[0];
+            a.damage = (a.damage || 0) + p.flatDamage;
+            a.bounce = (a.bounce || 0) + p.bounceBonus;
+            a.multicast = (a.multicast || 0) + p.multicastBonus;
+            this.spawn_createSkillIgnition(this.width / 2, this.height - 80, p.particleColor);
+            this.ui_updateAmmoUI();
+            this.spawn_createFloatingText(this.width / 2, this.height - 120, p.floatText, p.particleColor);
+            try { audio.playPowerup(3); } catch (e2) {}
+        }
+
+        // ---------- 词条解锁技能 ----------
+        else if (method === 'skill_frost_nova_burst') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            eventBus.emit(EVENT_TYPES.UI_FLASH_EFFECT, { color: p.flashColor, duration: 250 });
+            this.ui_triggerScreenShake(140);
+            const dmg = this.round * p.roundMult;
+            list.forEach(e => {
+                e.applyTemp(-p.tempDown);
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'mist');
+                dealTo(e, dmg, p.particleColor);
+            });
+            this.spawn_createShockwave(this.width / 2, this.height / 2, p.particleColor);
+            try { audio.playEffect('cryo'); } catch (e2) {}
+        }
+
+        else if (method === 'skill_irradiate_field') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            eventBus.emit(EVENT_TYPES.UI_FLASH_EFFECT, { color: p.flashColor, duration: 250 });
+            const dmg = this.round * p.roundMult;
+            list.forEach(e => {
+                e._frostPrisonAmp = Math.max(e._frostPrisonAmp || 0, p.damageAmpBonus);
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'spark');
+                this.spawn_createFloatingText(e.pos.x, e.pos.y - 20, '☢️辐照', p.particleColor);
+                dealTo(e, dmg, p.particleColor);
+            });
+            try { audio.playPowerup(3); } catch (e2) {}
+        }
+
+        else if (method === 'skill_flame_sword_dance') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            const swordDmg = Math.round(this.round * p.roundMult);
+            for (let i = 0; i < p.swordCount; i++) {
+                const target = list[Math.floor(Math.random() * list.length)];
+                const spawnX = target.pos.x + (Math.random() - 0.5) * 60;
+                const spawnY = Math.max(30, target.pos.y - 80);
+                const swordConfig = { damage: swordDmg, pyro: 2, cryo: 0, lightning: 0, overcharge: 0, wind: 0, multicast: 0, type: 'flying_sword' };
+                const lvl = this.variantLevels ? (this.variantLevels.flying_sword || 1) : 1;
+                this.combat_flyingSword_addSon(spawnX, spawnY, null, lvl, swordConfig, i * 5);
+                this.combat_flyingSword_assignTarget(target);
+                target.applyTemp(p.tempUp);
+            }
+            this.spawn_createFloatingText(this.width / 2, this.height / 2, '炎光劍舞!', p.particleColor);
+            try { audio.playEffect('split'); } catch (e2) {}
+        }
+
+        else if (method === 'skill_static_field') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            eventBus.emit(EVENT_TYPES.UI_FLASH_EFFECT, { color: p.flashColor, duration: 200 });
+            this.ui_triggerScreenShake(120);
+            list.forEach(e => {
+                e.applyTemp(p.shockStacks);
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'spark');
+            });
+            // 从血量最高的敌人引发一次闪电链
+            const source = list.slice().sort((a, b) => b.displayHp - a.displayHp)[0];
+            if (source) {
+                const dmg = p.chainDmgBase + this.round;
+                if (this.lightningBolts.length < CONFIG.performance[this.perfQualityLevel || 'high'].lightningLimit) {
+                    this.lightningBolts.push(new LightningBolt(source.pos.x, 0, source.pos.x, source.pos.y));
+                }
+                this.combat_lightning_triggerChain(source, dmg, [source], p.chainLevel);
+            }
+            try { audio.playLightning(); } catch (e2) {}
+        }
+
+        else if (method === 'skill_precision_volley') {
+            if (this.ammoQueue.length === 0) { refund('無彈藥可強化'); return; }
+            const a = this.ammoQueue[0];
+            a.damage = (a.damage || 0) + p.flatDamage;
+            a._critChance = Math.max(a._critChance || 0, p.critChance);
+            a._critDamage = Math.max(a._critDamage || 0, p.critDamage);
+            this.spawn_createSkillIgnition(this.width / 2, this.height - 80, p.particleColor);
+            this.ui_updateAmmoUI();
+            this.spawn_createFloatingText(this.width / 2, this.height - 120, p.floatText, p.particleColor);
+            try { audio.playPowerup(4); } catch (e2) {}
+        }
+
+        // ---------- 遗物解锁技能 ----------
+        else if (method === 'skill_gravity_well') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            const pushDistance = this.enemyHeight * p.pushRows;
+            const dmg = this.round * p.roundMult;
+            list.forEach(e => {
+                e.dropTargetY = Math.max(80, e.dropTargetY - pushDistance);
+                e.pos.y = e.dropTargetY;
+                this.spawn_createParticle(e.pos.x, e.pos.y + e.height / 2, p.particleColor, 'mist');
+                dealTo(e, dmg, p.particleColor);
+            });
+            this.spawn_createShockwave(this.width / 2, this.height / 2, p.shockwaveColor);
+            this.ui_triggerScreenShake(180);
+            try { audio.playEffect('split'); } catch (e2) {}
+        }
+
+        else if (method === 'skill_chrono_freeze') {
+            const list = activeEnemies();
+            const freezeFrames = Math.round(p.freezeDuration * 60);
+            eventBus.emit(EVENT_TYPES.UI_FLASH_EFFECT, { color: p.flashColor, duration: 300 });
+            this.ui_triggerScreenShake(150);
+            list.forEach(e => {
+                e.temp = -100;
+                e.frozenTurns = Math.max(e.frozenTurns || 0, freezeFrames);
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'mist');
+                this.spawn_createFloatingText(e.pos.x, e.pos.y - 20, '⏳冻结!', p.particleColor);
+            });
+            // 返还 SP（受上限约束）
+            const maxSP = CONFIG.gameplay.maxSkillPoints || 0;
+            this.skillPoints = Math.min(maxSP, (this.skillPoints || 0) + (p.spRefund || 0));
+            this.ui.updateSkillPoints(this.skillPoints);
+            this.ui.updateSkillBar(this.skillPoints, this.activeSkills);
+            try { audio.playEffect('cryo'); } catch (e2) {}
+        }
+
+        else if (method === 'skill_phoenix_blessing') {
+            const list = activeEnemies();
+            eventBus.emit(EVENT_TYPES.UI_FLASH_EFFECT, { color: p.flashColor, duration: 250 });
+            this.playerShield = (this.playerShield || 0) + p.shieldGain;
+            const dmg = this.round * p.roundMult;
+            list.forEach(e => {
+                e.applyTemp(15);
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'spark');
+                dealTo(e, dmg, p.particleColor);
+            });
+            this.spawn_createFloatingText(this.width / 2, this.height / 2, `🔥 屏障 +${p.shieldGain}`, p.particleColor);
+            if (typeof this.ui_updateShieldUI === 'function') this.ui_updateShieldUI();
+            try { audio.playPowerup(4); } catch (e2) {}
+        }
+
+        // ---------- 局内商店购买技能 ----------
+        else if (method === 'skill_meteor_strike') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            eventBus.emit(EVENT_TYPES.UI_FLASH_EFFECT, { color: p.flashColor, duration: 300 });
+            this.ui_triggerScreenShake(220);
+            const dmg = this.round * p.roundMult;
+            const overTemp = Math.round(100 * (p.tempUp / 100) + p.tempUp);
+            list.forEach(e => {
+                if (e.temp < overTemp) e.temp = Math.min(e.temp + p.tempUp, overTemp);
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'spark');
+                dealTo(e, dmg, p.particleColor);
+            });
+            this.spawn_createShockwave(this.width / 2, this.height / 2, p.particleColor);
+            this.spawn_createFloatingText(this.width / 2, this.height / 2, '隕石轟擊!', p.particleColor);
+            try { audio.playEffect('explosion'); } catch (e2) {}
+        }
+
+        else if (method === 'skill_prism_overload') {
+            if (this.ammoQueue.length === 0) { refund('無彈藥可強化'); return; }
+            const a = this.ammoQueue[0];
+            a.pyro = (a.pyro || 0) + p.elemStacks;
+            a.cryo = (a.cryo || 0) + p.elemStacks;
+            a.lightning = (a.lightning || 0) + p.elemStacks;
+            a.explosive = true;
+            a._forceFusion = true;
+            a.multicast = (a.multicast || 0) + p.multicastBonus;
+            this.spawn_createSkillIgnition(this.width / 2, this.height - 80, p.explosionColor);
+            this.ui_updateAmmoUI();
+            this.spawn_createFloatingText(this.width / 2, this.height - 120, p.floatText, p.explosionColor);
+            try { audio.playPowerup(5); } catch (e2) {}
+        }
+
+        else if (method === 'skill_fortune_strike') {
+            const list = activeEnemies();
+            if (list.length === 0) { refund('沒有敵人可攻擊'); return; }
+            const dmg = this.round * p.roundMult;
+            let kills = 0;
+            list.forEach(e => {
+                this.spawn_createParticle(e.pos.x, e.pos.y, p.particleColor, 'spark');
+                const r = dealTo(e, dmg, p.particleColor);
+                if (r.killed) kills++;
+            });
+            if (kills > 0) {
+                const gain = kills * p.fragmentsPerKill;
+                this.runFragments = (this.runFragments || 0) + gain;
+                this.spawn_createFloatingText(this.width / 2, this.height / 2, `💰 +${gain}`, p.particleColor);
+            }
+            try { audio.playEffect('collect'); } catch (e2) {}
+        }
     },
 
 /**

--- a/src/config.js
+++ b/src/config.js
@@ -1004,6 +1004,7 @@ const CONFIG = {
         eliteFragmentDropChance: 0.80,
         bossFragmentDrop: 8,            // Boss 击杀必掉
         maxSkillPoints: 3,  // 技能点上限
+        maxEquippedSkills: 4,  // [技能装配] 战斗技能栏可同时装备的技能上限（受 2×2 布局约束）
         skillChargeHitGain: 0.03,       // 命中获得的技能充能
         skillChargeKillGain: 0.10,      // 击杀获得的技能充能
         skillChargeRetainRatio: 0.35,   // 充能衰减后保留到实际条的比例

--- a/src/config.js
+++ b/src/config.js
@@ -287,6 +287,7 @@ const CONFIG = {
             venom: '#4ade80',
             overcharge: '#f59e0b',
             echo: '#60a5fa',
+            skill: '#c4b5fd',
             default: '#cbd5e1'
         },
         attributeDisplay: {
@@ -1758,6 +1759,46 @@ const RELIC_DB = [
         recommendTip: '遗物三选一不合心意时多看一轮，适合寻找关键构筑件。'
     },
 
+    // ==================== [技能来源扩展] 解锁主动技能的遗物 ====================
+    // effect: 'unlock_skill' + skillId 指向 SKILL_DB 中 source:'relic' 的技能。
+    // 拾取后由 combat_recomputeActiveSkills() 读取 ownedRelics 并解锁对应技能。
+    {
+        id: 'relic_gravity_core',
+        name: '引力核心',
+        icon: '🕳️',
+        desc: '解锁主动技能【引力坍缩】：消耗 SP 将所有敌人拉离防线并造成伤害。',
+        rarity: 'epic',
+        effect: 'unlock_skill',
+        skillId: 'skill_gravity_well',
+        maxStacks: 1,
+        tags: ['主动技能', '控场'],
+        recommendTip: '获得一个可用 SP 释放的范围控场技能，缓解贴线压力。'
+    },
+    {
+        id: 'relic_chrono_shard',
+        name: '時滯結晶',
+        icon: '⏳',
+        desc: '解锁主动技能【时滞冻结】：消耗 SP 冻结全场并返还 1 点 SP。',
+        rarity: 'legendary',
+        effect: 'unlock_skill',
+        skillId: 'skill_chrono_freeze',
+        maxStacks: 1,
+        tags: ['主动技能', '控场'],
+        recommendTip: '高价值控场技能，冻结全场且几乎零净消耗。'
+    },
+    {
+        id: 'relic_phoenix_feather',
+        name: '不死鳥之羽',
+        icon: '🔥',
+        desc: '解锁主动技能【不死鸟祝福】：消耗 SP 获得防线屏障并灼烧全场。',
+        rarity: 'epic',
+        effect: 'unlock_skill',
+        skillId: 'skill_phoenix_blessing',
+        maxStacks: 1,
+        tags: ['主动技能', '防线'],
+        recommendTip: '兼顾防守与清场的主动技能，适合稳住防线。'
+    },
+
     // 走私者系列：立即给予符文（按稀有度分为4个版本）
     {
         id: 'smuggler_pouch_common',
@@ -1999,6 +2040,7 @@ const SKILL_DB = [
     {
         id: 'skill_frost_prison',
         methodId: 'skill_frost_prison',
+        source: 'runeword',
         unlockRuneword: 'runeword_absolute_zero', // 解锁词条：绝对零度
         name: '冰牢封印',
         icon: '🧊',
@@ -2015,6 +2057,7 @@ const SKILL_DB = [
     {
         id: 'skill_thunder_call',
         methodId: 'skill_thunder_call',
+        source: 'runeword',
         unlockRuneword: 'runeword_thunderstorm', // 解锁词条：雷暴之语
         name: '雷神降臨',
         icon: '🌩️',
@@ -2032,6 +2075,7 @@ const SKILL_DB = [
     {
         id: 'skill_kinetic_burst',
         methodId: 'skill_kinetic_burst',
+        source: 'runeword',
         unlockRuneword: 'runeword_kinetic_surge', // 解锁词条：动能激增
         name: '動能爆發',
         icon: '🔄',
@@ -2048,6 +2092,7 @@ const SKILL_DB = [
     {
         id: 'skill_meltdown_nova',
         methodId: 'skill_meltdown_nova',
+        source: 'runeword',
         unlockRuneword: 'runeword_meltdown', // 解锁词条：熔毁
         name: '熔毀新星',
         icon: '🌋',
@@ -2063,6 +2108,7 @@ const SKILL_DB = [
     {
         id: 'skill_blade_rain',
         methodId: 'skill_blade_rain',
+        source: 'runeword',
         unlockRuneword: 'runeword_blade_storm', // 解锁词条：剑刃风暴
         name: '劍刃雨',
         icon: '⚔️',
@@ -2078,6 +2124,7 @@ const SKILL_DB = [
     {
         id: 'skill_prismatic_shot',
         methodId: 'skill_prismatic_shot',
+        source: 'runeword',
         unlockRuneword: 'runeword_elemental_fusion', // 解锁词条：元素聚变
         name: '棱光炮',
         icon: '🌈',
@@ -2091,6 +2138,235 @@ const SKILL_DB = [
             forceFusion: true,
             floatText: 'PRISMATIC!',
             explosionColor: '#f0abfc'
+        }
+    },
+
+    // ==================== [技能来源扩展] 基础技能（无需解锁，每局常驻可用） ====================
+    // 设计目的：保证任何构筑下 SP 都有去处，根治「有技能点但无技能可放」的问题。
+    {
+        id: 'skill_arcane_missiles',
+        methodId: 'skill_arcane_missiles',
+        source: 'base',
+        name: '奧術飛彈',
+        icon: '✨',
+        cost: 1,
+        color: '#c4b5fd',
+        desc: '向最靠近防线的 3 个敌人各发射一枚奥术飞弹，每枚造成 回合数 × 3 伤害。',
+        params: {
+            targetCount: 3,
+            roundMult: 3,
+            particleColor: '#c4b5fd'
+        }
+    },
+    {
+        id: 'skill_kinetic_charge',
+        methodId: 'skill_kinetic_charge',
+        source: 'base',
+        name: '蓄能填裝',
+        icon: '🔋',
+        cost: 1,
+        color: '#fcd34d',
+        desc: '下一发弹珠基础伤害 +8、弹跳上限 +3、连射 +1。',
+        params: {
+            flatDamage: 8,
+            bounceBonus: 3,
+            multicastBonus: 1,
+            floatText: 'CHARGED!',
+            particleColor: '#fcd34d'
+        }
+    },
+
+    // ==================== [技能来源扩展] 词条解锁技能（覆盖更多词条） ====================
+    {
+        id: 'skill_frost_nova_burst',
+        methodId: 'skill_frost_nova_burst',
+        source: 'runeword',
+        unlockRuneword: 'runeword_frost_nova', // 解锁词条：冰霜新星
+        name: '冰霜新星',
+        icon: '❄️',
+        cost: 2,
+        color: '#7dd3fc',
+        desc: '向全场释放冰霜新星，对所有敌人造成 回合数 × 3 冰属性伤害并大幅降温。',
+        params: {
+            roundMult: 3,
+            tempDown: 60,
+            particleColor: '#7dd3fc',
+            flashColor: 'rgba(125, 211, 252, 0.15)'
+        }
+    },
+    {
+        id: 'skill_irradiate_field',
+        methodId: 'skill_irradiate_field',
+        source: 'runeword',
+        unlockRuneword: 'runeword_irradiation', // 解锁词条：照射
+        name: '輻照領域',
+        icon: '☢️',
+        cost: 2,
+        color: '#a3e635',
+        desc: '展开辐照力场，对所有敌人造成 回合数 × 2 伤害，并使其本回合受到的伤害提升 25%。',
+        params: {
+            roundMult: 2,
+            damageAmpBonus: 0.25,
+            particleColor: '#a3e635',
+            flashColor: 'rgba(163, 230, 53, 0.15)'
+        }
+    },
+    {
+        id: 'skill_flame_sword_dance',
+        methodId: 'skill_flame_sword_dance',
+        source: 'runeword',
+        unlockRuneword: 'runeword_flame_sword', // 解锁词条：炎光剑影
+        name: '炎光劍舞',
+        icon: '🗡️',
+        cost: 2,
+        color: '#fb7185',
+        desc: '召唤 4 道炎光飞剑斩击随机敌人，每道造成 回合数 × 4 火属性伤害并升温。',
+        params: {
+            swordCount: 4,
+            roundMult: 4,
+            tempUp: 25,
+            particleColor: '#fb7185'
+        }
+    },
+    {
+        id: 'skill_static_field',
+        methodId: 'skill_static_field',
+        source: 'runeword',
+        unlockRuneword: 'runeword_lightning_shield', // 解锁词条：雷电护盾
+        name: '靜電力場',
+        icon: '⚡',
+        cost: 2,
+        color: '#38bdf8',
+        desc: '对所有敌人施加感电，并从血量最高的敌人引发一次 12 级闪电链。',
+        params: {
+            shockStacks: 4,
+            chainDmgBase: 6,
+            chainLevel: 12,
+            particleColor: '#38bdf8',
+            flashColor: 'rgba(56, 189, 248, 0.15)'
+        }
+    },
+    {
+        id: 'skill_precision_volley',
+        methodId: 'skill_precision_volley',
+        source: 'runeword',
+        unlockRuneword: 'runeword_focused_fire', // 解锁词条：专注射击
+        name: '精準齊射',
+        icon: '🎯',
+        cost: 2,
+        color: '#f87171',
+        desc: '下一发弹珠必定暴击（造成 200% 伤害），并附加 +6 基础伤害。',
+        params: {
+            flatDamage: 6,
+            critChance: 1,
+            critDamage: 2,
+            floatText: 'PRECISION!',
+            particleColor: '#f87171'
+        }
+    },
+
+    // ==================== [技能来源扩展] 遗物解锁技能（配套 RELIC_DB 中 effect:'unlock_skill'） ====================
+    {
+        id: 'skill_gravity_well',
+        methodId: 'skill_gravity_well',
+        source: 'relic',
+        unlockRelic: 'relic_gravity_core', // 解锁遗物：引力核心
+        name: '引力坍縮',
+        icon: '🕳️',
+        cost: 2,
+        color: '#818cf8',
+        desc: '将所有敌人向上拉离防线 2 行，并造成 回合数 × 3 伤害。',
+        params: {
+            pushRows: 2,
+            roundMult: 3,
+            shockwaveColor: '#818cf8',
+            particleColor: '#818cf8'
+        }
+    },
+    {
+        id: 'skill_chrono_freeze',
+        methodId: 'skill_chrono_freeze',
+        source: 'relic',
+        unlockRelic: 'relic_chrono_shard', // 解锁遗物：时滞结晶
+        name: '時滯凍結',
+        icon: '⏳',
+        cost: 3,
+        color: '#5eead4',
+        desc: '冻结所有敌人 4 秒，并立即返还 1 点 SP。',
+        params: {
+            freezeDuration: 4,
+            spRefund: 1,
+            particleColor: '#5eead4',
+            flashColor: 'rgba(94, 234, 212, 0.15)'
+        }
+    },
+    {
+        id: 'skill_phoenix_blessing',
+        methodId: 'skill_phoenix_blessing',
+        source: 'relic',
+        unlockRelic: 'relic_phoenix_feather', // 解锁遗物：不死鸟之羽
+        name: '不死鳥祝福',
+        icon: '🔥',
+        cost: 2,
+        color: '#fdba74',
+        desc: '获得 3 层防线屏障，并对所有敌人造成 回合数 × 2 火属性伤害。',
+        params: {
+            shieldGain: 3,
+            roundMult: 2,
+            particleColor: '#fdba74',
+            flashColor: 'rgba(253, 186, 116, 0.15)'
+        }
+    },
+
+    // ==================== [技能来源扩展] 局内商店购买技能（source:'shop' + shopPrice） ====================
+    {
+        id: 'skill_meteor_strike',
+        methodId: 'skill_meteor_strike',
+        source: 'shop',
+        shopPrice: 90,
+        name: '隕石轟擊',
+        icon: '☄️',
+        cost: 3,
+        color: '#f97316',
+        desc: '天降陨石轰击全场，对所有敌人造成 回合数 × 6 伤害并施加过热。',
+        params: {
+            roundMult: 6,
+            tempUp: 40,
+            particleColor: '#f97316',
+            flashColor: 'rgba(249, 115, 22, 0.2)'
+        }
+    },
+    {
+        id: 'skill_prism_overload',
+        methodId: 'skill_prism_overload',
+        source: 'shop',
+        shopPrice: 80,
+        name: '稜鏡超載',
+        icon: '🌟',
+        cost: 2,
+        color: '#e879f9',
+        desc: '下一发弹珠附加火/冰/雷各 3 层、强制爆破，且连射 +1。',
+        params: {
+            elemStacks: 3,
+            multicastBonus: 1,
+            floatText: 'OVERLOAD!',
+            explosionColor: '#e879f9'
+        }
+    },
+    {
+        id: 'skill_fortune_strike',
+        methodId: 'skill_fortune_strike',
+        source: 'shop',
+        shopPrice: 70,
+        name: '財富打擊',
+        icon: '💰',
+        cost: 2,
+        color: '#fde047',
+        desc: '对所有敌人造成 回合数 × 3 伤害；每击杀一个敌人额外获得 6 局内碎片。',
+        params: {
+            roundMult: 3,
+            fragmentsPerKill: 6,
+            particleColor: '#fde047'
         }
     }
 ];

--- a/src/core.js
+++ b/src/core.js
@@ -215,8 +215,10 @@ class Game {
         this.hasCombatWall = false; 
         this.unlockedSlots = ['multicast']; // 初始特殊槽：仅连击槽（技能点槽由符文词条解锁后动态加入）
         this.slotCount = 1; // 初始1个槽位
-        this.activeSkills = []; // 当前局内已解锁的技能列表（由符文词条激活驱动）
-        this.pegs = []; 
+        this.activeSkills = []; // 当前局内已解锁的技能列表（基础/词条/遗物/商店四类来源的并集）
+        this.purchasedSkillIds = []; // [技能来源扩展] 局内商店购买解锁的技能 id 列表
+        this._activeRunewordIds = new Set(); // [技能来源扩展] 当前激活词条 id 集合（由 ui_updateRuneGrid 写入）
+        this.pegs = [];
         this.enemies = []; 
         this.specialSlots = []; 
         this.dropBalls = []; 

--- a/src/core.js
+++ b/src/core.js
@@ -215,7 +215,10 @@ class Game {
         this.hasCombatWall = false; 
         this.unlockedSlots = ['multicast']; // 初始特殊槽：仅连击槽（技能点槽由符文词条解锁后动态加入）
         this.slotCount = 1; // 初始1个槽位
-        this.activeSkills = []; // 当前局内已解锁的技能列表（基础/词条/遗物/商店四类来源的并集）
+        this.activeSkills = []; // 当前装备到技能栏的技能（equippedSkillIds 的有序映射）
+        this.unlockedSkills = []; // [技能装配] 已解锁技能池（四类来源并集，可超过装备上限）
+        this.equippedSkillIds = []; // [技能装配] 玩家选择装备的技能 id（≤ maxEquippedSkills）
+        this._seenSkillIds = new Set(); // [技能装配] 上次池快照，用于识别「本次新解锁」以自动装备
         this.purchasedSkillIds = []; // [技能来源扩展] 局内商店购买解锁的技能 id 列表
         this._activeRunewordIds = new Set(); // [技能来源扩展] 当前激活词条 id 集合（由 ui_updateRuneGrid 写入）
         this.pegs = [];

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -789,11 +789,12 @@ export const game_phase = {
 
         // [技能来源扩展] 进入钉盘前先重算技能并集（基础技能保证 activeSkills 非空、skill_point 槽常驻）
         if (typeof this.combat_recomputeActiveSkills === 'function') {
-            this.combat_recomputeActiveSkills();
+            this.combat_recomputeActiveSkills({ allowEditorPopup: false });
         }
         // [unlock_slot 遗物 + slot_count_up] 在模块外额外创建特殊槽
         let effectiveSlots = [...(this.unlockedSlots || [])];
-        if (!this.activeSkills || this.activeSkills.length === 0) {
+        // [技能装配] skill_point 槽取决于「技能池」是否非空（而非当前装备数），玩家卸光技能仍保留 SP 来源
+        if (!this.unlockedSkills || this.unlockedSkills.length === 0) {
             effectiveSlots = effectiveSlots.filter(t => t !== 'skill_point');
         }
         const effectiveSlotCount = Math.min(this.slotCount || 0, effectiveSlots.length > 0 ? this.slotCount : 0);
@@ -1336,11 +1337,11 @@ export const game_phase = {
 
         // [技能来源扩展] 进入钉盘前先重算技能并集（基础技能保证 activeSkills 非空、skill_point 槽常驻）
         if (typeof this.combat_recomputeActiveSkills === 'function') {
-            this.combat_recomputeActiveSkills();
+            this.combat_recomputeActiveSkills({ allowEditorPopup: false });
         }
-        // [技能系统迭代] 动态过滤 skill_point 槽：仅当玩家有已解锁技能时才生成技能点槽
+        // [技能系统迭代] 动态过滤 skill_point 槽：只要技能池非空就生成技能点槽（与装备数无关）
         let effectiveSlots = [...this.unlockedSlots];
-        if (!this.activeSkills || this.activeSkills.length === 0) {
+        if (!this.unlockedSkills || this.unlockedSkills.length === 0) {
             effectiveSlots = effectiveSlots.filter(t => t !== 'skill_point');
         }
         const effectiveSlotCount = Math.min(this.slotCount, effectiveSlots.length > 0 ? this.slotCount : 0);

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -787,6 +787,10 @@ export const game_phase = {
             }
         }
 
+        // [技能来源扩展] 进入钉盘前先重算技能并集（基础技能保证 activeSkills 非空、skill_point 槽常驻）
+        if (typeof this.combat_recomputeActiveSkills === 'function') {
+            this.combat_recomputeActiveSkills();
+        }
         // [unlock_slot 遗物 + slot_count_up] 在模块外额外创建特殊槽
         let effectiveSlots = [...(this.unlockedSlots || [])];
         if (!this.activeSkills || this.activeSkills.length === 0) {
@@ -1330,6 +1334,10 @@ export const game_phase = {
             }
         }
 
+        // [技能来源扩展] 进入钉盘前先重算技能并集（基础技能保证 activeSkills 非空、skill_point 槽常驻）
+        if (typeof this.combat_recomputeActiveSkills === 'function') {
+            this.combat_recomputeActiveSkills();
+        }
         // [技能系统迭代] 动态过滤 skill_point 槽：仅当玩家有已解锁技能时才生成技能点槽
         let effectiveSlots = [...this.unlockedSlots];
         if (!this.activeSkills || this.activeSkills.length === 0) {

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -498,6 +498,8 @@ export const game_system = {
         this.unlockedSlots = ['multicast']; // 初始特殊槽：仅连击槽
         this.slotCount = 1; // 初始1个槽位
         this.activeSkills = []; // 重置已解锁技能列表
+        this.purchasedSkillIds = []; // [技能来源扩展] 重置商店购买的技能
+        this._activeRunewordIds = new Set(); // [技能来源扩展] 重置激活词条集合
         this.marbleSizeBonus = 0;
 
         // [PixiJS 迁移] 销毁所有残留特效的 PixiJS 适配器，防止阶段切换后孤立 Sprite 残留
@@ -2936,6 +2938,7 @@ export const game_system = {
                 hasCombatWall: this.hasCombatWall || false,
                 unlockedSlots: (this.unlockedSlots || []).slice(),
                 slotCount: this.slotCount || 1,
+                purchasedSkillIds: (this.purchasedSkillIds || []).slice(), // [技能来源扩展] 持久化商店购买的技能
                 marbleSizeBonus: this.marbleSizeBonus || 0,
                 flatDamageBonus: this.flatDamageBonus || 0,
                 playerShield: this.playerShield || 0,
@@ -3083,6 +3086,7 @@ export const game_system = {
             this.hasCombatWall = state.hasCombatWall || false;
             this.unlockedSlots = (state.unlockedSlots || ['multicast']).slice();
             this.slotCount = state.slotCount || 1;
+            this.purchasedSkillIds = (state.purchasedSkillIds || []).slice(); // [技能来源扩展] 恢复商店购买的技能
             this.marbleSizeBonus = state.marbleSizeBonus || 0;
             this.flatDamageBonus = state.flatDamageBonus || 0;
             this.playerShield = state.playerShield || 0;

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -497,7 +497,10 @@ export const game_system = {
         this.hasCombatWall = false;
         this.unlockedSlots = ['multicast']; // 初始特殊槽：仅连击槽
         this.slotCount = 1; // 初始1个槽位
-        this.activeSkills = []; // 重置已解锁技能列表
+        this.activeSkills = []; // 重置装备到技能栏的技能
+        this.unlockedSkills = []; // [技能装配] 重置技能池
+        this.equippedSkillIds = []; // [技能装配] 重置装备列表
+        this._seenSkillIds = new Set(); // [技能装配] 重置池快照
         this.purchasedSkillIds = []; // [技能来源扩展] 重置商店购买的技能
         this._activeRunewordIds = new Set(); // [技能来源扩展] 重置激活词条集合
         this.marbleSizeBonus = 0;
@@ -2939,6 +2942,9 @@ export const game_system = {
                 unlockedSlots: (this.unlockedSlots || []).slice(),
                 slotCount: this.slotCount || 1,
                 purchasedSkillIds: (this.purchasedSkillIds || []).slice(), // [技能来源扩展] 持久化商店购买的技能
+                equippedSkillIds: (this.equippedSkillIds || []).slice(), // [技能装配] 持久化装备的技能
+                seenSkillIds: Array.from(this._seenSkillIds || []), // [技能装配] 持久化池快照，避免读档误判新解锁
+                activeRunewordIds: Array.from(this._activeRunewordIds || []), // [技能装配] 持久化激活词条，保证读档后技能池正确
                 marbleSizeBonus: this.marbleSizeBonus || 0,
                 flatDamageBonus: this.flatDamageBonus || 0,
                 playerShield: this.playerShield || 0,
@@ -3087,6 +3093,13 @@ export const game_system = {
             this.unlockedSlots = (state.unlockedSlots || ['multicast']).slice();
             this.slotCount = state.slotCount || 1;
             this.purchasedSkillIds = (state.purchasedSkillIds || []).slice(); // [技能来源扩展] 恢复商店购买的技能
+            this.equippedSkillIds = (state.equippedSkillIds || []).slice(); // [技能装配] 恢复装备的技能
+            this._seenSkillIds = new Set(state.seenSkillIds || []); // [技能装配] 恢复池快照
+            this._activeRunewordIds = new Set(state.activeRunewordIds || []); // [技能装配] 恢复激活词条，保证首次重算技能池正确
+            // [技能装配] 读档后重算技能池/装配（不弹编辑器），保持 activeSkills 与 UI 一致
+            if (typeof this.combat_recomputeActiveSkills === 'function') {
+                this.combat_recomputeActiveSkills({ allowEditorPopup: false });
+            }
             this.marbleSizeBonus = state.marbleSizeBonus || 0;
             this.flatDamageBonus = state.flatDamageBonus || 0;
             this.playerShield = state.playerShield || 0;

--- a/src/styles/bitmap_ui.css
+++ b/src/styles/bitmap_ui.css
@@ -3430,3 +3430,132 @@ body.pc-mode #combat-bottom-dock #damage-stats-btn {
         width: 57% !important;
     }
 }
+
+/* ==================== [技能装配系统] 技能编辑器 ==================== */
+.skill-editor-open-btn {
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #e2e8f0;
+    background: linear-gradient(145deg, rgba(99, 102, 241, 0.35), rgba(15, 23, 42, 0.95));
+    border: 1px solid rgba(148, 163, 184, 0.5);
+    border-radius: 8px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+.skill-editor-open-btn:hover {
+    border-color: #a5b4fc;
+    box-shadow: 0 0 10px rgba(165, 180, 252, 0.4);
+}
+
+.skill-editor-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 600;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(2, 6, 23, 0.78);
+    backdrop-filter: blur(2px);
+}
+.skill-editor-overlay.is-open { display: flex; }
+
+.skill-editor-modal {
+    width: min(560px, 96vw);
+    max-height: 88vh;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(160deg, rgba(30, 41, 59, 0.98), rgba(2, 6, 23, 0.98));
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    border-radius: 14px;
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
+    overflow: hidden;
+}
+.skill-editor-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+.skill-editor-titles { display: flex; align-items: baseline; gap: 10px; }
+.skill-editor-title { margin: 0; font-size: 17px; font-weight: 700; color: #f1f5f9; }
+.skill-editor-count { font-size: 12px; color: #94a3b8; }
+.skill-editor-close-btn {
+    width: 30px; height: 30px;
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    color: #cbd5e1;
+    font-size: 14px;
+    cursor: pointer;
+}
+.skill-editor-close-btn:hover { border-color: #f87171; color: #fecaca; }
+.skill-editor-hint {
+    margin: 10px 16px 0;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: #fde68a;
+    background: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.4);
+    border-radius: 8px;
+}
+.skill-editor-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px 16px;
+    overflow-y: auto;
+}
+.skill-editor-empty { padding: 28px 8px; text-align: center; color: #94a3b8; font-size: 13px; }
+
+.skill-editor-card {
+    display: flex;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+    text-align: left;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(100, 116, 139, 0.4);
+    border-left: 4px solid var(--skill-color, #64748b);
+    cursor: pointer;
+    color: #e2e8f0;
+    transition: border-color 0.15s, background 0.15s, transform 0.1s;
+}
+.skill-editor-card:hover { background: rgba(30, 41, 59, 0.9); transform: translateX(2px); }
+.skill-editor-card.is-equipped {
+    border-color: var(--skill-color, #64748b);
+    box-shadow: inset 0 0 0 1px var(--skill-color, #64748b), 0 0 10px rgba(165, 180, 252, 0.18);
+    background: rgba(30, 41, 59, 0.95);
+}
+.skill-editor-card.is-locked { opacity: 0.55; }
+.skill-editor-card-icon { font-size: 26px; line-height: 1; align-self: center; min-width: 30px; text-align: center; }
+.skill-editor-card-main { display: flex; flex-direction: column; gap: 3px; flex: 1 1 auto; min-width: 0; }
+.skill-editor-card-title { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+.skill-editor-card-title b { color: #f8fafc; }
+.skill-editor-card-cost {
+    font-size: 11px; color: #cbd5e1;
+    padding: 1px 6px; border-radius: 6px;
+    background: rgba(99, 102, 241, 0.25);
+}
+.skill-editor-card-desc { font-size: 12px; color: #94a3b8; line-height: 1.4; }
+.skill-editor-card-meta { display: flex; flex-direction: column; align-items: flex-end; justify-content: space-between; gap: 6px; min-width: 56px; }
+.skill-editor-card-source { font-size: 10px; color: #64748b; }
+.skill-editor-card-toggle {
+    font-size: 11px; font-weight: 600;
+    padding: 3px 8px; border-radius: 999px;
+    color: #cbd5e1;
+    background: rgba(51, 65, 85, 0.8);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    white-space: nowrap;
+}
+.skill-editor-card.is-equipped .skill-editor-card-toggle {
+    color: #064e3b; background: #6ee7b7; border-color: #34d399;
+}

--- a/src/systems.js
+++ b/src/systems.js
@@ -12,7 +12,7 @@
  * - eventBus, EVENT_TYPES（来自 event_bus.js）
  */
 
-import { CONFIG } from './config.js';
+import { CONFIG, SKILL_DB, RELIC_DB } from './config.js';
 import { Enemy, Projectile, Particle, FloatingText, CloneSpore } from './entities.js';
 import { eventBus, EVENT_TYPES } from './event_bus.js';
 import { Vec2, adjustColorBrightness } from './utils/math_utils.js';
@@ -505,8 +505,57 @@ const TRUTH_BOOK_CATEGORIES = [
     { id: 'enemy_affix', name: '敌人词缀', icon: '◇', hint: '普通/精英敌人的行为规则' },
     { id: 'enemy_v2', name: 'V2 基底', icon: '▣', hint: '多格敌人与专属形体' },
     { id: 'attribute', name: '属性百科', icon: '✦', hint: '弹药属性、元素反应与演示' },
+    { id: 'skill', name: '主动技能', icon: '✨', hint: '四类来源、SP 消耗与效果' },
     { id: 'core', name: '核心机制', icon: '📘', hint: '充能、替换、保底与掉落' }
 ];
+
+// [技能图鉴] 由 SKILL_DB 动态生成主动技能图鉴条目（与 core 条目同构：纯说明 + 日志循环演示）
+const SKILL_SOURCE_LABEL = { base: '基础', runeword: '词条', relic: '遗物', shop: '商店' };
+function buildSkillCodexEntries() {
+    const rwName = (id) => (RUNEWORD_DB.find(r => r.id === id) || {}).name || id;
+    const relicName = (id) => (RELIC_DB.find(r => r.id === id) || {}).name || id;
+    return (SKILL_DB || []).map(sk => {
+        const cost = Math.max(0, Number(sk.cost) || 0);
+        let unlockSentence;
+        let unlockTag;
+        switch (sk.source) {
+            case 'base':
+                unlockSentence = '默认解锁：每局开局即可装备。';
+                unlockTag = '基础·常驻';
+                break;
+            case 'runeword':
+                unlockSentence = `解锁方式：激活词条「${rwName(sk.unlockRuneword)}」。`;
+                unlockTag = `词条·${rwName(sk.unlockRuneword)}`;
+                break;
+            case 'relic':
+                unlockSentence = `解锁方式：获得遗物「${relicName(sk.unlockRelic)}」。`;
+                unlockTag = `遗物·${relicName(sk.unlockRelic)}`;
+                break;
+            case 'shop':
+                unlockSentence = `解锁方式：局内商店购买（${sk.shopPrice || 80} 碎片）。`;
+                unlockTag = `商店·${sk.shopPrice || 80}碎片`;
+                break;
+            default:
+                unlockSentence = '解锁方式：未知。';
+                unlockTag = '其他';
+        }
+        return {
+            id: `truth_skill_${sk.id}`,
+            categoryId: 'skill',
+            title: sk.name,
+            icon: sk.icon || '✨',
+            tags: [`${cost} SP`, unlockTag],
+            content: `${sk.desc} 【消耗 ${cost} SP｜${unlockSentence}】`,
+            loop: [
+                { type: 'log', text: `${sk.name}｜消耗 ${cost} SP` },
+                { type: 'wait', frames: 90 },
+                { type: 'log', text: unlockSentence },
+                { type: 'wait', frames: 120 },
+                { type: 'reset' }
+            ]
+        };
+    });
+}
 
 function setupTruthBookBossDemo(game, bossId, isBigBoss = false) {
     if (!game || typeof game.spawn_spawnBoss !== 'function') return;
@@ -750,7 +799,9 @@ function buildTruthBookEntries() {
     const attributeEntries = (TRUTH_BOOK_DATA.attributes || []).map(entry => normalizeTruthBookEntry(entry, 'attribute'));
     const bossEntries = TRUTH_BOOK_BOSS_ENTRIES.map(entry => normalizeTruthBookEntry(entry, 'boss'));
     const coreEntries = TRUTH_BOOK_CORE_ENTRIES.map(entry => normalizeTruthBookEntry(entry, 'core'));
-    return [...bossEntries, ...enemyEntries, ...attributeEntries, ...coreEntries];
+    // [技能图鉴] 主动技能条目（由 SKILL_DB 动态生成）
+    const skillEntries = buildSkillCodexEntries().map(entry => normalizeTruthBookEntry(entry, 'skill'));
+    return [...bossEntries, ...enemyEntries, ...attributeEntries, ...skillEntries, ...coreEntries];
 }
 
 TRUTH_BOOK_DATA.categories = TRUTH_BOOK_CATEGORIES;

--- a/src/systems.js
+++ b/src/systems.js
@@ -5507,6 +5507,8 @@ function createCombatContext(mainGame, canvas) {
         activeRunewordStats: {},
         skillPoints: 0,
         activeSkills: [],
+        unlockedSkills: [],
+        equippedSkillIds: [],
         purchasedSkillIds: [],
         skillChargeActualValue: 0,
         skillChargeTempValue: 0,

--- a/src/systems.js
+++ b/src/systems.js
@@ -5507,6 +5507,7 @@ function createCombatContext(mainGame, canvas) {
         activeRunewordStats: {},
         skillPoints: 0,
         activeSkills: [],
+        purchasedSkillIds: [],
         skillChargeActualValue: 0,
         skillChargeTempValue: 0,
         skillChargeLevel: 0,

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -379,7 +379,8 @@ export const hud_system = {
                     'resonance': { name: '🔂 共鸣', color: CONFIG.ui.damageStats.resonance },
                     'venom': { name: '☠️ 剧毒', color: CONFIG.ui.damageStats.venom },
                     'overcharge': { name: '⚡ 超载', color: CONFIG.ui.damageStats.overcharge },
-                    'echo': { name: '🔊 回响', color: CONFIG.ui.damageStats.echo }
+                    'echo': { name: '🔊 回响', color: CONFIG.ui.damageStats.echo },
+                    'skill': { name: '✨ 技能', color: CONFIG.ui.damageStats.skill }
                 };
                 
                 const conf = typeConfig[dtype] || { name: dtype, color: CONFIG.ui.damageStats.default };

--- a/src/ui/run_shop.js
+++ b/src/ui/run_shop.js
@@ -17,7 +17,7 @@
  *   - 局结束时未消费的 runFragments 按比例转换为 saveData.runeFragments
  */
 
-import { CONFIG } from '../config.js';
+import { CONFIG, SKILL_DB } from '../config.js';
 import { RUNE_DB } from '../rune_config.js';
 import { MODULE_DEFS, addModuleComponentToInventory, getModuleMetaSummary } from '../pinboard_modules.js';
 
@@ -127,6 +127,22 @@ function generateInventory(game, count) {
     if (items.length < count) {
         const forceShowcase = modulePool.some(d => Array.isArray(d.tags) && d.tags.includes(MODULE_SHOWCASE_TAG));
         addModuleItem(forceShowcase && Math.random() < MODULE_SHOWCASE_PRIORITY);
+    }
+
+    // 1.5 [技能来源扩展] 主动技能商品：出售 source:'shop' 的技能，每局每个技能仅售一次。
+    const purchasedSkillSet = new Set(game.purchasedSkillIds || []);
+    const skillPool = (SKILL_DB || []).filter(s => s && s.source === 'shop' && !purchasedSkillSet.has(s.id));
+    const skillItem = takeRandom(skillPool);
+    if (skillItem && items.length < count) {
+        items.push({
+            kind: 'skill_unlock',
+            skillId: skillItem.id,
+            name: skillItem.name,
+            icon: skillItem.icon,
+            desc: `${skillItem.desc}（释放需消耗 ${skillItem.cost} SP）`,
+            price: skillItem.shopPrice || 80,
+            rarity: 'epic',
+        });
     }
 
     // 2. 结构扩展：槽位扩张 / 特殊槽解锁 / 特殊槽数量，三者最多出现一个。
@@ -426,6 +442,12 @@ export const run_shop = {
             if (!Array.isArray(this.runeInventory)) this.runeInventory = [];
             this.runeInventory.push({ id: it.runeId, level: 1 });
             if (window.showToast) window.showToast(`获得符文: ${it.name}`);
+        } else if (it.kind === 'skill_unlock') {
+            // [技能来源扩展] 购买主动技能：写入 purchasedSkillIds 并重算技能并集
+            if (!Array.isArray(this.purchasedSkillIds)) this.purchasedSkillIds = [];
+            if (!this.purchasedSkillIds.includes(it.skillId)) this.purchasedSkillIds.push(it.skillId);
+            if (typeof this.combat_recomputeActiveSkills === 'function') this.combat_recomputeActiveSkills();
+            if (window.showToast) window.showToast(`习得技能: ${it.name}`);
         } else if (it.kind === 'marble_pack') {
             this.runFragments -= it.price;
             inventory.splice(idx, 1);

--- a/src/ui/rune_launcher.js
+++ b/src/ui/rune_launcher.js
@@ -594,49 +594,22 @@ export const rune_launcher_system = {
             }
         }
 
-        // 9. [技能系统迭代] 根据激活的符文词条派生已解锁技能列表
-        //    SKILL_DB 中每个技能的 unlockRuneword 字段指向一个 RUNEWORD_DB 的 id
-        //    当该词条被激活时，对应技能自动解锁
-        const prevSkillCount = this.activeSkills ? this.activeSkills.length : 0;
-        const activatedRunewordIds = new Set(activatedRunewords.map(rw => rw.id));
-        const newActiveSkills = SKILL_DB.filter(sk => sk.unlockRuneword && activatedRunewordIds.has(sk.unlockRuneword));
-        this.activeSkills = newActiveSkills;
+        // 9. [技能来源扩展] 将当前激活的词条 id 写入实例，并交由统一的
+        //    combat_recomputeActiveSkills() 计算「基础/词条/遗物/商店」四类技能并集。
+        //    （槽位增删与技能栏/SP 面板的显隐刷新都在该方法内统一处理。）
+        const prevSkillIds = new Set((this.activeSkills || []).map(s => s.id));
+        this._activeRunewordIds = new Set(activatedRunewords.map(rw => rw.id));
+        if (typeof this.combat_recomputeActiveSkills === 'function') {
+            this.combat_recomputeActiveSkills();
+        } else {
+            // 兜底：旧逻辑（仅词条来源）
+            this.activeSkills = SKILL_DB.filter(sk => sk.unlockRuneword && this._activeRunewordIds.has(sk.unlockRuneword));
+        }
 
-        // 如果技能列表发生变化，同步更新技能杠和 SP 面板显隐
-        if (newActiveSkills.length !== prevSkillCount) {
-            // 如果有新解锁的技能，确保 skill_point 槽在下一回合中生成
-            if (newActiveSkills.length > 0 && !this.unlockedSlots.includes('skill_point')) {
-                this.unlockedSlots.push('skill_point');
-                // 增加槽位数量以容纳技能点槽
-                if (this.slotCount < this.unlockedSlots.length) {
-                    this.slotCount = this.unlockedSlots.length;
-                }
-                showToast('✨ 符文解锁技能！下一回合将出现技能点槽');
-            } else if (newActiveSkills.length === 0 && this.unlockedSlots.includes('skill_point')) {
-                this.unlockedSlots = this.unlockedSlots.filter(t => t !== 'skill_point');
-                this.slotCount = Math.max(1, this.unlockedSlots.length);
-            }
-            // 同步更新技能杠显示
-            if (this.ui) {
-                this.ui.updateSkillBar(this.skillPoints, this.activeSkills);
-            }
-            // [fix] 精确更新技能杠和 SP 面板的显隐，避免调用 ui_updateUI() 导致
-            // 所有 .ui-overlay 被全局隐藏，从而意外关闭符文发射器面板。
-            const hasSkills = this.activeSkills && this.activeSkills.length > 0;
-            const skillBar = document.getElementById('skill-bar');
-            if (skillBar) {
-                skillBar.style.display = (this.phase === 'combat' && hasSkills) ? 'flex' : 'none';
-            }
-            const spPanel = document.getElementById('sp-panel');
-            if (spPanel) {
-                if ((this.phase === 'gathering' || this.phase === 'combat') && hasSkills) {
-                    spPanel.style.opacity = '1';
-                    spPanel.style.pointerEvents = 'auto';
-                } else {
-                    spPanel.style.opacity = '0';
-                    spPanel.style.pointerEvents = 'none';
-                }
-            }
+        // 词条新解锁技能时给出提示（避免局开始的基础技能也弹提示）
+        const newlyUnlocked = (this.activeSkills || []).filter(s => s.unlockRuneword && !prevSkillIds.has(s.id));
+        if (newlyUnlocked.length > 0) {
+            showToast(`✨ 符文解锁技能：${newlyUnlocked.map(s => s.name).join('、')}`);
         }
     },
 

--- a/src/ui/rune_launcher.js
+++ b/src/ui/rune_launcher.js
@@ -18,7 +18,7 @@ import { RUNE_DB, RUNEWORD_DB, STAT_DISPLAY, RARITY_DISPLAY, ELEMENT_RESONANCE_D
 import { parseRuneGrid, calcRuneBaseStats, getRuneId, rune_merge, rune_reforge, getNewRunewordsOnPlacement } from '../rune_system.js';
 import { audio } from '../audio.js';
 import { showToast } from '../entities.js';
-import { SKILL_DB } from '../config.js'; // [技能系统迭代] 用于符文解锁技能派生
+import { SKILL_DB, CONFIG } from '../config.js'; // [技能系统迭代] 用于符文解锁技能派生 + 技能装配上限
 import { getRuneIconSrc } from '../bitmap_icons.js'; // [Phase 5A Task 5.A6] 位图符文图标
 
 /**
@@ -597,7 +597,7 @@ export const rune_launcher_system = {
         // 9. [技能来源扩展] 将当前激活的词条 id 写入实例，并交由统一的
         //    combat_recomputeActiveSkills() 计算「基础/词条/遗物/商店」四类技能并集。
         //    （槽位增删与技能栏/SP 面板的显隐刷新都在该方法内统一处理。）
-        const prevSkillIds = new Set((this.activeSkills || []).map(s => s.id));
+        const prevPoolIds = new Set((this.unlockedSkills || []).map(s => s.id));
         this._activeRunewordIds = new Set(activatedRunewords.map(rw => rw.id));
         if (typeof this.combat_recomputeActiveSkills === 'function') {
             this.combat_recomputeActiveSkills();
@@ -606,8 +606,8 @@ export const rune_launcher_system = {
             this.activeSkills = SKILL_DB.filter(sk => sk.unlockRuneword && this._activeRunewordIds.has(sk.unlockRuneword));
         }
 
-        // 词条新解锁技能时给出提示（避免局开始的基础技能也弹提示）
-        const newlyUnlocked = (this.activeSkills || []).filter(s => s.unlockRuneword && !prevSkillIds.has(s.id));
+        // 词条新解锁技能时给出提示（基于技能池增量，避免局开始的基础技能也弹提示）
+        const newlyUnlocked = (this.unlockedSkills || []).filter(s => s.unlockRuneword && !prevPoolIds.has(s.id));
         if (newlyUnlocked.length > 0) {
             showToast(`✨ 符文解锁技能：${newlyUnlocked.map(s => s.name).join('、')}`);
         }
@@ -2033,6 +2033,128 @@ export const rune_launcher_system = {
 
 //         // showStep(0);
     // },
+
+    // ==================== [技能装配系统] 技能编辑器（loadout） ====================
+    /**
+     * ui_openSkillEditor - 打开技能装配编辑器
+     * @param {object} [opts]
+     * @param {boolean} [opts.forced] 是否为「装备已满又解锁新技能」触发的强制弹出
+     */
+    ui_openSkillEditor(opts = {}) {
+        if (typeof document === 'undefined') return;
+        const overlay = document.getElementById('skill-editor-overlay');
+        if (!overlay) return;
+        this._skillEditorForced = !!opts.forced;
+        overlay.classList.add('is-open');
+        overlay.style.display = 'flex';
+        // 绑定一次性按钮事件
+        if (overlay.dataset.bound !== 'true') {
+            overlay.dataset.bound = 'true';
+            const closeBtn = document.getElementById('skill-editor-close-btn');
+            if (closeBtn) closeBtn.addEventListener('click', () => this.ui_closeSkillEditor());
+            // 点击遮罩空白处关闭
+            overlay.addEventListener('click', (e) => {
+                if (e.target === overlay) this.ui_closeSkillEditor();
+            });
+        }
+        this.ui_renderSkillEditor();
+    },
+
+    ui_closeSkillEditor() {
+        if (typeof document === 'undefined') return;
+        const overlay = document.getElementById('skill-editor-overlay');
+        if (!overlay) return;
+        overlay.classList.remove('is-open');
+        overlay.style.display = 'none';
+        this._skillEditorForced = false;
+    },
+
+    /**
+     * ui_toggleEquipSkill - 装备 / 卸下一个技能（受 maxEquippedSkills 上限约束）
+     */
+    ui_toggleEquipSkill(skillId) {
+        const pool = Array.isArray(this.unlockedSkills) ? this.unlockedSkills : [];
+        if (!pool.some(s => s.id === skillId)) return; // 不在池中，忽略
+        if (!Array.isArray(this.equippedSkillIds)) this.equippedSkillIds = [];
+        const cap = (CONFIG.gameplay && CONFIG.gameplay.maxEquippedSkills) || 4;
+        const idx = this.equippedSkillIds.indexOf(skillId);
+        if (idx >= 0) {
+            // 卸下（仍保留在池中，可重装）
+            this.equippedSkillIds.splice(idx, 1);
+        } else {
+            if (this.equippedSkillIds.length >= cap) {
+                showToast(`最多装备 ${cap} 个技能，请先卸下一个`);
+                return;
+            }
+            this.equippedSkillIds.push(skillId);
+        }
+        // 重算 activeSkills 与技能栏（不触发再次弹窗）
+        if (typeof this.combat_recomputeActiveSkills === 'function') {
+            this.combat_recomputeActiveSkills({ allowEditorPopup: false });
+        }
+        if (typeof this.sys_saveRunState === 'function') this.sys_saveRunState();
+        this.ui_renderSkillEditor();
+    },
+
+    /**
+     * ui_renderSkillEditor - 渲染技能编辑器内容（池中全部技能 + 装备状态）
+     */
+    ui_renderSkillEditor() {
+        if (typeof document === 'undefined') return;
+        const body = document.getElementById('skill-editor-body');
+        if (!body) return;
+        const pool = Array.isArray(this.unlockedSkills) ? this.unlockedSkills : [];
+        const equipped = new Set(this.equippedSkillIds || []);
+        const cap = (CONFIG.gameplay && CONFIG.gameplay.maxEquippedSkills) || 4;
+
+        // 头部计数与强制提示
+        const countEl = document.getElementById('skill-editor-count');
+        if (countEl) countEl.textContent = `已装备 ${equipped.size}/${cap}`;
+        const hintEl = document.getElementById('skill-editor-hint');
+        if (hintEl) {
+            if (this._skillEditorForced) {
+                hintEl.textContent = '技能已超过上限：请卸下不需要的技能，为新技能腾出装备位。';
+                hintEl.style.display = 'block';
+            } else {
+                hintEl.style.display = 'none';
+            }
+        }
+
+        const SOURCE_LABEL = { base: '基础', runeword: '词条', relic: '遗物', shop: '商店' };
+
+        body.innerHTML = '';
+        if (pool.length === 0) {
+            body.innerHTML = '<div class="skill-editor-empty">尚未解锁任何技能。激活符文词条、拾取遗物或在局内商店购买即可获得技能。</div>';
+            return;
+        }
+        pool.forEach(sk => {
+            const isEquipped = equipped.has(sk.id);
+            const atCap = equipped.size >= cap;
+            const card = document.createElement('button');
+            card.type = 'button';
+            card.className = 'skill-editor-card' + (isEquipped ? ' is-equipped' : '');
+            // 未装备且已满 → 视觉置灰但仍可点（点了会提示先卸下）
+            if (!isEquipped && atCap) card.classList.add('is-locked');
+            card.style.setProperty('--skill-color', sk.color || '#94a3b8');
+            const cost = Math.max(0, Number(sk.cost) || 0);
+            card.innerHTML = `
+                <span class="skill-editor-card-icon">${sk.icon || '✦'}</span>
+                <span class="skill-editor-card-main">
+                    <span class="skill-editor-card-title">
+                        <b>${sk.name}</b>
+                        <span class="skill-editor-card-cost">${cost} SP</span>
+                    </span>
+                    <span class="skill-editor-card-desc">${sk.desc || ''}</span>
+                </span>
+                <span class="skill-editor-card-meta">
+                    <span class="skill-editor-card-source">${SOURCE_LABEL[sk.source] || '技能'}</span>
+                    <span class="skill-editor-card-toggle">${isEquipped ? '✓ 已装备' : '＋ 装备'}</span>
+                </span>
+            `;
+            card.addEventListener('click', () => this.ui_toggleEquipSkill(sk.id));
+            body.appendChild(card);
+        });
+    },
 
 
 };

--- a/src/ui/shop.js
+++ b/src/ui/shop.js
@@ -13,7 +13,7 @@
  * @module ui/shop
  */
 
-import { META_SHOP_CONFIG, CONFIG, RELIC_DB, BOARD_STRUCTURE_RELICS } from '../config.js';
+import { META_SHOP_CONFIG, CONFIG, RELIC_DB, BOARD_STRUCTURE_RELICS, SKILL_DB } from '../config.js';
 import { RUNE_DB } from '../rune_config.js';
 import { showToast } from '../entities.js';
 import { eventBus } from '../event_bus.js';
@@ -395,9 +395,15 @@ export const shop_system = {
         if (window.showToast) showToast(`獲得遺物: ${relic.name}`);
         
         // 处理遗物效果
-        if (relic.effect === 'pink_peg_up') {
+        if (relic.effect === 'unlock_skill') {
+            // [技能来源扩展] 解锁主动技能的遗物：实际解锁由 combat_recomputeActiveSkills()
+            // 读取 ownedRelics 完成（本函数末尾统一调用）。
+            const sk = (SKILL_DB || []).find(s => s.id === relic.skillId);
+            if (window.showToast && sk) showToast(`解锁技能: ${sk.name}`);
+        }
+        else if (relic.effect === 'pink_peg_up') {
             this.pinkPegCount = (this.pinkPegCount || 0) + 3;
-        } 
+        }
         else if (relic.effect === 'combat_wall') {
             this.hasCombatWall = true;
         } else if (relic.effect === 'permanent_size_up') {
@@ -608,6 +614,11 @@ export const shop_system = {
             if (window.showToast) showToast(`混沌契约已签订！子弹伤害 ×2，但研磨阶段被禁用。`);
         }
         // ============================================================================
+
+        // [技能来源扩展] 拾取任意遗物后重算技能并集（unlock_skill 遗物据此解锁对应主动技能）
+        if (typeof this.combat_recomputeActiveSkills === 'function') {
+            this.combat_recomputeActiveSkills();
+        }
 
         if (!options.skipClose) this.ui_closeRelicSelection();
     },


### PR DESCRIPTION
## 背景

技能机制三处不完善：① **技能来源单一**——只有 6 个特定词条能解锁技能，不走这些构筑就「有 SP 没技能可放」；② **技能太少**（6 个）；③ **缺少取舍机制**——解锁数超过技能栏 4 格时无法管理。

本 PR 分两步解决（两个 commit）。

---

## Part 1 · 技能来源扩展 + 技能池 6 → 19

### 统一入口 `combat_recomputeActiveSkills()`
四类来源求并集，并维护 `skill_point` 槽 / 技能栏 / SP 面板。

| 来源 | 解锁方式 | 数量 |
|---|---|---|
| `base` 基础 | 每局常驻（根治「无技能可放」） | 2 |
| `runeword` 词条 | 对应词条激活（新覆盖 5 个词条） | 11（原 6 + 新 5）|
| `relic` 遗物 | 拾取 3 个新遗物（`effect:'unlock_skill'`） | 3 |
| `shop` 商店 | 局内商店购买（`shopPrice` 定价） | 3 |

新技能效果集中在 `combat_activateSkillExtended()`，复用既有伤害/温度/飞剑/闪电链/弹药 buff/屏障/碎片机制。

---

## Part 2 · 技能装配编辑器（loadout）

技能池可超过技能栏的 **4 格上限**（受锁定的 2×2 布局约束），新增显式装配系统：

**池 / 装配双层模型**
- `unlockedSkills`：四类来源并集 = 技能池，可 > 4。
- `equippedSkillIds`：玩家装备到技能栏的子集，≤ `maxEquippedSkills`(=4)。
- `activeSkills`：池中已装备项（按装备顺序）= 技能栏实际内容。

**行为**
- 新解锁有空位 → 自动装备；**装备已满又解锁新技能 → 强制弹出技能编辑器**让玩家一次性取舍。
- 编辑器「卸下」的技能**仍留在池中可重装**（`_seenSkillIds` 快照避免反复自动装回）。
- 词条技能随符文重排动态增减，离开池时自动从装备剔除。
- 自动装备优先级：商店 > 遗物 > 词条 > 基础。

**编辑器 UI**：`#skill-editor-overlay` 模态 + 顶栏入口 `#skill-editor-open-btn`（**随时可开**），方法在 `src/ui/rune_launcher.js`，样式在 `src/styles/bitmap_ui.css`。

**持久化**：`equippedSkillIds` / `purchasedSkillIds` / `_seenSkillIds` / `_activeRunewordIds` 纳入局存档；读档后重算（不弹窗）保持一致。`skill_point` 槽改由「技能池非空」决定（与装备数解耦）。

---

## 验证

- 全部改动文件 `node --check` 语法通过。
- 交叉引用校验（字段/来源分类/技能↔遗物双向/id 唯一/分发分支全覆盖）通过。
- 装配核心逻辑单测：自动装备、溢出检测、卸下保留、出池剔除、上限阻断 —— 全部符合预期。
- **真机 Chromium 冒烟测试**：模块连线 OK；解锁 6 技能时强制弹窗 ✓、编辑器渲染 6 张卡 ✓、自动装备到 4 ✓、卸下后可装备被挤出的基础技能 ✓、满 4 时再装被阻断 ✓。
- 既有 `tests/validate_scenarios.js` 106/106 通过；`validate_phase_contracts.mjs` 仅 2 个**与本 PR 无关的既有失败**（发射器炮管/旋转环视觉，已对比确认改动前也失败）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)