### PR TITLE
fix: 子剑穿透切割特效方向 + 召剑之语飞剑从炮台射出

### DIFF
--- a/src/combat_system.js
+++ b/src/combat_system.js
@@ -2245,12 +2245,26 @@ export const combat_system = {
                         multicast: 0,
                         type: 'flying_sword'
                     };
-                    this.combat_flyingSword_addSon(hitX, hitY, null, swordLevel, swordConfig, 0);
+                    // [修复] 从炮台位置生成子飞剑并朝命中点飞出，避免在敌人身上瞬间生成即扎入、看不出飞行效果。
+                    const cannonX = this.width / 2;
+                    const cannonY = this.height - 100;
+                    const beforeCount = this.sonSwords.length;
+                    this.combat_flyingSword_addSon(cannonX, cannonY, null, swordLevel, swordConfig, 0);
+                    if (this.sonSwords.length > beforeCount) {
+                        const newSword = this.sonSwords[this.sonSwords.length - 1];
+                        if (newSword) {
+                            // 初速指向命中点，使飞剑从炮台射出
+                            const dir = new Vec2(hitX - cannonX, hitY - cannonY).norm();
+                            const launchSpeed = (CONFIG.flyingSword && CONFIG.flyingSword.sonSpeed) || 12;
+                            newSword.vel = dir.mult(launchSpeed);
+                            newSword.angle = Math.atan2(newSword.vel.y, newSword.vel.x);
+                        }
+                    }
                     this.combat_flyingSword_assignTarget(enemy);
-                    // 视觉特效：蓝色剑光 + 浮动文字
-                    const slashAngle = Math.random() * Math.PI * 2;
-                    this.spawn_pushParticleWithLimit(new SlashAnim(hitX, hitY, slashAngle, 0.5, '#0ea5e9'));
-                    this.spawn_createParticle(hitX, hitY, '#0ea5e9', 'spark');
+                    // 视觉特效：在炮台口生成蓝色剑光 + 在命中点保留浮动文字提示
+                    const launchAngle = Math.atan2(hitY - cannonY, hitX - cannonX);
+                    this.spawn_pushParticleWithLimit(new SlashAnim(cannonX, cannonY, launchAngle, 0.5, '#0ea5e9'));
+                    this.spawn_createParticle(cannonX, cannonY, '#0ea5e9', 'spark');
                     this.spawn_createFloatingText(hitX, hitY - 20, '⚔召剑!', '#0ea5e9');
                 }
             }

--- a/src/entities.js
+++ b/src/entities.js
@@ -4090,7 +4090,8 @@ class SonSword {
                                      lightning: Math.floor((this.config.lightning || 0) * markRatio)
                                  };
                              }
-                             game.combat_damageEnemy(e, { config: cfgForHit, pos: this.pos, isCopy: true });
+                             // [修复] 传入子剑当前朝向 vel，使穿透切割特效（PierceCutEffect）沿飞行方向，而非固定水平。
+                             game.combat_damageEnemy(e, { config: cfgForHit, pos: this.pos, isCopy: true, vel: new Vec2(Math.cos(this.angle), Math.sin(this.angle)) });
                              // [限制] SlashAnim 受全局粒子上限约束
                              game.spawn_pushParticleWithLimit(new SlashAnim(this.pos.x, this.pos.y, this.angle, 0.4));
                              audio.playSlash();
@@ -4256,7 +4257,7 @@ class SonSword {
             this.hitEnemiesInRecall.add(enemy);
             // 回收伤害设定
             const fsCfg = CONFIG.mechanics.flying_sword;
-            game.combat_damageEnemy(enemy, { config: this.config, pos: this.pos, isCopy: true }, fsCfg.recallDamageMult);
+            game.combat_damageEnemy(enemy, { config: this.config, pos: this.pos, isCopy: true, vel: new Vec2(Math.cos(this.angle), Math.sin(this.angle)) }, fsCfg.recallDamageMult);
              // [限制] SlashAnim 受全局粒子上限约束
             game.spawn_pushParticleWithLimit(new SlashAnim(this.pos.x, this.pos.y, this.angle, 0.35));
                 audio.playSlash();
@@ -4266,11 +4267,13 @@ class SonSword {
         if (enemy === this.currentTarget && this.passingThroughEnemy !== enemy) {
             const fsCfg = CONFIG.mechanics.flying_sword;
             let dmg = this.config.damage * fsCfg.dashDamageMult;
+            // [修复] 传入子剑朝向 vel，使穿透切割特效沿飞行方向呈现，而非永远水平。
+            const hitVel = new Vec2(Math.cos(this.angle), Math.sin(this.angle));
             if (this.level >= 2) {
-                game.combat_damageEnemy(enemy, { config: this.config, pos: this.pos, isCopy: true });
+                game.combat_damageEnemy(enemy, { config: this.config, pos: this.pos, isCopy: true, vel: hitVel });
             } else {
                 // Lv1子剑伤害，也通过combat_damageEnemy统一处理
-                game.combat_damageEnemy(enemy, { config: { ...this.config, damage: dmg }, pos: this.pos, isCopy: true });
+                game.combat_damageEnemy(enemy, { config: { ...this.config, damage: dmg }, pos: this.pos, isCopy: true, vel: hitVel });
             }
 
             // 特效


### PR DESCRIPTION
## 问题

1. **子剑的穿透攻击切割特效永远是水平方向。**
2. **召剑之语的飞剑在敌人身上瞬间生成即扎入，看不出飞行效果。**

## 根因

1. `PierceCutEffect`（穿透切割特效）通过 `projectile.vel` 计算切割角度（`combat_system.js:1784`）。但子剑（`SonSword`）每次命中都用一个伪造的 `{ config, pos, isCopy }` 对象调用 `combat_damageEnemy`，**没有 `vel` 字段** → 角度回退到默认值 `0` → 切口永远水平。

2. 召剑之语（`son_sword_summon`）直接在命中点 `hitX, hitY`（敌人身上）生成子飞剑，并立即把该敌人设为目标，所以飞剑一生成就贴着敌人扎进去，没有飞行过程。

## 改动

**`src/entities.js`** — `SonSword` 的所有 `combat_damageEnemy` 调用（冲刺命中、回收命中、主命中 Lv1/Lv2+）传入沿当前朝向的 `vel`：

```js
vel: new Vec2(Math.cos(this.angle), Math.sin(this.angle))
```

切割特效（canvas 与 PixiJS 两条渲染路径都按 `angle` 旋转）随之沿飞剑飞行方向呈现。

**`src/combat_system.js`** — 召剑之语改为从炮台位置（`width/2, height-100`，与其他发射逻辑一致）生成子飞剑，并把初速指向命中点，使飞剑可见地从炮台射出后再飞向敌人；炮口处生成对应朝向的剑光特效，命中点保留「⚔召剑!」浮动文字提示。

## 验证

- `node --check` 通过（两个文件语法正确）。
- 仅触及子剑命中特效与召剑之语生成位置，未改动伤害数值逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrWr8JezSR7GV5F7BTRSLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrWr8JezSR7GV5F7BTRSLA)_