### PR TITLE
fix: 修复持续特效（火焰/子弹拖尾/光晕/清场击杀）在屏幕上残留不消失

### DIFF
--- a/src/game_system.js
+++ b/src/game_system.js
@@ -2375,7 +2375,15 @@ export const game_system = {
         // 否则子弹拖尾、火焰波、贪婪转盘等 Sprite 会孤立残留在场上不消失。
         if (Array.isArray(this.projectiles)) {
             for (const p of this.projectiles) {
-                if (p && typeof p.releasePixiResources === 'function') p.releasePixiResources();
+                if (!p) continue;
+                if (typeof p.releasePixiResources === 'function') p.releasePixiResources();
+                // [击杀清场拖尾残留修复] 本方法常在「击杀最后一个敌人」时由 combat_damageEnemy
+                // 在子弹自身 update() 内部触发（见 combat_system.js activeCount===0 分支）。
+                // 届时主循环仍持有该击杀子弹的局部引用，紧接着会调用它的 draw()。若只释放资源而
+                // 不标记 destroyed/失活，draw() 守卫会放行并重新创建拖尾/光晕 Sprite，而该子弹已不在
+                // 任何数组中 → 永久孤立残留。故此处标记销毁，令后续 draw() 早退。
+                p.active = false;
+                p.destroyed = true;
             }
         }
         if (Array.isArray(this.fireWaves)) {


### PR DESCRIPTION
## 背景

修复一类「特效在屏幕上残留、不消失」的问题，跨持续元素特效（火焰/电弧/毒液/风场）与子弹拖尾/光晕。

**共同根因**：这些特效的 PixiJS 显示对象挂在全局效果容器 / `ParticleContainer` 上，只在「常规离场路径」释放。一旦经其他路径离场、或释放后又被重建，Sprite 就孤立残留。
> PixiJS 7.4.2 中 `DisplayObject.destroy()` 本身会从父容器移除 —— 问题是 `destroy()` 根本没被调用，或被调用/释放后又被重建。

## 修复内容（5 个提交）

### 1. 持续元素特效（火焰等）离场不释放
敌人经非 HP 死亡路径（被吞噬 / Boss 落点清除 / **阶段切换·每回合发生**）离场时，`BurnEffect`/`ElectrocuteEffect`/`VenomEffect`/`WindMarkEffect` 从不销毁。
- 新增幂等 `Enemy.releasePersistentEffects()`；死亡路径复用；主战斗循环兜底；`pixiCleanupAllEffects()` 遍历 `enemies` 清理

### 2. 子弹拖尾/光晕离场不释放
- 新增无副作用、幂等的 `Projectile.releasePixiResources()`；`destroy()` / 吞噬路径 / 主循环 / `data_clearProjectiles()` / `pixiCleanupAllEffects()` 全覆盖

### 3. 子弹 draw-after-destroy 竞态
主循环 `update() → draw() → splice`：子弹在 `update()` 内被销毁后，旧守卫挡不住已 destroyed 的子弹 → 重建光晕/拖尾 → 随即被移出数组 → 永久残留。
- `draw()` 守卫改为 `this.destroyed || !this.active`，覆盖所有子弹类型

### 4. 训练场入口 + 演示画面重置泄漏（全特效扫描发现）
- `TrainingGround.enter()` 清空前先 `pixiCleanupAllEffects`
- 演示画面每帧 filter 改为 `filterAndRelease`，仅释放被丢弃元素

### 5. ★ 清场击杀子弹（完成 Boss 击杀）拖尾/光晕永久残留
击杀**最后一个敌人**时，`combat_damageEnemy` 在「击杀子弹自身的 `update()` 内部」调用 `data_clearProjectiles()`，释放资源并把 `this.projectiles` 置空。但主循环此刻仍持有该击杀子弹的局部引用，`update()` 返回后紧接着 `draw()` —— 因 `data_clearProjectiles` 只释放资源未标记 destroyed，守卫放行 → **重建光晕+拖尾**，而该子弹已不在任何数组中 → 永久孤立残留。Boss 通常是最后击杀目标、火焰子弹带拖尾+光晕，故表现为该症状（实为所有清场击杀子弹通病）。
- `data_clearProjectiles()` 释放每颗子弹资源后同时置 `active=false; destroyed=true`，令后续 `draw()` 早退

## 全特效扫描结论

- **竞态扫描**：22 个特效类的 `draw()` 守卫均正确（done 态早退），子弹是唯二漏网（draw-after-destroy + 清场重建），均已修
- **重置覆盖扫描**：`pixiCleanupAllEffects` 对所有带 `_pixi` 的数组完整覆盖；另修两处重置泄漏

## 验证

- 全部改动文件 `node --check` 通过
- 三个独立模拟脚本分别验证：draw-after-destroy 竞态、持续特效三场景、清场击杀子弹 —— 均「修复前泄漏 / 修复后零泄漏」

> 注：本 PR 为本会话 VFX 残留修复的完整集合，包含 #144 / #155 的全部内容并新增清场击杀子弹修复，按要求另开。确认采用后可关闭 #144 / #155。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAeUcc96in3wDhTSTAUEAm)_