### PR TITLE
fix: 修复持续特效（火焰/子弹拖尾/光晕等）在屏幕上残留不消失

### DIFF
--- a/src/entities/projectile.js
+++ b/src/entities/projectile.js
@@ -1013,7 +1013,13 @@ class Projectile {
     }
 
     draw(ctx) {
-        if (!this.active && !this.destroyed) return;
+        // [拖尾/光晕残留修复] 仅绘制「存活且未销毁」的子弹。
+        // 关键：主循环顺序为 update()→draw()→（destroyed 则 splice）。若 update() 内部
+        // 触发了 destroy()（生命周期耗尽 / 命中销毁），此处必须早退，否则会重新创建弹道
+        // 光晕 Sprite、重新从池中取拖尾 Sprite，而该子弹随即被移出数组，导致这些 Sprite
+        // 孤立残留在场上（即「拖尾/光晕有时滞留」）。原 `!active && !destroyed` 守卫只挡住
+        // 被吞噬的 limbo 子弹，挡不住已 destroyed 的子弹。
+        if (this.destroyed || !this.active) return;
         const integrity = (this.bouncesLeft + this.piercesLeft) / (this.maxDurability || 1);
 
         // [Bullet Glow V2] 弹道环境光照 — PixiJS 激活时在子弹下方绘制柔和发光精灵

--- a/src/game_phase.js
+++ b/src/game_phase.js
@@ -3042,7 +3042,9 @@ phase_gathering_getRandomPegType() {
                         }
                         this.projectiles.splice(i, 1);
                     } else if (!p.active) {
-                        // [拖尾残留修复] 子弹经非 destroy() 路径失活（如被吞噬），从数组移除避免长期滞留
+                        // [拖尾残留修复] 子弹经非 destroy() 路径失活（如被吞噬），
+                        // 释放其拖尾/光晕 GPU 精灵后再移出数组，避免残留 + 长期滞留
+                        if (typeof p.releasePixiResources === 'function') p.releasePixiResources();
                         this.projectiles.splice(i, 1);
                     }
                 }

--- a/src/systems.js
+++ b/src/systems.js
@@ -20,7 +20,12 @@ import { RUNEWORD_DB, ELEMENT_RESONANCE_DB } from './rune_config.js';
 import { ENEMY_V2_METADATA, ENEMY_V2_BY_ID } from './data/enemy_v2_metadata.js';
 import { getEnemyV2IconSrc } from './bitmap_icons.js';
 import { resolveEnemyVisualAsset, describeAssetHitStatus, buildEnemyAssetKey } from './data/enemy_visual_assets.js';
-import { pixiCleanupAllEffects } from './render/pixi_effect_adapter.js';
+import {
+    pixiCleanupAllEffects,
+    floatingText_pixiDestroy, shockwave_pixiDestroy, lightningBolt_pixiDestroy,
+    fireWave_pixiDestroy, healWave_pixiDestroy,
+} from './render/pixi_effect_adapter.js';
+import { pixiReleaseParticleSprite } from './render/pixi_bridge.js';
 
 // ==================== 真理之书数据 ====================
 
@@ -4989,6 +4994,9 @@ class TrainingGround {
         const compactTrainingLayout = window.innerWidth <= 767;
         if (trainSidebar) trainSidebar.classList.toggle('collapsed', compactTrainingLayout);
         if (trainSidebarToggle) trainSidebarToggle.textContent = compactTrainingLayout ? '>' : '<';
+        // [特效残留修复] 清空实体/特效数组前先释放其 PixiJS 资源（子弹拖尾/光晕、粒子、持续元素特效等），
+        // 否则进入训练场时上一场的残留 Sprite 会孤立留在共享效果容器上不消失。
+        pixiCleanupAllEffects(this.game);
         this.game.enemies = [];
         this.game.projectiles = [];
         this.game.particles = [];
@@ -5336,14 +5344,29 @@ class TruthBook {
             this.demoGame.fireWaves.forEach(f => f.update(ts));
             this.demoGame.healWaves.forEach(h => h.update(ts, this.demoGame));
             
-            this.demoGame.projectiles = this.demoGame.projectiles.filter(p => p.active);
-            this.demoGame.particles = this.demoGame.particles.filter(p => p.active);
+            // [特效残留修复] 过滤掉失效特效前，先释放被丢弃元素的 PixiJS 资源，
+            // 否则演示画面持续运行会不断把死亡特效的 Sprite 孤立残留在共享效果容器上。
+            // filterAndRelease：保留 keep() 为真的元素，对被丢弃的元素调用 release()。
+            const filterAndRelease = (arr, keep, release) => {
+                if (!Array.isArray(arr)) return arr;
+                for (const it of arr) { if (it && !keep(it)) release(it); }
+                return arr.filter(keep);
+            };
+            this.demoGame.projectiles = filterAndRelease(this.demoGame.projectiles, p => p.active,
+                p => { if (typeof p.releasePixiResources === 'function') p.releasePixiResources(); });
+            this.demoGame.particles = filterAndRelease(this.demoGame.particles, p => p.active,
+                p => { if (p._pixiSprite) { pixiReleaseParticleSprite(p._pixiSprite); p._pixiSprite = null; } });
             this.demoGame.spores = this.demoGame.spores.filter(s => s.active);
-            this.demoGame.floatingTexts = this.demoGame.floatingTexts.filter(f => f.life > 0);
-            this.demoGame.shockwaves = this.demoGame.shockwaves.filter(s => s.alpha > 0);
-            this.demoGame.lightningBolts = this.demoGame.lightningBolts.filter(l => l.life > 0);
-            this.demoGame.fireWaves = this.demoGame.fireWaves.filter(f => f.active);
-            this.demoGame.healWaves = this.demoGame.healWaves.filter(h => h.active);
+            this.demoGame.floatingTexts = filterAndRelease(this.demoGame.floatingTexts, f => f.life > 0,
+                f => { if (f._pixi) { floatingText_pixiDestroy(f._pixi); f._pixi = null; } });
+            this.demoGame.shockwaves = filterAndRelease(this.demoGame.shockwaves, s => s.alpha > 0,
+                s => { if (s._pixi) { shockwave_pixiDestroy(s._pixi); s._pixi = null; } });
+            this.demoGame.lightningBolts = filterAndRelease(this.demoGame.lightningBolts, l => l.life > 0,
+                l => { if (l._pixi) { lightningBolt_pixiDestroy(l._pixi); l._pixi = null; } });
+            this.demoGame.fireWaves = filterAndRelease(this.demoGame.fireWaves, f => f.active,
+                f => { if (f._pixi) { fireWave_pixiDestroy(f._pixi); f._pixi = null; } });
+            this.demoGame.healWaves = filterAndRelease(this.demoGame.healWaves, h => h.active,
+                h => { if (h._pixi) { healWave_pixiDestroy(h._pixi); h._pixi = null; } });
             this.draw();
         } finally {
             window.game = _realGame;


### PR DESCRIPTION
## 背景

修复一类「特效在屏幕上残留、不消失」的问题，跨持续元素特效（火焰/电弧/毒液/风场）与子弹拖尾/光晕。

**共同根因**：这些特效的 PixiJS 显示对象挂在全局效果容器 / `ParticleContainer` 上，只在「常规离场路径」释放。一旦经其他路径离场，释放从不触发，Sprite 孤立残留。
> PixiJS 7.4.2 中 `DisplayObject.destroy()` 本身会从父容器移除 —— 问题是 `destroy()` 根本没被调用，或被调用后又被重建。

## 修复内容（4 个提交）

### 1. 持续元素特效（火焰等）离场不释放
敌人经非 HP 死亡路径（被吞噬 / Boss 落点清除 / **阶段切换·每回合发生**）离场时，`BurnEffect`/`ElectrocuteEffect`/`VenomEffect`/`WindMarkEffect` 从不销毁。
- 新增幂等 `Enemy.releasePersistentEffects()`；死亡路径复用
- 主战斗循环兜底：敌人失活即释放
- `pixiCleanupAllEffects()` 遍历 `enemies` 一并清理

### 2. 子弹拖尾/光晕离场不释放
- 新增无副作用、幂等的 `Projectile.releasePixiResources()`；`destroy()` 复用；吞噬路径立即释放
- 主子弹循环：失活子弹也释放并移出数组
- `data_clearProjectiles()` 清空前释放（含 fireWaves / greedyWheelEffects 的 `_pixi`）

### 3. 子弹 draw-after-destroy 竞态 ★「光晕/拖尾有时滞留」的真因
主循环顺序为 `update() → draw() → (destroyed 则 splice)`。子弹在 `update()` 内被销毁（命中/寿命耗尽）后，`draw()` 旧守卫 `!active && !destroyed` 挡不住已 destroyed 的子弹 → **重建光晕 Sprite、重取拖尾 Sprite** → 随即被移出数组 → 精灵成无主对象永久残留。
- `draw()` 守卫改为 `this.destroyed || !this.active`，仅绘制存活且未销毁的子弹
- 覆盖**所有子弹类型**（共用同一 `_syncBulletGlow`）

### 4. 训练场入口 + 演示画面重置泄漏（全特效扫描发现）
- `TrainingGround.enter()`：清空实体/特效数组前先 `pixiCleanupAllEffects(game)`
- 演示/吸引画面每帧 filter 丢弃失效特效却不释放 `_pixi`（且会渗入真实对局）：改为 `filterAndRelease`，仅对被丢弃元素释放，存活元素零开销

## 全特效扫描结论

- **竞态扫描**：全部 22 个特效类的 `draw()` 守卫均正确（done 态早退、不重建 `_pixi`），子弹是唯一漏网，已修
- **重置覆盖扫描**：`pixiCleanupAllEffects` 对所有带 `_pixi` 的数组完整覆盖；另揪出上述 2 处重置泄漏

## 验证

- 全部改动文件 `node --check` 通过
- 竞态修复有独立模拟脚本验证（旧守卫泄漏拖尾+光晕、新守卫零泄漏）
- 持续特效释放有独立逻辑脚本验证「中途失活 + 阶段切换 + 幂等重调」三场景

> 注：本 PR 内容与 #144 相同，按要求另开。如确认采用本 PR，可关闭 #144。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAeUcc96in3wDhTSTAUEAm)_