### PR TITLE
feat(relic): 末日计时器特效改用 PixiJS 引擎重做为终末钟面演出

### DIFF
--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -3723,41 +3723,19 @@ export const combat_system = {
                     const hpDamage = result.hpDamage ?? result.actualDamage ?? 0;
                     cinematicDelayMs = Math.max(cinematicDelayMs, baseDelayMs);
 
-                    // 末日时钟特效：深红/黑金主题，模拟倒计时归零与钟面崩裂
-                    // 1. 三层扩散冲击波（血红 → 暗金 → 黑紫，错峰营造"终末钟声"感）
-                    // @perf-impact: 遗物回合开始动画（末日计时器）- 使用 relicCinematic* 预算和既有 Shockwave/Particle 上限
-                    if (typeof this.spawn_createShockwave === 'function') {
+                    // 末日时钟特效：深红/黑金主题，模拟倒计时归零（T-00）与钟面崩裂。
+                    // [PixiJS 引擎重做] 旧版由「通用 Shockwave×3 + 散点 Particle」拼装，
+                    // 现统一为专属 DoomsdayClockEffect 钟面演出（秒针归零 + 钟盘龟裂 + 三重终末钟声）。
+                    // @perf-impact: 遗物回合开始动画（末日计时器）- 使用 doomsdayClockLimit 预算，单 Graphics 演出
+                    if (typeof this.spawn_createDoomsdayClock === 'function') {
+                        this.spawn_createDoomsdayClock(cx, cy, chainIndex);
+                    } else if (typeof this.spawn_createShockwave === 'function') {
+                        // 兜底：旧式三重冲击波（极端环境下钟面演出不可用时）
                         this.spawn_createShockwave(cx, cy, chainIndex > 0 ? '#f97316' : '#dc2626');
                         setTimeout(() => { if (this.spawn_createShockwave) this.spawn_createShockwave(cx, cy, '#facc15'); }, 120);
                         setTimeout(() => { if (this.spawn_createShockwave) this.spawn_createShockwave(cx, cy, '#4c1d95'); }, 240);
                     }
-                    // 2. 环形血红/暗金粒子，表达钟盘刻度崩落
-                    const doomSparkCount = budget.relicCinematicSparkCount || 0;
-                    for (let i = 0; i < doomSparkCount; i++) {
-                        if (typeof this.spawn_createParticle === 'function') {
-                            const color = i % 3 === 0 ? '#facc15' : '#dc2626';
-                            const angle = (Math.PI * 2 * i) / Math.max(1, doomSparkCount);
-                            const radius = 18 + Math.random() * 18;
-                            const p = this.spawn_createParticle(cx + Math.cos(angle) * radius, cy + Math.sin(angle) * radius * 0.72, color, i % 2 === 0 ? 'spark' : 'ember');
-                            if (p) {
-                                p.vel.x = Math.cos(angle) * (1.2 + Math.random() * 1.8);
-                                p.vel.y = Math.sin(angle) * (1.0 + Math.random() * 1.6) - 0.6;
-                            }
-                        }
-                    }
-                    // 3. 秒针归零碎片：短促横向飞散，避免误读为闪电打击
-                    const clockShardCount = budget.relicCinematicBoltCount || 0;
-                    for (let i = 0; i < clockShardCount; i++) {
-                        if (typeof this.spawn_createParticle === 'function') {
-                            const angle = -Math.PI / 2 + ((i - (clockShardCount - 1) / 2) * Math.PI) / Math.max(3, clockShardCount);
-                            const p = this.spawn_createParticle(cx + Math.cos(angle) * 12, cy + Math.sin(angle) * 8, i % 2 === 0 ? '#facc15' : '#7f1d1d', 'spark');
-                            if (p) {
-                                p.vel.x = Math.cos(angle) * (2.6 + Math.random() * 1.6);
-                                p.vel.y = Math.sin(angle) * (1.5 + Math.random() * 1.2);
-                            }
-                        }
-                    }
-                    // 4. 浮动文字：计时器/骷髅语义 + 伤害数值，暗红色强调末日感
+                    // 浮动文字：计时器/骷髅语义 + 伤害数值，暗红色强调末日感
                     if (typeof this.spawn_createFloatingText === 'function' && hpDamage > 0) {
                         const label = chainIndex > 0 ? `☠️ 末日回响 -${Math.ceil(hpDamage)}` : `☠️ 末日 -${Math.ceil(hpDamage)}`;
                         this.spawn_createFloatingText(cx, cy - 36, label, chainIndex > 0 ? '#f97316' : '#dc2626');

--- a/src/config.js
+++ b/src/config.js
@@ -1491,6 +1491,7 @@ const CONFIG = {
             relicCinematicSparkCount: 18,
             relicCinematicBoltCount: 8,
             greedyWheelEffectLimit: 8,
+            doomsdayClockLimit: 5,
             // [开炮 VFX 增强] 枪口火光 V2 / 冲击波 / 屏幕反馈
             muzzleFlashV2: true,           // 枪口火光 V2 总开关
             muzzleFlashV2Sparks: 13,       // 火星粒子数
@@ -1549,6 +1550,7 @@ const CONFIG = {
             relicCinematicSparkCount: 10,
             relicCinematicBoltCount: 4,
             greedyWheelEffectLimit: 5,
+            doomsdayClockLimit: 3,
             // [开炮 VFX 增强] medium 降级
             muzzleFlashV2: true,
             muzzleFlashV2Sparks: 6,
@@ -1609,6 +1611,7 @@ const CONFIG = {
             relicCinematicSparkCount: 4,
             relicCinematicBoltCount: 1,
             greedyWheelEffectLimit: 3,
+            doomsdayClockLimit: 2,
             // [开炮 VFX 增强] low 档：关闭大部分视觉增强
             muzzleFlashV2: false,
             muzzleFlashV2Sparks: 0,

--- a/src/core.js
+++ b/src/core.js
@@ -260,6 +260,7 @@ class Game {
         this.energyOrbs = []; 
         this.rewardDropEffects = []; // 遗物/精华掉落特效数组
         this.greedyWheelEffects = [];
+        this.doomsdayClockEffects = []; // 末日计时器遗物专属钟面演出
         this.fortuneWheel = new FortuneWheel(this);
         // [triangle 布局专属] 底部左右倍率转盘（初始为空数组，在 phase_gathering_initPachinko 中根据布局初始化）
         this.triangleSideWheels = [];

--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -34,6 +34,7 @@ import {
     bladeStormRing_pixiCreate, bladeStormRing_pixiSync, bladeStormRing_pixiDestroy,
     bladeStormVortex_pixiCreate, bladeStormVortex_pixiSync, bladeStormVortex_pixiDestroy,
     greedyWheelEffect_pixiCreate, greedyWheelEffect_pixiSync, greedyWheelEffect_pixiDestroy,
+    doomsdayClock_pixiCreate, doomsdayClock_pixiSync, doomsdayClock_pixiDestroy,
     energyOrb_pixiCreate, energyOrb_pixiSync, energyOrb_pixiDestroy,
     floatingText_pixiCreate, floatingText_pixiSync, floatingText_pixiDestroy,
     rewardDropEffect_pixiCreate, rewardDropEffect_pixiSync, rewardDropEffect_pixiDestroy,
@@ -815,6 +816,202 @@ class GreedyWheelEffect {
             ctx.fill();
         }
 
+        ctx.restore();
+    }
+}
+
+// @perf-impact: Doomsday clock cinematic (末日计时器遗物) - capped by doomsdayClockLimit; one short-lived Graphics per strike
+// --- 末日时钟特效：终末钟面归零（T-00）+ 钟盘龟裂 + 三重终末钟声 ---
+// 替代旧的「通用 Shockwave×3 + 散点 Particle + FloatingText」组合，统一走 PixiJS 引擎。
+class DoomsdayClockEffect {
+    /**
+     * @param {number} x 钟面中心 X
+     * @param {number} y 钟面中心 Y
+     * @param {number} chainIndex 0=主触发（深红），>0=末日回响（暗橙）
+     * @param {string} quality 性能档位
+     */
+    constructor(x, y, chainIndex = 0, quality = 'high') {
+        this.x = x;
+        this.y = y;
+        this.chainIndex = chainIndex | 0;
+        this.quality = quality || 'high';
+        this.age = 0;
+        this.duration = 46; // ≈0.77s @60fps
+        this.life = 1.0;
+        this.seed = Math.random() * Math.PI * 2;
+        this.radius = 30 + Math.random() * 6;
+        this.maxRingRadius = 132;
+        // 秒针起始角：归零前从该角加速扫向 12 点（-PI/2）
+        this.handStart = -Math.PI / 2 + Math.PI * 2 * (1.15 + Math.random() * 0.4);
+        // 钟盘龟裂：5 条带折点的裂纹
+        this.cracks = Array.from({ length: 5 }, (_, i) => ({
+            angle: this.seed + i * (Math.PI * 2 / 5) + (Math.random() - 0.5) * 0.5,
+            len: this.radius * (0.9 + Math.random() * 0.5),
+            kink: 0.5 + Math.random() * 0.2,
+            bend: (Math.random() - 0.5) * 0.5,
+        }));
+        // 刻度碎片：钟盘崩落飞散
+        const shardCount = quality === 'low' ? 5 : 10;
+        this.shards = Array.from({ length: shardCount }, (_, i) => ({
+            angle: this.seed * 1.7 + i * (Math.PI * 2 / shardCount) + (Math.random() - 0.5) * 0.4,
+            dist: this.radius * (1.0 + Math.random() * 1.3),
+            size: 2.2 + Math.random() * 2.4,
+            spin: (Math.random() - 0.5) * 4,
+            alpha: 0.7 + Math.random() * 0.3,
+            gold: i % 3 === 0,
+        }));
+        this._pixi = null; // [PixiJS 迁移]
+    }
+
+    update(timeScale) {
+        this.age += (Number.isFinite(timeScale) ? Math.max(0, timeScale) : 1);
+        this.life = Math.max(0, 1 - this.age / this.duration);
+    }
+
+    /** 计算三段相位进度（供 Pixi 适配器与 Canvas 回退共用，避免重复推导） */
+    phases() {
+        const t = Math.min(1, this.age / this.duration);
+        const tStrike = 0.5;
+        // pre: 归零前进度（秒针扫动）；post: 归零后进度（龟裂/钟声）；flash: 归零瞬间闪光
+        const pre = Math.min(1, t / tStrike);
+        const post = t <= tStrike ? 0 : Math.min(1, (t - tStrike) / (1 - tStrike));
+        const flashWin = 0.16;
+        const flash = t < tStrike ? 0 : Math.max(0, 1 - (t - tStrike) / flashWin);
+        return { t, pre, post, flash };
+    }
+
+    /** 秒针角度：归零前缓出扫向 12 点（-PI/2），归零后定格 */
+    handAngle(ph) {
+        const p = ph || this.phases();
+        const ease = 1 - (1 - p.pre) * (1 - p.pre); // easeOut
+        const target = -Math.PI / 2;
+        return this.handStart + (target - this.handStart) * ease;
+    }
+
+    draw(ctx) {
+        if (this.life <= 0) return;
+
+        // [PixiJS 迁移] 优先走 WebGL 路径
+        if (pixiIsActive()) {
+            if (!this._pixi) this._pixi = doomsdayClock_pixiCreate(this);
+            if (this._pixi) { doomsdayClock_pixiSync(this, this._pixi); return; }
+        }
+
+        // ── Canvas 2D 回退 ──
+        const ph = this.phases();
+        const isLow = this.quality === 'low';
+        const isEcho = this.chainIndex > 0;
+        const primary = isEcho ? '#f97316' : '#dc2626';
+        const gold = '#facc15';
+        const violet = '#4c1d95';
+
+        ctx.save();
+        ctx.translate(this.x, this.y);
+        ctx.globalCompositeOperation = isLow ? 'source-over' : 'lighter';
+
+        // 三重终末钟声
+        const rings = [
+            { delay: 0.0, color: primary },
+            { delay: 0.14, color: gold },
+            { delay: 0.28, color: violet },
+        ];
+        for (const ring of rings) {
+            const rp = ph.post <= ring.delay ? 0 : Math.min(1, (ph.post - ring.delay) / (1 - ring.delay));
+            if (rp <= 0 || rp >= 1) continue;
+            const r = Math.max(0.1, rp * this.maxRingRadius);
+            const a = (1 - rp) * this.life;
+            ctx.globalAlpha = a * 0.6;
+            ctx.strokeStyle = ring.color;
+            ctx.lineWidth = isLow ? 1.5 : 3 * (1 - rp * 0.4);
+            ctx.beginPath();
+            ctx.arc(0, 0, r, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+
+        const dialAlpha = this.life * (1 - ph.post * 0.55);
+        const R = this.radius * (1 + ph.flash * 0.14);
+        if (dialAlpha > 0.01) {
+            if (!isLow) { ctx.shadowColor = gold; ctx.shadowBlur = _sb(8); }
+            // 钟盘外环
+            ctx.globalAlpha = dialAlpha * 0.9;
+            ctx.strokeStyle = gold;
+            ctx.lineWidth = isLow ? 2 : 3.2;
+            ctx.beginPath();
+            ctx.arc(0, 0, R, 0, Math.PI * 2);
+            ctx.stroke();
+            // 内圈血红
+            ctx.shadowBlur = 0;
+            ctx.globalAlpha = dialAlpha * 0.7;
+            ctx.strokeStyle = primary;
+            ctx.lineWidth = 1.6;
+            ctx.beginPath();
+            ctx.arc(0, 0, R * 0.74, 0, Math.PI * 2);
+            ctx.stroke();
+            // 12 刻度
+            const tickPush = ph.flash * 6 + ph.post * 10;
+            for (let i = 0; i < 12; i++) {
+                const a = -Math.PI / 2 + i * (Math.PI / 6);
+                const major = i % 3 === 0;
+                const inner = R * (major ? 0.78 : 0.84) + tickPush;
+                const outer = R * 0.97 + tickPush;
+                ctx.globalAlpha = dialAlpha * (major ? 0.95 : 0.6);
+                ctx.strokeStyle = major ? gold : '#fdba74';
+                ctx.lineWidth = major ? 2.6 : 1.4;
+                ctx.beginPath();
+                ctx.moveTo(Math.cos(a) * inner, Math.sin(a) * inner);
+                ctx.lineTo(Math.cos(a) * outer, Math.sin(a) * outer);
+                ctx.stroke();
+            }
+            // 秒针
+            const handLen = R * 0.9;
+            const ha = this.handAngle(ph);
+            ctx.globalAlpha = dialAlpha * 0.95;
+            ctx.strokeStyle = '#ffffff';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(-Math.cos(ha) * R * 0.16, -Math.sin(ha) * R * 0.16);
+            ctx.lineTo(Math.cos(ha) * handLen, Math.sin(ha) * handLen);
+            ctx.stroke();
+            // 中心轴
+            ctx.globalAlpha = dialAlpha * 0.95;
+            ctx.fillStyle = gold;
+            ctx.beginPath();
+            ctx.arc(0, 0, 3.2 + ph.flash * 2, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        // 龟裂 + 碎片
+        if (ph.post > 0) {
+            ctx.shadowBlur = 0;
+            for (const crack of this.cracks) {
+                const grow = Math.min(1, ph.post / 0.7);
+                const len = crack.len * (0.25 + 0.75 * grow);
+                const ca = Math.cos(crack.angle), sa = Math.sin(crack.angle);
+                const kx = ca * len * crack.kink - sa * crack.bend * len;
+                const ky = sa * len * crack.kink + ca * crack.bend * len;
+                ctx.globalAlpha = this.life * 0.85;
+                ctx.strokeStyle = '#ffffff';
+                ctx.lineWidth = 1.3;
+                ctx.beginPath();
+                ctx.moveTo(0, 0); ctx.lineTo(kx, ky); ctx.lineTo(ca * len, sa * len);
+                ctx.stroke();
+            }
+            for (const sh of this.shards) {
+                const dist = sh.dist * Math.min(1, ph.post / 0.85);
+                const sx = Math.cos(sh.angle) * dist;
+                const sy = Math.sin(sh.angle) * dist - ph.post * 6;
+                const sa = sh.alpha * this.life * (1 - ph.post * 0.4);
+                if (sa <= 0.01) continue;
+                ctx.globalAlpha = sa;
+                ctx.fillStyle = sh.gold ? gold : '#7f1d1d';
+                ctx.beginPath();
+                ctx.arc(sx, sy, sh.size, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+
+        ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = 'source-over';
         ctx.restore();
     }
 }
@@ -3833,6 +4030,7 @@ export {
     DeathExplosion,
     HealWave,
     GreedyWheelEffect,
+    DoomsdayClockEffect,
     BladeStormRing,
     BladeStormVortex,
     SwordScar,

--- a/src/entities.js
+++ b/src/entities.js
@@ -35,7 +35,7 @@ import {
     Particle, SlashEffect, PierceCutEffect, CollectionBeam, Shockwave, LaserBeam,
     FloatingText, EnergyOrb, LightningBolt, FireWave,
     IceWave, DeathExplosion, HealWave,
-    GreedyWheelEffect, BladeStormRing, BladeStormVortex, SwordScar, RewardDropEffect,
+    GreedyWheelEffect, DoomsdayClockEffect, BladeStormRing, BladeStormVortex, SwordScar, RewardDropEffect,
     MuzzleFlashV2, FiringBurst, AffixSkillVFX,
     BurnEffect, ElectrocuteEffect, VenomEffect, WindMarkEffect
 } from './effects/particles.js';
@@ -5435,6 +5435,7 @@ export {
     DeathExplosion,
     HealWave,
     GreedyWheelEffect,
+    DoomsdayClockEffect,
     BladeStormRing,
     BladeStormVortex,
     SwordScar,

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -19,6 +19,7 @@ import {
     lightningBolt_pixiDestroy,
     fireWave_pixiDestroy, deathExplosion_pixiDestroy,
     rewardDropEffect_pixiDestroy, greedyWheelEffect_pixiDestroy,
+    doomsdayClock_pixiDestroy,
     shockwave_pixiDestroy, energyOrb_pixiDestroy,
     slashEffect_pixiDestroy, pierceCutEffect_pixiDestroy,
     swordScar_pixiDestroy, bladeStormVortex_pixiDestroy,
@@ -3117,6 +3118,19 @@ phase_gathering_getRandomPegType() {
                     if (gwe.life <= 0) {
                         if (gwe._pixi) { greedyWheelEffect_pixiDestroy(gwe._pixi); gwe._pixi = null; }
                         this.greedyWheelEffects.splice(i, 1);
+                    }
+                }
+            }
+
+            // [末日计时器] 更新和绘制终末钟面演出
+            if (this.doomsdayClockEffects) {
+                for (let i = this.doomsdayClockEffects.length - 1; i >= 0; i--) {
+                    const dce = this.doomsdayClockEffects[i];
+                    dce.update(timeScale);
+                    dce.draw(this.ctx);
+                    if (dce.life <= 0) {
+                        if (dce._pixi) { doomsdayClock_pixiDestroy(dce._pixi); dce._pixi = null; }
+                        this.doomsdayClockEffects.splice(i, 1);
                     }
                 }
             }

--- a/src/game_system.js
+++ b/src/game_system.js
@@ -19,7 +19,7 @@ import { audio } from './audio.js';
 import { loot_calcRuneDrop } from './loot_system.js';
 import { RUNE_DB } from './rune_config.js';
 import { pixiTick, pixiResize, pixiSetVisibility } from './render/pixi_bridge.js';
-import { pixiCleanupAllEffects, fireWave_pixiDestroy, greedyWheelEffect_pixiDestroy } from './render/pixi_effect_adapter.js';
+import { pixiCleanupAllEffects, fireWave_pixiDestroy, greedyWheelEffect_pixiDestroy, doomsdayClock_pixiDestroy } from './render/pixi_effect_adapter.js';
 import { eventBus, EVENT_TYPES } from './event_bus.js';
 import { calcCombatLauncherGeometryToTarget } from './utils/emitter_geometry.js';
 import { getBossDisplayName, getBossPreviewInfo, getBossShortName } from './utils/boss_schedule_utils.js';
@@ -2388,12 +2388,18 @@ export const game_system = {
                 if (gw && gw._pixi) { greedyWheelEffect_pixiDestroy(gw._pixi); gw._pixi = null; }
             }
         }
+        if (Array.isArray(this.doomsdayClockEffects)) {
+            for (const dce of this.doomsdayClockEffects) {
+                if (dce && dce._pixi) { doomsdayClock_pixiDestroy(dce._pixi); dce._pixi = null; }
+            }
+        }
         this.sonSwords = [];
         this.projectiles = [];
         this.burstQueue = [];
         this.spores = [];
         this.fireWaves = [];
         this.greedyWheelEffects = [];
+        this.doomsdayClockEffects = [];
     },
 
     /**

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -1011,6 +1011,146 @@ export function greedyWheelEffect_pixiDestroy(pixi) {
     if (pixi.gfx) { pixi.gfx.destroy(); pixi.gfx = null; }
 }
 
+// ─── DoomsdayClock 适配器 [末日计时器 · 终末钟面] ─────────────────
+//
+// 末日计时器遗物的专属演出，替代旧的「通用冲击波 + 散点粒子」组合。
+// 母题：一面深红/黑金的终末时钟，秒针加速扫向 12 点归零（T-00），
+//       钟面随之龟裂、刻度崩落、三重终末钟声扩散。
+// 全程 PIXI.Graphics 绘制（三层辉光替代 shadowBlur），与 GreedyWheelEffect 同构。
+
+export function doomsdayClock_pixiCreate(dc) {
+    const container = pixiGetEffectContainer();
+    if (!container) return null;
+
+    const gfx = new PIXI.Graphics();
+    gfx.blendMode = PIXI.BLEND_MODES.ADD;
+    container.addChild(gfx);
+    return { gfx };
+}
+
+export function doomsdayClock_pixiSync(dc, pixi) {
+    const gfx = pixi.gfx;
+    if (!gfx) return;
+    gfx.clear();
+    if (dc.life <= 0) return;
+
+    const ph = dc.phases();
+    const cx = dc.x, cy = dc.y;
+    const isEcho = dc.chainIndex > 0;
+    const primary = isEcho ? 0xf97316 : 0xdc2626;
+    const gold = 0xfacc15;
+    const blood = 0x7f1d1d;
+    const violet = 0x4c1d95;
+
+    // ── 三重终末钟声（血红 → 暗金 → 黑紫，错峰扩散） ──
+    const rings = [
+        { delay: 0.0, color: primary },
+        { delay: 0.14, color: gold },
+        { delay: 0.28, color: violet },
+    ];
+    for (const ring of rings) {
+        const rp = ph.post <= ring.delay ? 0 : Math.min(1, (ph.post - ring.delay) / (1 - ring.delay));
+        if (rp <= 0 || rp >= 1) continue;
+        const r = Math.max(0.1, rp * dc.maxRingRadius);
+        const a = (1 - rp) * dc.life;
+        // 外辉光 + 核心环
+        gfx.lineStyle(5 * (1 - rp * 0.5) * 2.4, ring.color, a * 0.28);
+        gfx.drawCircle(cx, cy, r);
+        gfx.lineStyle(2.4 * (1 - rp * 0.4), 0xFFFFFF, a * 0.5);
+        gfx.drawCircle(cx, cy, r);
+    }
+
+    // 钟面整体随归零产生轻微外胀，然后随龟裂淡出
+    const dialAlpha = dc.life * (1 - ph.post * 0.55);
+    const R = dc.radius * (1 + ph.flash * 0.14);
+
+    if (dialAlpha > 0.01) {
+        // ── 钟盘外环（金，三层辉光） ──
+        gfx.lineStyle(3.2 * 2.6, gold, dialAlpha * 0.22);
+        gfx.drawCircle(cx, cy, R);
+        gfx.lineStyle(3.2 * 1.5, gold, dialAlpha * 0.5);
+        gfx.drawCircle(cx, cy, R);
+        gfx.lineStyle(3.2, 0xFFF7CC, dialAlpha * 0.9);
+        gfx.drawCircle(cx, cy, R);
+
+        // ── 内圈血红薄环 ──
+        gfx.lineStyle(1.6, primary, dialAlpha * 0.7);
+        gfx.drawCircle(cx, cy, R * 0.74);
+
+        // ── 12 刻度（归零瞬间向外迸射） ──
+        const tickPush = ph.flash * 6 + ph.post * 10;
+        for (let i = 0; i < 12; i++) {
+            const a = -Math.PI / 2 + i * (Math.PI / 6);
+            const major = i % 3 === 0;
+            const inner = R * (major ? 0.78 : 0.84) + tickPush;
+            const outer = R * 0.97 + tickPush;
+            const cos = Math.cos(a), sin = Math.sin(a);
+            gfx.lineStyle(major ? 2.6 : 1.4, major ? gold : 0xFDBA74, dialAlpha * (major ? 0.95 : 0.6));
+            gfx.moveTo(cx + cos * inner, cy + sin * inner);
+            gfx.lineTo(cx + cos * outer, cy + sin * outer);
+        }
+
+        // ── 秒针：加速扫向 12 点；归零后定格并淡出 ──
+        const handLen = R * 0.9;
+        const ha = dc.handAngle(ph);
+        const hcos = Math.cos(ha), hsin = Math.sin(ha);
+        // 外辉光
+        gfx.lineStyle(4.5, primary, dialAlpha * 0.4);
+        gfx.moveTo(cx, cy);
+        gfx.lineTo(cx + hcos * handLen, cy + hsin * handLen);
+        // 核心
+        gfx.lineStyle(2, 0xFFFFFF, dialAlpha * 0.95);
+        gfx.moveTo(cx - hcos * R * 0.16, cy - hsin * R * 0.16);
+        gfx.lineTo(cx + hcos * handLen, cy + hsin * handLen);
+
+        // ── 中心轴 ──
+        gfx.beginFill(gold, dialAlpha * 0.95);
+        gfx.drawCircle(cx, cy, 3.2 + ph.flash * 2);
+        gfx.endFill();
+    }
+
+    // ── 钟面龟裂（归零后从轴心向外生长，三层辉光） ──
+    if (ph.post > 0) {
+        for (const crack of dc.cracks) {
+            const grow = Math.min(1, ph.post / 0.7);
+            const len = crack.len * (0.25 + 0.75 * grow);
+            const ca = Math.cos(crack.angle), sa = Math.sin(crack.angle);
+            // 折点（龟裂的拐角）
+            const kx = cx + ca * len * crack.kink - sa * crack.bend * len;
+            const ky = cy + sa * len * crack.kink + ca * crack.bend * len;
+            const ex = cx + ca * len, ey = cy + sa * len;
+            const a = dc.life;
+            gfx.lineStyle(2.4 * 2.2, primary, a * 0.3);
+            gfx.moveTo(cx, cy); gfx.lineTo(kx, ky); gfx.lineTo(ex, ey);
+            gfx.lineStyle(1.3, 0xFFFFFF, a * 0.85);
+            gfx.moveTo(cx, cy); gfx.lineTo(kx, ky); gfx.lineTo(ex, ey);
+        }
+
+        // ── 刻度碎片飞散（钟盘崩落） ──
+        for (const sh of dc.shards) {
+            const dist = sh.dist * Math.min(1, ph.post / 0.85);
+            const sx = cx + Math.cos(sh.angle) * dist;
+            const sy = cy + Math.sin(sh.angle) * dist - ph.post * 6; // 略微上扬
+            const sa = sh.alpha * dc.life * (1 - ph.post * 0.4);
+            if (sa <= 0.01) continue;
+            const s = sh.size;
+            const rot = sh.angle + ph.post * sh.spin;
+            const rc = Math.cos(rot), rs = Math.sin(rot);
+            gfx.beginFill(sh.gold ? gold : blood, sa);
+            gfx.moveTo(sx + rc * s, sy + rs * s);
+            gfx.lineTo(sx - rs * s * 0.7, sy + rc * s * 0.7);
+            gfx.lineTo(sx - rc * s * 0.5, sy - rs * s * 0.5);
+            gfx.closePath();
+            gfx.endFill();
+        }
+    }
+}
+
+export function doomsdayClock_pixiDestroy(pixi) {
+    if (!pixi) return;
+    if (pixi.gfx) { pixi.gfx.destroy(); pixi.gfx = null; }
+}
+
 // ─── EnergyOrb 适配器 ────────────────────────────────────────────
 
 export function energyOrb_pixiCreate(orb) {

--- a/src/spawn_system.js
+++ b/src/spawn_system.js
@@ -4,7 +4,7 @@ import {
 import { 
     Vec2, MarbleDefinition, SpecialSlot, FortuneWheel, Peg, DropBall, Enemy, SwordQi, 
     SlashAnim, SonSword, Projectile, CloneSpore, Particle, SlashEffect, CollectionBeam, 
-    Shockwave, LaserBeam, FloatingText, EnergyOrb, LightningBolt, FireWave, HealWave, GreedyWheelEffect, AffixSkillVFX, showToast,
+    Shockwave, LaserBeam, FloatingText, EnergyOrb, LightningBolt, FireWave, HealWave, GreedyWheelEffect, DoomsdayClockEffect, AffixSkillVFX, showToast,
     rotateTowards, adjustColorBrightness, lerpColor, lerp, hexToRgba 
 } from './entities.js';
 import { getThemeSegment } from './utils/math_utils.js';
@@ -2092,6 +2092,22 @@ export const spawn_system = {
         // @perf-impact: Greedy wheel battle VFX - capped by greedyWheelEffectLimit and drawn flat in low quality
         if (this.greedyWheelEffects.length >= (_budget.greedyWheelEffectLimit ?? 6)) return;
         this.greedyWheelEffects.push(new GreedyWheelEffect(x, y, mode, quality));
+    },
+
+    /**
+     * @method spawn_createDoomsdayClock
+     * @description 末日计时器遗物的终末钟面演出（归零 T-00 + 钟盘龟裂 + 三重钟声）。
+     * @param {number} x 钟面中心 X
+     * @param {number} y 钟面中心 Y
+     * @param {number} chainIndex 0=主触发，>0=末日回响（暗橙主题）
+     */
+    spawn_createDoomsdayClock(x, y, chainIndex = 0) {
+        if (!this.doomsdayClockEffects) this.doomsdayClockEffects = [];
+        const quality = this.perfQualityLevel || 'high';
+        const _budget = CONFIG.performance[quality] || CONFIG.performance.high;
+        // @perf-impact: Doomsday clock cinematic - capped by doomsdayClockLimit
+        if (this.doomsdayClockEffects.length >= (_budget.doomsdayClockLimit ?? 4)) return;
+        this.doomsdayClockEffects.push(new DoomsdayClockEffect(x, y, chainIndex, quality));
     },
 
     /**


### PR DESCRIPTION
## 背景

「末日计时器」遗物的旧版命中演出由 **通用 `Shockwave×3` + 散点 `Particle` + `FloatingText`** 临时拼装，没有专属母题，也未走最新的 PixiJS 渲染管线。本 PR 按已迁移效果（`GreedyWheelEffect` / `BladeStormVortex` 等）的同构方式，把它重做为一个独立的、**用最新引擎绘制**且**更贴合「倒计时归零」技能语义**的终末钟面演出。

## 新特效：DoomsdayClockEffect（终末钟面）

- 秒针加速缓出扫向 12 点 **归零（T-00）**
- 归零瞬间钟盘外胀闪光、刻度向外迸射
- 钟盘随后从轴心 **龟裂**，刻度碎片崩落飞散
- **三重终末钟声** 错峰扩散（血红 → 暗金 → 黑紫）
- 末日回响（`chainIndex>0`）采用暗橙主题，区分主触发 / 补触发
- 全程 `PIXI.Graphics` 三层辉光绘制（替代 `shadowBlur`），并保留 Canvas 2D 回退

## 改动接线

| 文件 | 改动 |
|---|---|
| `src/effects/particles.js` | 新增 `DoomsdayClockEffect` 类（含相位 `phases()` / 秒针 `handAngle()` 与 Canvas 回退）；导出 |
| `src/render/pixi_effect_adapter.js` | 新增 `doomsdayClock_pixiCreate/Sync/Destroy` |
| `src/entities.js` | 桶文件补充 import + re-export |
| `src/core.js` | 初始化 `doomsdayClockEffects` 数组 |
| `src/spawn_system.js` | 新增 `spawn_createDoomsdayClock(x, y, chainIndex)`（按预算限流） |
| `src/game_phase.js` | 每帧更新/绘制/销毁该效果数组 |
| `src/game_system.js` | 清场时回收 Pixi 对象并清空数组 |
| `src/config.js` | 三档性能新增 `doomsdayClockLimit`（high 5 / med 3 / low 2） |
| `src/combat_system.js` | 触发处改调 `spawn_createDoomsdayClock`，保留旧式三重冲击波作兜底；伤害浮字与屏幕震动不变 |

## 验证

- 8 个改动文件 `node --check` 全部通过
- 无头浏览器（Chromium/Playwright）加载 `index.html`：模块图解析无报错（仅外部 CDN 代理失败，与本改动无关）
- 在实机 `game` 实例上调用 `spawn_createDoomsdayClock`（主触发 + 回响），推进 30 帧 `update`/`draw`：**无异常抛出**，`life` 正确衰减，Pixi 渲染路径正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSbjMBKjBQpZ4PFkMdkvQW)_