### PR TITLE
fix: 修复清场击杀子弹（完成 Boss 击杀）拖尾/光晕永久残留

### DIFF
--- a/src/game_system.js
+++ b/src/game_system.js
@@ -2375,7 +2375,15 @@ export const game_system = {
         // 否则子弹拖尾、火焰波、贪婪转盘等 Sprite 会孤立残留在场上不消失。
         if (Array.isArray(this.projectiles)) {
             for (const p of this.projectiles) {
-                if (p && typeof p.releasePixiResources === 'function') p.releasePixiResources();
+                if (!p) continue;
+                if (typeof p.releasePixiResources === 'function') p.releasePixiResources();
+                // [击杀清场拖尾残留修复] 本方法常在「击杀最后一个敌人」时由 combat_damageEnemy
+                // 在子弹自身 update() 内部触发（见 combat_system.js activeCount===0 分支）。
+                // 届时主循环仍持有该击杀子弹的局部引用，紧接着会调用它的 draw()。若只释放资源而
+                // 不标记 destroyed/失活，draw() 守卫会放行并重新创建拖尾/光晕 Sprite，而该子弹已不在
+                // 任何数组中 → 永久孤立残留。故此处标记销毁，令后续 draw() 早退。
+                p.active = false;
+                p.destroyed = true;
             }
         }
         if (Array.isArray(this.fireWaves)) {


### PR DESCRIPTION
## 最新修复：清场击杀子弹（完成 Boss 击杀）拖尾/光晕永久残留

> 本 PR 仅含**最新一处修复**的 diff（`src/game_system.js`，9 行）。
> 基线为 `claude/funny-rubin-wb72za`（含本次修复所依赖的 `Projectile.releasePixiResources()` 等前置改动），因此独立成 PR。

### 症状
完成 Boss 击杀的火焰子弹，其拖尾和光晕永久滞留在屏幕上。

### 根因
击杀**最后一个敌人**时，`combat_damageEnemy` 在「击杀子弹自身的 `update()` 内部」调用 `data_clearProjectiles()`，该方法释放资源并把 `this.projectiles` 置空。但主循环此刻仍持有该击杀子弹的局部引用 `p`，`update()` 返回后紧接着会调用 `p.draw()`：

```
killer.update()
  └ combat_damageEnemy() → activeCount===0
      └ data_clearProjectiles()   // 释放资源 + this.projectiles = []
killer.draw()                      // 主循环仍持有 killer 局部引用
  └ 守卫 (destroyed||!active) 放行  // data_clear 未标记 destroyed
      └ 重新创建光晕 + 重取拖尾 Sprite
killer 已不在任何数组 → 永久孤立残留 ★
```

因 Boss 通常是最后被击杀的敌人、火焰子弹又带拖尾+光晕，故表现为该症状；实为**所有清场击杀子弹的通病**。

### 修复
`data_clearProjectiles()` 释放每颗子弹资源后，同时置 `active=false; destroyed=true`，令主循环随后对该击杀子弹的 `draw()` 早退，不再重建 Sprite。

### 验证
- `node --check` 通过
- 独立模拟脚本：修复前残留 1 光晕 + 5 拖尾精灵；修复后为 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAeUcc96in3wDhTSTAUEAm)_