### PR TITLE
移除燃烧特效的「体焰弧」层

### DIFF
--- a/src/effects/particles.js
+++ b/src/effects/particles.js
@@ -1508,11 +1508,11 @@ class FireWave {
  * BurnEffect - 敌人持续燃烧的持久视觉特效
  *
  * 附着在 temp >= 34 的敌人身上，强度随温度平滑缩放。
- * 三层视觉：热光环脉冲 + 体焰弧 + 火星飘升
+ * 两层视觉：热光环脉冲 + 火星飘升（原「体焰弧」层已移除，观感杂乱）
  *
  * 由 enemy.js 管理生命周期（创建/更新/销毁），不在全局数组中。
  *
- * @perf-impact: 持续燃烧特效 - 每敌人 1 Sprite + 1 Graphics + 4 ember Sprite（WebGL 批处理）
+ * @perf-impact: 持续燃烧特效 - 每敌人 1 Sprite + 4 ember Sprite（WebGL 批处理）
  */
 class BurnEffect {
     /**
@@ -1537,15 +1537,7 @@ class BurnEffect {
             active: false,
         }));
         this._emberTimer = 0;
-
-        // 焰弧种子（6 段，固定随机偏移确保有机感）
-        this._flameSeeds = Array.from({ length: 6 }, () => ({
-            angle: Math.random() * Math.PI * 2,
-            span: 0.25 + Math.random() * 0.35,
-            lift: 0.7 + Math.random() * 0.35,
-            speed: 0.8 + Math.random() * 0.6,
-            phase: Math.random() * Math.PI * 2,
-        }));
+        // 注：原「焰弧种子（_flameSeeds）」已随体焰弧层移除。
     }
 
     /**
@@ -1606,7 +1598,7 @@ class BurnEffect {
     }
 
     /**
-     * Canvas 2D 回退绘制：热光环 + 焰弧 + 火星
+     * Canvas 2D 回退绘制：热光环 + 火星
      */
     _drawCanvas2D(ctx) {
         const w = this.width, h = this.height;
@@ -1628,23 +1620,7 @@ class BurnEffect {
         ctx.fillStyle = auraGrad;
         ctx.beginPath(); ctx.arc(0, 0, auraR, 0, Math.PI * 2); ctx.fill();
 
-        // 层 2：体焰弧（6 段跳动的火焰弧）
-        for (const seed of this._flameSeeds) {
-            const flicker = Math.sin(t * seed.speed + seed.phase);
-            const r = Math.max(w, h) * 0.45 * seed.lift;
-            const arcAlpha = intensity * (0.4 + flicker * 0.2);
-            const lw = 2.5 + flicker * 0.8;
-            const startAngle = seed.angle + t * 0.3 * seed.speed;
-            ctx.globalAlpha = Math.max(0, arcAlpha);
-            ctx.strokeStyle = seed.lift > 0.85 ? '#fbbf24' : '#f97316';
-            ctx.lineWidth = lw;
-            ctx.shadowBlur = _sb(6 * intensity);
-            ctx.shadowColor = '#f97316';
-            ctx.beginPath();
-            ctx.arc(0, 0, r, startAngle, startAngle + seed.span);
-            ctx.stroke();
-        }
-        ctx.shadowBlur = 0;
+        // 层 2（体焰弧）已移除：原为 6 段环绕敌人的旋转发光短弧，观感杂乱，去掉只保留光环与火星。
 
         // 层 3：火星（Canvas 2D 简化版 - 小圆点）
         ctx.globalCompositeOperation = 'lighter';

--- a/src/render/pixi_effect_adapter.js
+++ b/src/render/pixi_effect_adapter.js
@@ -1697,10 +1697,8 @@ export function burnEffect_pixiCreate(be) {
         container.addChild(auraSprite);
     }
 
-    // 层 2：体焰弧 — PIXI.Graphics（三层辉光替代 shadowBlur）
-    const gfx = new PIXI.Graphics();
-    gfx.blendMode = PIXI.BLEND_MODES.ADD;
-    container.addChild(gfx);
+    // 层 2（体焰弧）已移除：保留 gfx=null 占位以兼容 sync/destroy 结构。
+    const gfx = null;
 
     // 层 3：火星飘升 — 复用 ember 粒子纹理
     const emberTex = pixiGetParticleTexture('ember');
@@ -1728,7 +1726,6 @@ export function burnEffect_pixiSync(be, pixi) {
     const { auraSprite, gfx, emberSprites } = pixi;
     if (be.intensity < 0.01) {
         if (auraSprite) auraSprite.alpha = 0;
-        if (gfx) gfx.clear();
         for (const sp of emberSprites) sp.alpha = 0;
         return;
     }
@@ -1749,26 +1746,7 @@ export function burnEffect_pixiSync(be, pixi) {
         auraSprite.alpha = auraAlpha;
     }
 
-    // 层 2：体焰弧（三层辉光替代 shadowBlur）
-    gfx.clear();
-    for (const seed of be._flameSeeds) {
-        const flicker = Math.sin(t * seed.speed + seed.phase);
-        const r = Math.max(w, h) * 0.45 * seed.lift;
-        const arcAlpha = intensity * (0.4 + flicker * 0.2);
-        const lw = 2.5 + flicker * 0.8;
-        const startAngle = seed.angle + t * 0.3 * seed.speed;
-        const color = seed.lift > 0.85 ? 0xFBBF24 : 0xF97316;
-
-        // 外辉光（宽、淡）
-        gfx.lineStyle(lw * 2, color, Math.max(0, arcAlpha * 0.3));
-        gfx.arc(be.x, be.y, r, startAngle, startAngle + seed.span);
-        // 中层
-        gfx.lineStyle(lw * 1.3, color, Math.max(0, arcAlpha * 0.6));
-        gfx.arc(be.x, be.y, r, startAngle, startAngle + seed.span);
-        // 核心
-        gfx.lineStyle(lw, 0xFFFFFF, Math.max(0, arcAlpha * 0.4));
-        gfx.arc(be.x, be.y, r, startAngle, startAngle + seed.span);
-    }
+    // 层 2（体焰弧）已移除。
 
     // 层 3：火星飘升 Sprite 同步
     for (let i = 0; i < emberSprites.length; i++) {


### PR DESCRIPTION
## 背景

用户反馈：敌人燃烧状态下，身体周围有「奇奇怪怪的环绕发光短条」。

这其实是 `BurnEffect` 特效的**第 2 层「体焰弧」**——6 段用极坐标绘制、围绕敌人旋转并闪烁的短弧线（`_flameSeeds`）。因为是离散、短、随机、又在旋转/加法混合发光，在敌人快速移动或燃烧强度较低时会呈现为几根游离的发光小条，观感杂乱。它是纯装饰，不代表任何数值（层数/伤害/计时）。

## 改动

去掉这一层，保留另外两层（热光环 + 火星飘升）：

- `src/effects/particles.js`
  - 移除 Canvas 2D 路径的体焰弧绘制块
  - 移除已无用的 `_flameSeeds` 初始化
  - 更新类/方法注释（三层 → 两层）
- `src/render/pixi_effect_adapter.js`
  - 移除 PixiJS 路径中 `gfx`（PIXI.Graphics）的创建与逐帧弧线绘制
  - 保留 `gfx=null` 占位以兼容 sync/destroy 结构

净删除 46 行。`node --check` 两文件均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtxL8uHRUf7CFrA1G2hSE1)_